### PR TITLE
Update cpx_red_led.py (and guidelines)

### DIFF
--- a/CircuitPython_Made_Easy_On_CPX/cpx_red_led.py
+++ b/CircuitPython_Made_Easy_On_CPX/cpx_red_led.py
@@ -1,3 +1,4 @@
 from adafruit_circuitplayground.express import cpx
 
-cpx.red_led = True
+while True:
+    cpx.red_led = True


### PR DESCRIPTION
Hi,
This change keeps the red led turned on. Currently, without while loop, the led is only turned on for a fraction of a second and is turned off once the program ends.

[If this is merged, I guess you would also need to move the description of the while loop into the first paragraph, i.e. from "Blinky" to "Red LED": https://learn.adafruit.com/circuitpython-made-easy-on-circuit-playground-express/red-led] 