### PR TITLE
fixed drop byte in Feather/Pi LoRa Weather Monitor

### DIFF
--- a/lorawan_sensing_network/lora_device.py
+++ b/lorawan_sensing_network/lora_device.py
@@ -47,7 +47,7 @@ rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 rfm9x.tx_power = 23
 
 # sensor data
-bme280_data = bytearray(7)
+bme280_data = bytearray(8)
 
 while True:
     # Get sensor readings
@@ -71,8 +71,9 @@ while True:
     bme280_data[4] = humid_val & 0xff
 
     # Pressure data
-    bme280_data[5] = (pres_val >> 8) & 0xff
-    bme280_data[6] = pres_val & 0xff
+    bme280_data[5] = (pres_val >> 16) & 0xff
+    bme280_data[6] = (pres_val >> 8) & 0xff
+    bme280_data[7] = pres_val & 0xff
 
     # Convert bytearray to bytes
     bme280_data_bytes = bytes(bme280_data)

--- a/lorawan_sensing_network/lora_gateway.py
+++ b/lorawan_sensing_network/lora_gateway.py
@@ -77,10 +77,13 @@ temperature_feed_2 = aio.feeds('feather-2-temp')
 humidity_feed_2 = aio.feeds('feather-2-humid')
 pressure_feed_2 = aio.feeds('feather-2-pressure')
 
-def pkt_int_to_float(pkt_val_1, pkt_val_2):
-    """Converts 2 bytes of packet data to float.
+def pkt_int_to_float(pkt_val_1, pkt_val_2, pkt_val_3=None):
+    """Convert packet data to float.
     """
-    float_val = pkt_val_1 << 8 | pkt_val_2
+    if pkt_val_3 is None:
+        float_val = pkt_val_1 << 8 | pkt_val_2
+    else:
+        float_val = pkt_val_1 << 16 | pkt_val_2 << 8 | pkt_val_3
     return float_val/100
 
 while True:
@@ -100,7 +103,7 @@ while True:
         # Decode packet
         temp_val = pkt_int_to_float(packet[1], packet[2])
         humid_val = pkt_int_to_float(packet[3], packet[4])
-        pres_val = pkt_int_to_float(packet[5], packet[6])
+        pres_val = pkt_int_to_float(packet[5], packet[6], packet[7])
 
         # Display packet information
         print('Device ID: LoRa Feather #', packet[0])


### PR DESCRIPTION
re: https://forums.adafruit.com/viewtopic.php?f=57&t=153641

`pres_val = 101275` won't fit in 2 bytes, increasing size of bytearray to fit `pres_val`. Third byte handled in the gateway's `pkt_int_to_float` method as an optional kwarg