### PR TITLE
Print RFMx RuntimeError messages

### DIFF
--- a/pi_radio/rfm69_check.py
+++ b/pi_radio/rfm69_check.py
@@ -54,9 +54,10 @@ while True:
     try:
         rfm69 = adafruit_rfm69.RFM69(spi, CS, RESET, 915.0)
         display.text('RFM69: Detected', 0, 0, 1)
-    except RuntimeError:
+    except RuntimeError as error:
         # Thrown on version mismatch
         display.text('RFM69: ERROR', 0, 0, 1)
+        print('RFM69 Error: ', error)
 
     # Check buttons
     if not btnA.value:

--- a/pi_radio/rfm9x_check.py
+++ b/pi_radio/rfm9x_check.py
@@ -53,9 +53,10 @@ while True:
     try:
         rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, 915.0)
         display.text('RFM9x: Detected', 0, 0, 1)
-    except RuntimeError:
+    except RuntimeError as error:
         # Thrown on version mismatch
         display.text('RFM9x: ERROR', 0, 0, 1)
+        print('RFM9x Error: ', error)
 
     # Check buttons
     if not btnA.value:


### PR DESCRIPTION
Print error messages for RFM69/RFM9x test scripts to the terminal to help with debugging.

https://forums.adafruit.com/viewtopic.php?f=50&t=159573&p=785930#p785930