### PR TITLE
Fix PyPortal Thermostat Font Preloading

### DIFF
--- a/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -55,6 +55,11 @@ class Thermometer_GFX(displayio.Group):
         self.title_text.y = 15
         self._text_group.append(self.title_text)
 
+        self.subtitle_text = Label(self.info_font, text="Analog Devices ADT7410")
+        self.subtitle_text.x = 43
+        self.subtitle_text.y = 35
+        self._text_group.append(self.subtitle_text)
+
         self.temp_text = Label(self.c_font, max_glyphs=8)
         self.temp_text.x = 25
         self.temp_text.y = 110

--- a/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -12,7 +12,6 @@ cwd = ("/"+__file__).rsplit('/', 1)[0] # the current working directory (where th
 # Fonts within /fonts folder
 info_font = cwd+"/fonts/Nunito-Black-17.bdf"
 temperature_font = cwd+"/fonts/Nunito-Light-75.bdf"
-glyphs = b'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-,.:'
 
 class Thermometer_GFX(displayio.Group):
     def __init__(self, celsius=True, usa_date=True):
@@ -42,6 +41,7 @@ class Thermometer_GFX(displayio.Group):
         self.set_icon(self._cwd+"/icons/pyportal_splash.bmp")
 
         print('loading fonts...')
+        glyphs = b'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-,.:/ '
         self.info_font = bitmap_font.load_font(info_font)
         self.info_font.load_glyphs(glyphs)
 


### PR DESCRIPTION
adding `/` and `space` characters to glyph string