### PR TITLE
Update startup colors to be more primary

### DIFF
--- a/NeoTrellis_M4_Sound_Board/code.py
+++ b/NeoTrellis_M4_Sound_Board/code.py
@@ -45,7 +45,7 @@ SAMPLES = [("01.wav", RED),
            ("32.wav", PINK)]
 
 # For the intro, pick any number of colors to make a fancy gradient!
-INTRO_SWIRL = [PINK, TEAL, YELLOW]
+INTRO_SWIRL = [RED, GREEN, BLUE]
 # the color for the selected sample
 SELECTED_COLOR = WHITE
 


### PR DESCRIPTION
Star Trek was one of the first color television shows so they had a very primary palette of colors. Changed intro swirl to RED, GREEN, BLUE as Limor asked that the pastel colors be more Star Trek.

Dano should test this - if it isn't enough Trek, maybe a different animation?