### PR TITLE
revise PyPortal_Smart_Thermometer thermometer_helper.py 

### DIFF
--- a/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -141,4 +141,3 @@ class Thermometer_GFX(displayio.Group):
                                                    position=(0,0))
 
         self._icon_group.append(self._icon_sprite)
-

--- a/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -29,11 +29,9 @@ class Thermometer_GFX(displayio.Group):
 
         # create background icon group
         self._icon_group = displayio.Group(max_size=1)
-        self.append(self._icon_group)
         board.DISPLAY.show(self._icon_group)
         # create text object group
         self._text_group = displayio.Group(max_size=6)
-        self.append(self._text_group)
 
         self._icon_sprite = None
         self._icon_file = None
@@ -143,6 +141,4 @@ class Thermometer_GFX(displayio.Group):
                                                    position=(0,0))
 
         self._icon_group.append(self._icon_sprite)
-        board.DISPLAY.refresh_soon()
-        board.DISPLAY.wait_for_frame()
   

--- a/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -141,4 +141,4 @@ class Thermometer_GFX(displayio.Group):
                                                    position=(0,0))
 
         self._icon_group.append(self._icon_sprite)
-  
+


### PR DESCRIPTION
fixes #891 
remove unnecessary appends and calls to refresh_soon and wait_for_frame

tested on CP4.10. and CP5.0alpha-4
