### PR TITLE
add decoder scripts for TinyLoRa Guide

### DIFF
--- a/TheThingsNetwork_Feather/tinylora_dht22_decoder.js
+++ b/TheThingsNetwork_Feather/tinylora_dht22_decoder.js
@@ -1,0 +1,14 @@
+// TinyLoRa - DHT22 Decoder
+function Decoder(bytes, port) {
+  var decoded = {};
+
+  // Decode bytes to int
+  var celciusInt = (bytes[0] << 8) | bytes[1];
+  var humidInt = (bytes[2] << 8) | bytes[3];
+  
+  // Decode int to float
+  decoded.celcius = celciusInt / 100;
+  decoded.humid = humidInt / 100;
+
+  return decoded;
+}

--- a/TheThingsNetwork_Feather/tinylora_hello_decoder.js
+++ b/TheThingsNetwork_Feather/tinylora_hello_decoder.js
@@ -1,0 +1,7 @@
+// TTN Decoder for 'Hello LoRa'
+function Decoder(bytes, port) {
+  // Decode plain text; for testing only 
+  return {
+      myTestValue: String.fromCharCode.apply(null, bytes)
+  };
+}

--- a/TheThingsNetwork_Feather/ttn_lmic_dht22_decoder.js
+++ b/TheThingsNetwork_Feather/ttn_lmic_dht22_decoder.js
@@ -1,3 +1,5 @@
+// TTN Decoder for TTN OTAA Feather US915 DHT22 Sketch
+// Link: https://github.com/mcci-catena/arduino-lmic/blob/master/examples/ttn-otaa-feather-us915-dht22/ttn-otaa-feather-us915-dht22.ino
 function Decoder(bytes, port) {
   // Decode an uplink message from a buffer
   // (array) of bytes to an object of fields.


### PR DESCRIPTION
Adding two TTN payload decoder scripts (for TinyLoRa) to embed in the 'Using Feather 32u4' pages. 

Renaming original decoder (for LMIC) to avoid confusion. 