### PR TITLE
ulab: correct waterfall demo

### DIFF
--- a/ulab_Crunch_Numbers_Fast/waterfall.py
+++ b/ulab_Crunch_Numbers_Fast/waterfall.py
@@ -81,8 +81,8 @@ def main():
         # to change any zeros to nonzero numbers
         spectrogram1 = ulab.vector.log(spectrogram1 + 1e-7)
         spectrogram1 = spectrogram1[1:(fft_size//2)-1]
-        min_curr = ulab.numerical.min(spectrogram1)[0]
-        max_curr = ulab.numerical.max(spectrogram1)[0]
+        min_curr = ulab.numerical.min(spectrogram1)
+        max_curr = ulab.numerical.max(spectrogram1)
 
         if max_curr > max_all:
             max_all = max_curr


### PR DESCRIPTION
At one time, ulab's min and max had a bug where they returned an array with a single item inside.  This bug has been fixed (by 5.3.0 if not earlier) so remove the workaround.

Reported by @firepixie, thanks!