### PR TITLE
fixing audioio.AudioOut which now seems to have only one param

### DIFF
--- a/Introducing_CircuitPlaygroundExpress/Playground_808.py
+++ b/Introducing_CircuitPlaygroundExpress/Playground_808.py
@@ -27,12 +27,13 @@ audiofiles = ["bd_tek.wav", "elec_hi_snare.wav", "elec_cymbal.wav",
               "elec_blip2.wav", "bd_zome.wav", "bass_hit_c.wav",
               "drum_cowbell.wav"]
 
+a = audioio.AudioOut(board.A0)
 
 def play_file(filename):
     print("playing file " + filename)
     f = open(filename, "rb")
-    a = audioio.AudioOut(board.A0, f)
-    a.play()
+    wave = audioio.WaveFile(f)
+    a.play(wave)
     time.sleep(bpm / 960)  # sixteenthNote delay
 
 


### PR DESCRIPTION
The code sample (as it was) when run on my new adfruit circuitboard playground express was throwing an error
```
Traceback (most recent call last):
  File "main.py", line 43, in <module>
  File "main.py", line 34, in play_file
TypeError: extra positional arguments given
```
Line 34 was:
```
a = audioio.AudioOut(board.A0, f)
```
It looks as if audioio.AudioOut has been changed to only accept one arg

Inspiration for this PR was found at:
https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/master/CircuitPython_Essentials/CircuitPython_Audio_Out_Wave.py

