### PR TITLE
RGBMatrix: fruit demo: fix ValueError exception

### DIFF
--- a/CircuitPython_RGBMatrix/fruit.py
+++ b/CircuitPython_RGBMatrix/fruit.py
@@ -36,7 +36,7 @@ class Wheel(displayio.TileGrid):
     def __init__(self):
         # Portions of up to 3 tiles are visible.
         super().__init__(bitmap=bitmap, pixel_shader=displayio.ColorConverter(),
-                         width=1, height=3, tile_width=20)
+                         width=1, height=3, tile_width=20, tile_height=24)
         self.order = shuffled(range(20))
         self.state = STOPPED
         self.pos = 0


### PR DESCRIPTION
The tile width setting was lost when I simplified the demo for inclusion in the guide.  Restore it.
