### PR TITLE
Fix Home Assistant YAML

### DIFF
--- a/home-assistant-io/feather_bme280.yaml
+++ b/home-assistant-io/feather_bme280.yaml
@@ -32,10 +32,10 @@ mqtt:
   password: ${io_key}
   topic_prefix: '${io_username}/feeds'
   birth_message:
-    topic: ${io_username}/status
+    topic: ${io_username}/feeds/status
     payload: Online
   will_message:
-    topic: ${io_username}/status
+    topic: ${io_username}/feeds/status
     payload: Offline
   log_topic:
 


### PR DESCRIPTION
Correcting IO feed path to resolve error: `[12:42:53](Message skipped because it was too big to fit in TCP buffer - This is only cosmetic)`