### PR TITLE
add notes for PDMIn name change of frequency to sample_rate

### DIFF
--- a/CircuitPython_Made_Easy_On_CPX/cpx_sound_meter.py
+++ b/CircuitPython_Made_Easy_On_CPX/cpx_sound_meter.py
@@ -19,8 +19,15 @@ def normalized_rms(values):
     return math.sqrt(sum(float(sample - minbuf) *
                          (sample - minbuf) for sample in values) / len(values))
 
+# For CircuitPython 2.x:
+mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA,
+                       frequency=16000, bit_depth=16)
+# For Circuitpython 3.0 and up, "frequency" is now called "sample_rate".
+# Comment the lines above and uncomment the lines below.
+#mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA,
+#                       sample_rate=16000, bit_depth=16)
 
-mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, frequency=16000, bit_depth=16)
+
 samples = array.array('H', [0] * 160)
 mic.record(samples, len(samples))
 input_floor = normalized_rms(samples) + 10

--- a/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_SoundMeter.py
+++ b/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_SoundMeter.py
@@ -88,8 +88,14 @@ pixels = neopixel.NeoPixel(board.NEOPIXEL, NUM_PIXELS,
 pixels.fill(0)
 pixels.show()
 
-mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK,
-                       board.MICROPHONE_DATA, frequency=16000, bit_depth=16)
+# For CircuitPython 2.x:
+mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA,
+                       frequency=16000, bit_depth=16)
+# For Circuitpython 3.0 and up, "frequency" is now called "sample_rate".
+# Comment the lines above and uncomment the lines below.
+#mic = audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA,
+#                       sample_rate=16000, bit_depth=16)
+
 # Record an initial sample to calibrate. Assume it's quiet when we start.
 samples = array.array('H', [0] * NUM_SAMPLES)
 mic.record(samples, len(samples))


### PR DESCRIPTION
Incompatible change made in `PDMIn()` constructor: keyword arg changed from `frequency` to `sample_rate`. Include both in sample code. (FYI see https://github.com/adafruit/circuitpython/issues/881)