### PR TITLE
Add Learn Guide version of updated BLE color picker

### DIFF
--- a/BLE_CPB_Color_Picker/ble_color_picker.py
+++ b/BLE_CPB_Color_Picker/ble_color_picker.py
@@ -1,0 +1,27 @@
+# CircuitPython NeoPixel Color Picker Example
+
+import board
+import neopixel
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
+from adafruit_bluefruit_connect.packet import Packet
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+ble = BLERadio()
+uart_service = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_service)
+
+pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, brightness=0.1)
+
+while True:
+    # Advertise when not connected.
+    ble.start_advertising(advertisement)
+    while not ble.connected:
+        pass
+
+    while ble.connected:
+        packet = Packet.from_stream(uart_service)
+        if isinstance(packet, ColorPacket):
+            print(packet.color)
+            pixels.fill(packet.color)


### PR DESCRIPTION
https://learn.adafruit.com/cpx-cauldron was pointing to the library example for a color picker. Copy that code to this repo and update it for CircuitPython 5.0.0-beta.0.

Tested on a CPB.