### PR TITLE
Update display and brightness code in Magic_Nine_Ball

### DIFF
--- a/Magic_Nine_Ball/magic_nine_ball.py
+++ b/Magic_Nine_Ball/magic_nine_ball.py
@@ -7,8 +7,6 @@ import os
 import random
 import board
 import displayio
-import pulseio
-import busio
 import adafruit_lis3dh
 
 splash = displayio.Group()


### PR DESCRIPTION
Was using `Sprite` instead of `TileGrid`.
Now use builtin `brightness` control.

I'm seeing flickering when the brightness gets near 1.0, but I think that's an issue unrelated to this code, and probably needs to be fixed elsewhere.