### PR TITLE
Turn off built-in dotstar LED in earrings code

### DIFF
--- a/Gemma_Hoop_Earrings/Gemma_Hoop_Earrings.py
+++ b/Gemma_Hoop_Earrings/Gemma_Hoop_Earrings.py
@@ -4,6 +4,7 @@
 import board
 import neopixel
 import time
+import adafruit_dotstar as dotstar
 try:
 	import urandom as random  # for v1.0 API support
 except ImportError:
@@ -12,6 +13,11 @@ except ImportError:
 numpix = 16  # Number of NeoPixels (e.g. 16-pixel ring)
 pixpin = board.D0  # Pin where NeoPixels are connected
 strip  = neopixel.NeoPixel(pixpin, numpix, brightness=.3)
+
+# Turn off the onboard dotstar RGB to avoid distractions
+dot = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+dot[0] = (0, 0, 0)
+dot.show()
 
 def wheel(pos):
 	# Input a value 0 to 255 to get a color value.


### PR DESCRIPTION
Hi,

This change turn off the onboard dotstar RGB in the Gemma_Hoop_Earrings.py code to
avoid distractions (it's just the neopixel ring that lights up).

Cheers,
Klas