### PR TITLE
Fix out-of-bounds error with moonphasenames array

### DIFF
--- a/EInk_Weather_Station/adafruit_epd_weather/adafruit_epd_weather.ino
+++ b/EInk_Weather_Station/adafruit_epd_weather/adafruit_epd_weather.ino
@@ -1,4 +1,3 @@
-
 #include <time.h>
 #include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_EPD.h>
@@ -41,7 +40,7 @@ OpenWeatherMapForecastData owfdata[3];
 
 Adafruit_NeoPixel neopixel = Adafruit_NeoPixel(1, NEOPIXELPIN, NEO_GRB + NEO_KHZ800);
 
-  const char *moonphasenames[28] = {
+  const char *moonphasenames[29] = {
     "New Moon",
     "Waxing Crescent",
     "Waxing Crescent",
@@ -64,6 +63,7 @@ Adafruit_NeoPixel neopixel = Adafruit_NeoPixel(1, NEOPIXELPIN, NEO_GRB + NEO_KHZ
     "Waning Gibbous",
     "Waning Gibbous",
     "Last Quarter",
+    "Waning Crescent",
     "Waning Crescent",
     "Waning Crescent",
     "Waning Crescent",


### PR DESCRIPTION
Increased moonphasenames from [28] to [29] to include the last day before a new moon and avoid an out-of-bounds error causing sketch to crash. This commit also clean ups mixed end of line feeds, which may explain the issue of the display not properly showing the changed diffs in GitHub.