### PR TITLE
use board.SPI() in circuitstonks demo

### DIFF
--- a/CircuitStonks/code.py
+++ b/CircuitStonks/code.py
@@ -1,6 +1,5 @@
 import time
 import board
-import busio
 from digitalio import DigitalInOut
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
@@ -22,7 +21,7 @@ except ImportError:
 esp32_cs = DigitalInOut(board.D13)
 esp32_ready = DigitalInOut(board.D11)
 esp32_reset = DigitalInOut(board.D12)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+spi = board.SPI()
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets)
 


### PR DESCRIPTION
I kept getting an ```SCK in use ``` error when using busio.SPI(.....)
this change makes it work for me.

Tested on feather_bluefruit_sense with airlift_featherwing and minitft_featherwing.
Same issue with feather_nrf52840_express.