### PR TITLE
CircuitPython Essentials examples

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_AnalogIn.py
+++ b/CircuitPython_Essentials/CircuitPython_AnalogIn.py
@@ -1,0 +1,16 @@
+# CircuitPython AnalogIn Demo
+
+import time
+from analogio import AnalogIn
+import board
+
+analog_in = AnalogIn(board.A1)
+
+
+def get_voltage(pin):
+    return (pin.value * 3.3) / 65536
+
+
+while True:
+    print((get_voltage(analog_in),))
+    time.sleep(0.1)

--- a/CircuitPython_Essentials/CircuitPython_AnalogOut.py
+++ b/CircuitPython_Essentials/CircuitPython_AnalogOut.py
@@ -1,0 +1,12 @@
+# CircuitPython IO demo - analog output
+
+from analogio import AnalogOut
+import board
+
+analog_out = AnalogOut(board.A0)
+
+while True:
+    # Count up from 0 to 65535, with 64 increment
+    # which ends up corresponding to the DAC's 10-bit range
+    for i in range(0, 65535, 64):
+        analog_out.value = i

--- a/CircuitPython_Essentials/CircuitPython_CapTouch.py
+++ b/CircuitPython_Essentials/CircuitPython_CapTouch.py
@@ -1,0 +1,13 @@
+import time
+import board
+import touchio
+
+touch_pad = board.A0  # Will not work for Circuit Playground Express!
+# touch_pad = board.A1  # For Circuit Playground Express
+
+touch = touchio.TouchIn(touch_pad)
+
+while True:
+    if touch.value:
+        print("Touched!")
+    time.sleep(0.05)

--- a/CircuitPython_Essentials/CircuitPython_CapTouch_2Pins.py
+++ b/CircuitPython_Essentials/CircuitPython_CapTouch_2Pins.py
@@ -1,0 +1,16 @@
+# CircuitPython Demo - Cap Touch Multiple Pins
+# Example does NOT work with Trinket M0!
+
+import time
+import board
+import touchio
+
+touch_A1 = touchio.TouchIn(board.A1)  # Not a touch pin on Trinket M0!
+touch_A2 = touchio.TouchIn(board.A2)  # Not a touch pin on Trinket M0!
+
+while True:
+    if touch_A1.value:
+        print("Touched A1!")
+    if touch_A2.value:
+        print("Touched A2!")
+    time.sleep(0.05)

--- a/CircuitPython_Essentials/CircuitPython_Digital_In_Out.py
+++ b/CircuitPython_Essentials/CircuitPython_Digital_In_Out.py
@@ -1,0 +1,24 @@
+# CircuitPython IO demo #1 - General Purpose I/O
+
+import time
+from digitalio import DigitalInOut, Direction, Pull
+import board
+
+led = DigitalInOut(board.D13)
+led.direction = Direction.OUTPUT
+
+switch = DigitalInOut(board.D2)  # For Gemma M0, Trinket M0, Metro M0 Express, ItsyBitsy M0 Express
+# switch = DigitalInOut(board.D5)  # For Feather M0 Express
+# switch = DigitalInOut(board.D7)  # For Circuit Playground Express
+switch.direction = Direction.INPUT
+switch.pull = Pull.UP
+
+
+while True:
+    # We could also just do "led.value = not switch.value"!
+    if switch.value:
+        led.value = False
+    else:
+        led.value = True
+
+    time.sleep(0.01)  # debounce delay

