### PR TITLE
 fixes for some PyPortal guides…

### DIFF
--- a/PyPortal_OpenWeather/openweather_graphics.py
+++ b/PyPortal_OpenWeather/openweather_graphics.py
@@ -130,10 +130,13 @@ class OpenWeather_Graphics(displayio.Group):
             self._icon_file.close()
         self._icon_file = open(filename, "rb")
         icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(icon,
-                                               pixel_shader=displayio.ColorConverter(),
-                                               position=(0, 0))
-
+        try:
+            self._icon_sprite = displayio.TileGrid(icon,
+                                                   pixel_shader=displayio.ColorConverter())
+        except TypeError:
+            self._icon_sprite = displayio.TileGrid(icon,
+                                                   pixel_shader=displayio.ColorConverter(),
+                                                   position=(0,0))
         self._icon_group.append(self._icon_sprite)
         board.DISPLAY.refresh_soon()
         board.DISPLAY.wait_for_frame()

--- a/pyportal_weather_station/weatherstation_helper.py
+++ b/pyportal_weather_station/weatherstation_helper.py
@@ -141,9 +141,13 @@ class WeatherStation_GFX(displayio.Group):
             self._icon_file.close()
         self._icon_file = open(filename, "rb")
         icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(icon,
-                                               pixel_shader=displayio.ColorConverter(),
-                                               position=(0, 0))
+        try:
+            self._icon_sprite = displayio.TileGrid(icon,
+                                                   pixel_shader=displayio.ColorConverter())
+        except TypeError:
+            self._icon_sprite = displayio.TileGrid(icon,
+                                                   pixel_shader=displayio.ColorConverter(),
+                                                   position=(0,0))
 
         self._icon_group.append(self._icon_sprite)
         board.DISPLAY.refresh_soon()


### PR DESCRIPTION
Pyportal_OpenWeather and pyportal_weather_station use TileGrid from displayio. A recent change to the API requires change to the kwargs. Added try/except to work with both versions of TileGrid.

Tested PyPortal_OpenWeather with both versions.
I am not able to test pyportal_weather_station since I do not have all the HW.