### PR TITLE
simplify ble_crickit_light_switch.py

### DIFF
--- a/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
+++ b/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
@@ -6,6 +6,7 @@
 
 import board
 import digitalio
+import time
 
 from adafruit_crickit import crickit
 from adafruit_ble.uart import UARTServer
@@ -52,3 +53,6 @@ while True:
                 elif packet.button == ButtonPacket.DOWN:
                     # The Down button was pressed.
                     crickit.servo_1.angle = DOWN_ANGLE
+
+                # Wait a bit before returning to neutral position.
+                time.sleep(0.25)

--- a/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
+++ b/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
@@ -4,9 +4,10 @@
 # running on an nRF52840 Feather board and Crickit FeatherWing
 # micro servo, 3D printed switch actuator
 
+import time
+
 import board
 import digitalio
-import time
 
 from adafruit_crickit import crickit
 from adafruit_ble.uart import UARTServer

--- a/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
+++ b/BLE_Crickit_Light_Switch/ble_crickit_light_switch.py
@@ -30,7 +30,6 @@ crickit.servo_1.angle = NEUTRAL_ANGLE
 
 while True:
     blue_led.value = False
-    crickit.servo_1.angle = NEUTRAL_ANGLE
     uart_server.start_advertising()
 
     while not uart_server.connected:
@@ -39,6 +38,7 @@ while True:
 
     blue_led.value = True
     while uart_server.connected:
+        crickit.servo_1.angle = NEUTRAL_ANGLE
         if uart_server.in_waiting:
             # Packet is arriving.
             red_led.value = False


### PR DESCRIPTION
This simplifies the code, removing `advertising_now` and removing moving the server one degree at a time. That code was there from the CircusPython to move the servo more slowly and to call `sparkle()` as continuously as possible. It's not necessary here.

The Learn Guide will need a tiny update to remove the sentence saying the servo is moved one degree at a time.