--- a/CircuitPython_Essentials/CircuitPython_DotStar.py
+++ b/CircuitPython_Essentials/CircuitPython_DotStar.py
@@ -1,0 +1,125 @@
+# CircuitPython demo - Dotstar
+
+import time
+import board
+import adafruit_dotstar
+
+num_pixels = 30
+pixels = adafruit_dotstar.DotStar(board.A1, board.A2, num_pixels, brightness=0.1, auto_write=False)
+
+
+def wheel(pos):
+    # Input a value 0 to 255 to get a color value.
+    # The colours are a transition r - g - b - back to r.
+    if pos < 0 or pos > 255:
+        return (0, 0, 0)
+    if pos < 85:
+        return (255 - pos * 3, pos * 3, 0)
+    if pos < 170:
+        pos -= 85
+        return (0, 255 - pos * 3, pos * 3)
+    pos -= 170
+    return (pos * 3, 0, 255 - pos * 3)
+
+
+def color_fill(color, wait):
+    pixels.fill(color)
+    pixels.show()
+    time.sleep(wait)
+
+
+def slice_alternating(wait):
+    pixels[::2] = [RED] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::2] = [ORANGE] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[::2] = [YELLOW] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::2] = [GREEN] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[::2] = [TEAL] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::2] = [CYAN] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[::2] = [BLUE] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::2] = [PURPLE] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[::2] = [MAGENTA] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::2] = [WHITE] * (num_pixels // 2)
+    pixels.show()
+    time.sleep(wait)
+
+
+def slice_rainbow(wait):
+    pixels[::6] = [RED] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+    pixels[1::6] = [ORANGE] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+    pixels[2::6] = [YELLOW] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+    pixels[3::6] = [GREEN] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+    pixels[4::6] = [BLUE] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+    pixels[5::6] = [PURPLE] * (num_pixels // 6)
+    pixels.show()
+    time.sleep(wait)
+
+
+def rainbow_cycle(wait):
+    for j in range(255):
+        for i in range(num_pixels):
+            rc_index = (i * 256 // num_pixels) + j
+            pixels[i] = wheel(rc_index & 255)
+        pixels.show()
+        time.sleep(wait)
+
+
+RED = (255, 0, 0)
+YELLOW = (255, 150, 0)
+ORANGE = (255, 40, 0)
+GREEN = (0, 255, 0)
+TEAL = (0, 255, 120)
+CYAN = (0, 255, 255)
+BLUE = (0, 0, 255)
+PURPLE = (180, 0, 255)
+MAGENTA = (255, 0, 20)
+WHITE = (255, 255, 255)
+
+while True:
+    color_fill(RED, 0.5)  # Change this number to change how long it stays on each solid color.
+    color_fill(YELLOW, 0.5)
+    color_fill(ORANGE, 0.5)
+    color_fill(GREEN, 0.5)
+    color_fill(TEAL, 0.5)
+    color_fill(CYAN, 0.5)
+    color_fill(BLUE, 0.5)
+    color_fill(PURPLE, 0.5)
+    color_fill(MAGENTA, 0.5)
+    color_fill(WHITE, 0.5)
+
+    slice_alternating(0.1)  # Increase or decrease this to speed up or slow down the animation.
+
+    color_fill(WHITE, 0.5)
+
+    slice_rainbow(0.1)  # Increase or decrease this to speed up or slow down the animation.
+
+    time.sleep(0.5)
+
+    rainbow_cycle(0)  # Increase this number to slow down the rainbow animation.

--- a/CircuitPython_Essentials/CircuitPython_HIDKeyboard.py
+++ b/CircuitPython_Essentials/CircuitPython_HIDKeyboard.py
@@ -1,0 +1,63 @@
+# CircuitPlayground demo - Keyboard emu
+
+from digitalio import DigitalInOut, Direction, Pull
+import touchio
+import board
+import time
+from adafruit_hid.keyboard import Keyboard
+from adafruit_hid.keycode import Keycode
+from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
+
+# A simple neat keyboard demo in circuitpython
+
+# The button pins we'll use, each will have an internal pullup
+buttonpins = [board.D2, board.D1, board.D0]
+# our array of button objects
+buttons = []
+# The keycode sent for each button, will be paired with a control key
+buttonkeys = [Keycode.A, Keycode.B, "Hello World!\n"]
+controlkey = Keycode.SHIFT
+
+# the keyboard object!
+# sleep for a bit to avoid a race condition on some systems
+time.sleep(1)
+kbd = Keyboard()
+# we're americans :)
+layout = KeyboardLayoutUS(kbd)
+
+# make all pin objects, make them inputs w/pullups
+for pin in buttonpins:
+    button = DigitalInOut(pin)
+    button.direction = Direction.INPUT
+    button.pull = Pull.UP   
+    buttons.append(button)
+
+led = DigitalInOut(board.D13)
+led.direction = Direction.OUTPUT
+ 
+print("Waiting for button presses")
+
+while True:
+    # check each button
+    for button in buttons:
+        if not button.value:   # pressed?
+            i = buttons.index(button)
+            print("Button #%d Pressed" % i)
+
+            # turn on the LED
+            led.value = True
+
+            while not button.value:
+                pass  # wait for it to be released!
+            # type the keycode or string
+            k = buttonkeys[i]    # get the corresp. keycode/str
+            if type(k) is str:
+                layout.write(k)
+            else:
+                kbd.press(controlkey, k) # press...
+                kbd.release_all()        # release!
+
+            # turn off the LED
+            led.value = False
+    
+    time.sleep(0.01)

--- a/CircuitPython_Essentials/CircuitPython_I2C.py
+++ b/CircuitPython_Essentials/CircuitPython_I2C.py
@@ -1,0 +1,25 @@
+# I2C sensor demo
+
+import board
+import busio
+import adafruit_si7021
+import time
+
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# lock the I2C device before we try to scan
+while not i2c.try_lock():
+    pass
+print("I2C addresses found:", [hex(i) for i in i2c.scan()])
+
+# unlock I2C now that we're done scanning.
+i2c.unlock()
+
+# Create library object on our I2C port
+si7021 = adafruit_si7021.SI7021(i2c)
+
+
+# Use library to read the data!
+while True:
+    print("Temp: %0.2F *C   Humidity: %0.1F %%" % (si7021.temperature, si7021.relative_humidity))
+    time.sleep(1)

--- a/CircuitPython_Essentials/CircuitPython_I2C_Scan.py
+++ b/CircuitPython_Essentials/CircuitPython_I2C_Scan.py
@@ -1,0 +1,15 @@
+# CircuitPython demo - I2C scan
+
+import board
+import busio
+import time
+
+# can also use board.SDA and board.SCL for neater looking code!
+i2c = busio.I2C(board.SCL, board.SDA)
+
+while not i2c.try_lock():
+    pass
+
+while True:
+    print("I2C addresses found:", [hex(device_address) for device_address in i2c.scan()])
+    time.sleep(2)

--- a/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_colors.py
+++ b/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_colors.py
@@ -1,0 +1,19 @@
+import time
+import board
+import neopixel
+import adafruit_dotstar
+
+# For Trinket M0, Gemma M0, and ItsyBitsy M0 Express
+led = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1)
+# For Feather M0 Express, Metro M0 Express, and Circuit Playground Express
+# led = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+led.brightness = 0.3
+
+while True:
+    led[0] = (255, 0, 0)
+    time.sleep(0.5)
+    led[0] = (0, 255, 0)
+    time.sleep(0.5)
+    led[0] = (0, 0, 255)
+    time.sleep(0.5)

--- a/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_rainbow.py
+++ b/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_rainbow.py
@@ -1,0 +1,32 @@
+import time
+import board
+import neopixel
+import adafruit_dotstar
+
+# For Trinket M0, Gemma M0, and ItsyBitsy M0 Express
+led = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1)
+# For Feather M0 Express, Metro M0 Express, and Circuit Playground Express
+# led = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+
+def wheel(pos):
+    # Input a value 0 to 255 to get a color value.
+    # The colours are a transition r - g - b - back to r.
+    if pos < 0 or pos > 255:
+        return 0, 0, 0
+    if pos < 85:
+        return int(255 - pos*3), int(pos*3), 0
+    if pos < 170:
+        pos -= 85
+        return 0, int(255 - pos*3), int(pos*3)
+    pos -= 170
+    return int(pos * 3), 0, int(255 - (pos*3))
+
+
+led.brightness = 0.3
+
+i = 0
+while True:
+    i = (i + 1) % 256  # run from 0 to 255
+    led.fill(wheel(i))
+    time.sleep(0.1)

--- a/CircuitPython_Essentials/CircuitPython_Logger.py
+++ b/CircuitPython_Essentials/CircuitPython_Logger.py
@@ -1,0 +1,24 @@
+import board
+import digitalio
+import microcontroller
+import time
+
+led = digitalio.DigitalInOut(board.D13)
+led.switch_to_output()
+
+try:
+    with open("/temperature.txt", "a") as fp:
+        while True:
+            temp = microcontroller.cpu.temperature
+            # do the C-to-F conversion here if you would like
+            fp.write('{0:f}\n'.format(temp))
+            fp.flush()
+            led.value = not led.value
+            time.sleep(1)
+except OSError as e:
+    delay = 0.5
+    if e.args[0] == 28:
+        delay = 0.25
+    while True:
+        led.value = not led.value
+        time.sleep(delay)

--- a/CircuitPython_Essentials/CircuitPython_Logger_Boot.py
+++ b/CircuitPython_Essentials/CircuitPython_Logger_Boot.py
@@ -1,0 +1,11 @@
+import digitalio
+import board
+import storage
+
+switch = digitalio.DigitalInOut(board.D0)
+switch.direction = digitalio.Direction.INPUT
+switch.pull = digitalio.Pull.UP
+
+# If the D0 is connected to ground with a wire
+# CircuitPython can write to the drive
+storage.remount("/", switch.value)

--- a/CircuitPython_Essentials/CircuitPython_NeoPixel.py
+++ b/CircuitPython_Essentials/CircuitPython_NeoPixel.py
@@ -1,0 +1,69 @@
+# CircuitPython demo - NeoPixel
+
+import time
+import board
+import neopixel
+
+pixel_pin = board.A1
+num_pixels = 8
+
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.3, auto_write=False)
+
+
+def wheel(pos):
+    # Input a value 0 to 255 to get a color value.
+    # The colours are a transition r - g - b - back to r.
+    if pos < 0 or pos > 255:
+        return (0, 0, 0)
+    if pos < 85:
+        return (255 - pos * 3, pos * 3, 0)
+    if pos < 170:
+        pos -= 85
+        return (0, 255 - pos * 3, pos * 3)
+    pos -= 170
+    return (pos * 3, 0, 255 - pos * 3)
+
+
+def color_chase(color, wait):
+    for i in range(num_pixels):
+        pixels[i] = color
+        time.sleep(wait)
+        pixels.show()
+    time.sleep(0.5)
+
+
+def rainbow_cycle(wait):
+    for j in range(255):
+        for i in range(num_pixels):
+            rc_index = (i * 256 // num_pixels) + j
+            pixels[i] = wheel(rc_index & 255)
+        pixels.show()
+        time.sleep(wait)
+
+
+RED = (255, 0, 0)
+YELLOW = (255, 150, 0)
+GREEN = (0, 255, 0)
+CYAN = (0, 255, 255)
+BLUE = (0, 0, 255)
+PURPLE = (180, 0, 255)
+
+while True:
+    pixels.fill(RED)
+    pixels.show()
+    time.sleep(1)  # Increase or decrease to change the speed of the solid color change.
+    pixels.fill(GREEN)
+    pixels.show()
+    time.sleep(1)
+    pixels.fill(BLUE)
+    pixels.show()
+    time.sleep(1)
+
+    color_chase(RED, 0.1)  # Increase the number to slow down the color chase
+    color_chase(YELLOW, 0.1)
+    color_chase(GREEN, 0.1)
+    color_chase(CYAN, 0.1)
+    color_chase(BLUE, 0.1)
+    color_chase(PURPLE, 0.1)
+
+    rainbow_cycle(0)  # Increase the number to slow down the rainbow

--- a/CircuitPython_Essentials/CircuitPython_NeoPixel_RGBW.py
+++ b/CircuitPython_Essentials/CircuitPython_NeoPixel_RGBW.py
@@ -1,0 +1,70 @@
+# CircuitPython demo - NeoPixel RGBW
+
+import time
+import board
+import neopixel
+
+pixel_pin = board.A1
+num_pixels = 8
+
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels,
+                           brightness=0.3, auto_write=False, pixel_order=(1, 0, 2, 3))
+
+
+def wheel(pos):
+    # Input a value 0 to 255 to get a color value.
+    # The colours are a transition r - g - b - back to r.
+    if pos < 0 or pos > 255:
+        return (0, 0, 0, 0)
+    if pos < 85:
+        return (255 - pos * 3, pos * 3, 0, 0)
+    if pos < 170:
+        pos -= 85
+        return (0, 255 - pos * 3, pos * 3, 0)
+    pos -= 170
+    return (pos * 3, 0, 255 - pos * 3, 0)
+
+
+def color_chase(color, wait):
+    for i in range(num_pixels):
+        pixels[i] = color
+        time.sleep(wait)
+        pixels.show()
+    time.sleep(0.5)
+
+
+def rainbow_cycle(wait):
+    for j in range(255):
+        for i in range(num_pixels):
+            rc_index = (i * 256 // num_pixels) + j
+            pixels[i] = wheel(rc_index & 255)
+        pixels.show()
+        time.sleep(wait)
+
+
+RED = (255, 0, 0, 0)
+YELLOW = (255, 150, 0, 0)
+GREEN = (0, 255, 0, 0)
+CYAN = (0, 255, 255, 0)
+BLUE = (0, 0, 255, 0)
+PURPLE = (180, 0, 255, 0)
+
+while True:
+    pixels.fill(RED)
+    pixels.show()
+    time.sleep(1)  # Increase or decrease to change the speed of the solid color change.
+    pixels.fill(GREEN)
+    pixels.show()
+    time.sleep(1)
+    pixels.fill(BLUE)
+    pixels.show()
+    time.sleep(1)
+
+    color_chase(RED, 0.1)  # Increase the number to slow down the color chase
+    color_chase(YELLOW, 0.1)
+    color_chase(GREEN, 0.1)
+    color_chase(CYAN, 0.1)
+    color_chase(BLUE, 0.1)
+    color_chase(PURPLE, 0.1)
+
+    rainbow_cycle(0)  # Increase the number to slow down the rainbow

--- a/CircuitPython_Essentials/CircuitPython_PWM.py
+++ b/CircuitPython_Essentials/CircuitPython_PWM.py
@@ -1,0 +1,14 @@
+import time
+import pulseio
+import board
+
+led = pulseio.PWMOut(board.D13, frequency=5000, duty_cycle=0)
+
+while True:
+    for i in range(100):
+        # PWM LED up and down
+        if i < 50:
+            led.duty_cycle = int(i * 2 * 65535 / 100)  # Up
+        else:
+            led.duty_cycle = 65535 - int((i - 50) * 2 * 65535 / 100)  # Down
+        time.sleep(0.01)

--- a/CircuitPython_Essentials/CircuitPython_PWM_Piezo.py
+++ b/CircuitPython_Essentials/CircuitPython_PWM_Piezo.py
@@ -1,0 +1,14 @@
+import time
+import pulseio
+import board
+
+piezo = pulseio.PWMOut(board.A2, duty_cycle=0, frequency=440, variable_frequency=True)
+
+while True:
+    for f in (262, 294, 330, 349, 392, 440, 494, 523):
+        piezo.frequency = f
+        piezo.duty_cycle = 65536 // 2  # On 50%
+        time.sleep(0.25)  # On for 1/4 second
+        piezo.duty_cycle = 0   # Off
+        time.sleep(0.05)  # Pause between notes
+    time.sleep(0.5)

--- a/CircuitPython_Essentials/CircuitPython_PWM_Piezo_simpleio.py
+++ b/CircuitPython_Essentials/CircuitPython_PWM_Piezo_simpleio.py
@@ -1,0 +1,9 @@
+import time
+import board
+import simpleio
+
+while True:
+    for f in (262, 294, 330, 349, 392, 440, 494, 523):
+        simpleio.tone(board.A2, f, 0.25)  # on for 1/4 second
+        time.sleep(0.05)                  # pause between notes
+    time.sleep(0.5)

--- a/CircuitPython_Essentials/CircuitPython_Servo.py
+++ b/CircuitPython_Essentials/CircuitPython_Servo.py
@@ -1,0 +1,13 @@
+import time
+import simpleio
+import board
+
+servo = simpleio.Servo(board.A2)
+
+while True:
+    for angle in range(0, 180, 5):  # 0-180 degrees, 5 degrees at a time
+        servo.angle = angle
+        time.sleep(0.05)
+    for angle in range(180, 0, -5):  # 180-0 degrees, 5 degrees at a time
+        servo.angle = angle
+        time.sleep(0.05)

--- a/CircuitPython_Essentials/CircuitPython_UART.py
+++ b/CircuitPython_Essentials/CircuitPython_UART.py
@@ -1,0 +1,22 @@
+# CircuitPython Demo - USB/Serial echo
+
+import digitalio
+import board
+import busio
+
+led = digitalio.DigitalInOut(board.D13)
+led.direction = digitalio.Direction.OUTPUT
+
+uart = busio.UART(board.TX, board.RX, baudrate=9600)
+
+while True:
+    data = uart.read(32)  # read up to 32 bytes
+    # print(data)  # this is a bytearray type
+
+    if data is not None:
+        led.value = True
+
+        data_string = ''.join([chr(b) for b in data])  # convert bytearray to string
+        print(data_string, end="")
+
+        led.value = False

--- a/CircuitPython_Essentials/PWM_Test_Script.py
+++ b/CircuitPython_Essentials/PWM_Test_Script.py
@@ -1,0 +1,13 @@
+import board
+import pulseio
+
+for pin_name in dir(board):
+    pin = getattr(board, pin_name)
+    try:
+        p = pulseio.PWMOut(pin)
+        p.deinit()
+        print("PWM on:", pin_name)  # Prints the valid, PWM-capable pins!
+    except ValueError:  # This is the error returned when the pin is invalid.
+        print("No PWM on:", pin_name)  # Prints the invalid pins.
+    except RuntimeError:  # This is the error returned when there is a timer conflict.
+        print("Timers in use:", pin_name)  # Prints the timer conflict pins.

--- a/CircuitPython_Essentials/SPI_Test_Script.py
+++ b/CircuitPython_Essentials/SPI_Test_Script.py
@@ -1,0 +1,17 @@
+import board
+import busio
+
+
+def is_hardware_SPI(clock_pin, data_pin):
+    try:
+        p = busio.SPI(clock_pin, data_pin)
+        p.deinit()
+        return True
+    except ValueError:
+        return False
+
+
+if is_hardware_SPI(board.A1, board.A2):  # Provide the two pins you intend to use.
+    print("This pin combination is hardware SPI!")
+else:
+    print("This pin combination isn't hardware SPI.")

--- a/CircuitPython_Essentials/UART_Test_Script.py
+++ b/CircuitPython_Essentials/UART_Test_Script.py
@@ -1,0 +1,38 @@
+import board
+import busio
+
+
+def is_hardware_UART(tx, rx):
+    try:
+        p = busio.UART(tx, rx)
+        p.deinit()
+        return True
+    except ValueError:
+        return False
+
+
+def get_unique_pins():
+    pin_names = dir(board)
+    if "NEOPIXEL" in pin_names:
+        pin_names.remove("NEOPIXEL")
+    if "APA102_MOSI" in pin_names:
+        pin_names.remove("APA102_MOSI")
+    if "APA102_SCK" in pin_names:
+        pin_names.remove("APA102_SCK")
+    pins = [getattr(board, p) for p in pin_names]
+    unique = []
+    for p in pins:
+        if p not in unique:
+            unique.append(p)
+    return unique
+
+
+for tx_pin in get_unique_pins():
+    for rx_pin in get_unique_pins():
+        if rx_pin is tx_pin:
+            continue
+        else:
+            if is_hardware_UART(tx_pin, rx_pin):
+                print("RX pin:", rx_pin, "\t TX pin:", tx_pin)
+            else:
+                pass


### PR DESCRIPTION
Changing the directory name to match the guide title. At the time that we started unifying the quick starts, we hadn't decided to create a separate guide for them. Now that we have one, the directory structure should match the guide name. I will be updating all the links in the guide before removing the other directory. All further working examples will be pushed to this directory.