### PR TITLE
Update Adafruit IO CircuitPython Examples for breaking v2.0

### DIFF
--- a/PyPortal_AdafruitIO_Logger/pyportal_adafruit_io_logger.py
+++ b/PyPortal_AdafruitIO_Logger/pyportal_adafruit_io_logger.py
@@ -20,8 +20,8 @@ from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 # Import NeoPixel Library
 import neopixel
 
-# Import Adafruit IO REST Client
-from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
+# Import Adafruit IO HTTP Client
+from adafruit_io.adafruit_io import IO_HTTP, AdafruitIO_RequestError
 
 # Import ADT7410 Library
 import adafruit_adt7410
@@ -51,8 +51,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 ADAFRUIT_IO_USER = secrets['aio_username']
 ADAFRUIT_IO_KEY = secrets['aio_key']
 
-# Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+# Create an instance of the Adafruit IO HTTP client
+io = IO_HTTP(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
 
 try:
     # Get the 'temperature' feed from Adafruit IO

--- a/PyPortal_IOT_Scale/pyportal_scale.py
+++ b/PyPortal_IOT_Scale/pyportal_scale.py
@@ -16,7 +16,7 @@ from adafruit_bitmap_font import bitmap_font
 
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import neopixel
-from adafruit_io.adafruit_io import RESTClient
+from adafruit_io.adafruit_io import IO_HTTP
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -74,8 +74,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 aio_username = secrets['aio_username']
 aio_key = secrets['aio_key']
 
-# Create an instance of the Adafruit IO REST client
-io = RESTClient(aio_username, aio_key, wifi)
+# Create an instance of the IO_HTTP client
+io = IO_HTTP(aio_username, aio_key, wifi)
 
 # Get the weight feed from IO
 weight_feed = io.get_feed('weight')

--- a/PyPortal_Smart_Thermometer/thermometer.py
+++ b/PyPortal_Smart_Thermometer/thermometer.py
@@ -15,7 +15,7 @@ from analogio import AnalogIn
 import adafruit_adt7410
 
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
+from adafruit_io.adafruit_io import IO_HTTP, AdafruitIO_RequestError
 
 # thermometer graphics helper
 import thermometer_helper
@@ -49,8 +49,8 @@ except KeyError:
     raise KeyError('To use this code, you need to include your Adafruit IO username \
 and password in a secrets.py file on the CIRCUITPY drive.')
 
-# Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+# Create an instance of the IO_HTTP client
+io = IO_HTTP(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
 
 # Get the temperature feed from Adafruit IO
 temperature_feed = io.get_feed('temperature')

--- a/pyportal_weather_station/code.py
+++ b/pyportal_weather_station/code.py
@@ -15,7 +15,7 @@ from simpleio import map_range
 from digitalio import DigitalInOut
 
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
+from adafruit_io.adafruit_io import IO_HTTP, AdafruitIO_RequestError
 
 # sensor libs
 import adafruit_veml6075
@@ -56,8 +56,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 ADAFRUIT_IO_USER = secrets['aio_username']
 ADAFRUIT_IO_KEY = secrets['aio_key']
 
-# Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+# Create an instance of the Adafruit IO HTTP client
+io = IO_HTTP(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
 
 # create an i2c object
 i2c = busio.I2C(board.SCL, board.SDA)


### PR DESCRIPTION
The Adafruit IO CircuitPython module's latest release changes a class name, `RESTCLIENT` to `IO_HTTP`. This PR adds the appropriate substitutions to Learning System Guides which use this module.

https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/releases/tag/2.0.0