### PR TITLE
Matrix 7 segment led backpack merge

### DIFF
--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/alphanum4_test.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/alphanum4_test.py
@@ -1,0 +1,56 @@
+import time
+import board
+import busio
+from adafruit_ht16k33 import segments
+
+# Create the I2C interface.
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# Create the LED segment class.
+# This creates a 14 segment 4 character display:
+display = segments.Seg14x4(i2c)
+
+# Clear the display.
+display.fill(0)
+
+# set brightness, range 1-15, 15 max brightness
+display.brightness = 15
+
+# show phrase on alphanumeric display
+message = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
+count = 0
+
+# print one character at time with short sleep
+# creates smooth scrolling effect
+while count < len(message):
+    display.print(message[count])
+    count += 1
+    time.sleep(0.3)
+
+# Can just print a number
+display.print(42)
+time.sleep(1)
+
+# Set the first character to '1':
+display[0] = '1'
+# Set the second character to '2':
+display[1] = '2'
+# Set the third character to 'A':
+display[2] = 'A'
+# Set the forth character to 'B':
+display[3] = 'B'
+time.sleep(1)
+
+numbers = [0.0, 1.0, -1.0, 0.55, -0.55, 10.23, -10.2, 100.5, -100.5]
+
+# print negative and positive floating point numbers
+for i in numbers:
+    display.print(i)
+    time.sleep(0.5)
+
+# print hex values, enable colon
+for i in range(0xFF):
+    display.fill(0)
+    display.print(':')
+    display.print(hex(i))
+    time.sleep(0.25)

--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/bicolor24_test.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/bicolor24_test.py
@@ -1,0 +1,38 @@
+# Basic example of using the Bi-color 24 segment bargraph display.
+# This example and library is meant to work with Adafruit CircuitPython API.
+# Author: Carter Nelson
+# License: Public Domain
+
+import time
+import board
+import busio
+
+# Import the Bicolor24 driver from the HT16K33 module
+from adafruit_ht16k33.bargraph import Bicolor24
+
+# Create the I2C interface
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# Create the LED bargraph class.
+bc24 = Bicolor24(i2c)
+
+# Set individual segments of bargraph
+bc24[0] = bc24.LED_RED
+bc24[1] = bc24.LED_GREEN
+bc24[2] = bc24.LED_YELLOW
+
+time.sleep(2)
+
+# Turn them all off
+bc24.fill(bc24.LED_OFF)
+
+# Turn them on in a loop
+for i in range(24):
+    bc24[i] = bc24.LED_RED
+    time.sleep(0.1)
+    bc24[i] = bc24.LED_OFF
+
+time.sleep(1)
+
+# Fill the entrire bargraph
+bc24.fill(bc24.LED_GREEN)

--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/matrix8x8_test.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/matrix8x8_test.py
@@ -23,7 +23,7 @@ while True:
 
     # illuminate a column one LED at a time
     while col < col_max:
-        matrix[row, col] = 1
+        matrix[row, col] = 2
         col += 1
         time.sleep(.2)
 

--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/matrix_bicolor_test.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/matrix_bicolor_test.py
@@ -1,0 +1,68 @@
+# Import all pins
+import time
+import board
+import busio
+from adafruit_ht16k33 import matrix
+
+# Create the I2C interface
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# Create the LED bargraph class.
+bicolor = matrix.Matrix8x8x2(i2c)
+
+# color mapping shortcut
+OFF = 0
+GREEN = 1
+RED = 2
+YELLOW = 3
+
+# Set individual segments of the bicolor matrix
+# Illuminate the first three pixels
+bicolor[0,0] = GREEN
+bicolor[0,1] = RED
+bicolor[0,2] = YELLOW
+
+time.sleep(2)
+
+# Edges of an 8x8 matrix
+col_max = 8
+row_max = 8
+
+# Turn all pixels off
+bicolor.fill(OFF)
+col = 0
+row = 0
+
+# Illuminate each pixel with each color
+while row < row_max:
+
+    # Turn them on in a loop
+    while col < col_max:
+        bicolor[row, col] = RED
+        time.sleep(.25)
+        bicolor[row, col] = GREEN
+        time.sleep(.25)
+        bicolor[row, col] = YELLOW
+        time.sleep(.25)
+        col += 1
+
+    # next row when previous column is full
+    if row < row_max:
+        row += 1
+        col = 0
+
+    # clear matrix, start over
+    else:
+        row = col = 0
+        bicolor.fill(OFF)
+
+time.sleep(1)
+
+# Fill the entrire display, with each color
+bicolor.fill(GREEN)
+time.sleep(1)
+bicolor.fill(RED)
+time.sleep(1)
+bicolor.fill(YELLOW)
+time.sleep(1)
+bicolor.fill(OFF)


### PR DESCRIPTION
Merged code examples from original LED_Backpack and HT16K33. Deprecating LED Backpack Display on Raspberry Pi and BeagleBone Black guide in favor of Matrix and 7-Segement LED Backpack with the Raspberry Pi guide. 