### PR TITLE
Fix import path in MiniMQTT examples

### DIFF
--- a/PyPortal_AWS_IOT_Planter/code.py
+++ b/PyPortal_AWS_IOT_Planter/code.py
@@ -15,7 +15,7 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_aws_iot import MQTT_CLIENT
 from adafruit_seesaw.seesaw import Seesaw
 import aws_gfx_helper

--- a/PyPortal_GCP_IOT_Planter/code.py
+++ b/PyPortal_GCP_IOT_Planter/code.py
@@ -15,7 +15,7 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_gc_iot_core import MQTT_API, Cloud_Core
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_seesaw.seesaw import Seesaw
 import digitalio
 

--- a/pyportal_pet_planter/code.py
+++ b/pyportal_pet_planter/code.py
@@ -11,7 +11,7 @@ import neopixel
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text.label import Label
 from adafruit_io.adafruit_io import IO_MQTT
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_pyportal import PyPortal
 from adafruit_seesaw.seesaw import Seesaw
 from simpleio import map_range


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/40

This pull request:
* Changes import statements in MiniMQTT code examples to reflect the library's modified path in release `3.1.0`
* Updated https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/1122, excluded from this PR