### PR TITLE
Replace SimpleIO servo with Adafruit_Motor Servo

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_Servo.py
+++ b/CircuitPython_Essentials/CircuitPython_Servo.py
@@ -1,16 +1,18 @@
 import time
 import board
-import simpleio
+import pulseio
+from adafruit_motor import servo
 
-# For the M0 boards:
-servo = simpleio.Servo(board.A2)
-# For the M4 boards:
-# servo = simpleio.Servo(board.A1)
+# create a PWMOut object on Pin 13.
+pwm = pulseio.PWMOut(board.D13, duty_cycle=2 ** 15, frequency=50)
+
+# Create a servo object, my_servo.
+my_servo = servo.Servo(pwm)
 
 while True:
-    for angle in range(0, 180, 5):  # 0-180 degrees, 5 degrees at a time
-        servo.angle = angle
+    for angle in range(0, 180, 5):  # 0 - 180 degrees, 5 degrees at a time.
+        my_servo.angle = angle
         time.sleep(0.05)
-    for angle in range(180, 0, -5):  # 180-0 degrees, 5 degrees at a time
-        servo.angle = angle
+    for angle in range(180, 0, -5): # 180 - 0 degrees, 5 degrees at a time.
+        my_servo.angle = angle
         time.sleep(0.05)

--- a/Combo_Dial_Safe/main.py
+++ b/Combo_Dial_Safe/main.py
@@ -5,11 +5,14 @@
 import time
 
 import board
-import simpleio
+import pulseio
+from adafruit_motor import servo
 from adafruit_circuitplayground.express import cpx
 
+pwm = pulseio.PWMOut(board.A3, duty_cycle=2 ** 15, frequency=50)
+
 #  plug red servo wire to VOUT, brown to GND, yellow to A3
-servo = simpleio.Servo(board.A3)
+servo = servo.Servo(pwm)
 
 cpx.pixels.brightness = 0.05  # set brightness value
 


### PR DESCRIPTION
Replacing `simpleio`'s servo helper with `adafruit_motor`'s servo helper. 

Issue: https://github.com/adafruit/Adafruit_CircuitPython_SimpleIO/issues/33

**Learn Guide Pages Affected by this change:**

- https://learn.adafruit.com/circuitpython-essentials/circuitpython-servo, Tested on Feather M4, SG92R Servo.


- https://learn.adafruit.com/combo-dial-safe-with-circuit-playground-express/code-with-circuitpython#download-the-combo-dial-python-code-3-5, Tested on CPX, SG92R Servo.

