### PR TITLE
Fix Interrupt pin number

### DIFF
--- a/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_Accelerometer_Simpletest.py
+++ b/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_Accelerometer_Simpletest.py
@@ -7,7 +7,7 @@ import adafruit_lis3dh
 
 # Set up accelerometer on I2C bus, 4G range:
 i2c = busio.I2C(board.SCL, board.SDA)
-int1 = digitalio.DigitalInOut(board.D5)
+int1 = digitalio.DigitalInOut(board.D6)
 accel = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
 accel.range = adafruit_lis3dh.RANGE_4_G
 accel.set_tap(1, 100)


### PR DESCRIPTION
The interrupt is hooked to D6, not D5.