### PR TITLE
Updated for LSM6DSOX->LSM6DS rename

### DIFF
--- a/Jupyter_USB/LSM6DSOX_Accel.ipynb
+++ b/Jupyter_USB/LSM6DSOX_Accel.ipynb
@@ -16,7 +16,7 @@
    "source": [
     " # Python Software Package Installation\n",
     "import sys\n",
-    "!{sys.executable} -m pip install adafruit-circuitpython-lsm6dsox ipympl"
+    "!{sys.executable} -m pip install adafruit-circuitpython-lsm6ds ipympl"
    ]
   },
   {
@@ -47,10 +47,10 @@
     "# Import CircuitPython Libraries\n",
     "import board\n",
     "import busio\n",
-    "import adafruit_lsm6dsox\n",
+    "import adafruit_lsm6ds\n",
     "\n",
     "i2c = busio.I2C(board.SCL, board.SDA)\n",
-    "sox = adafruit_lsm6dsox.LSM6DSOX(i2c)\n",
+    "sox = adafruit_lsm6ds.LSM6DSOX(i2c)\n",
     "\n",
     "print(\"Acceleration: X:%.2f, Y: %.2f, Z: %.2f m/s^2\"%(sox.acceleration))"
    ]


### PR DESCRIPTION
Updated to reflect the name change of the LSM6DSOX library. Tested with a FT232H