### PR TITLE
Create circuit_playground_bluefruit_sensornet.py

### DIFF
--- a/BLE_Sensornet/circuit_playground_bluefruit_sensornet.py
+++ b/BLE_Sensornet/circuit_playground_bluefruit_sensornet.py
@@ -1,0 +1,17 @@
+"""This uses the Circuit Playground Bluefruit as a Bluetooth LE sensor node."""
+
+import time
+from adafruit_circuitplayground import cp
+import adafruit_ble_broadcastnet
+
+print("This is BroadcastNet Circuit Playground Bluefruit sensor:", adafruit_ble_broadcastnet.device_address)
+
+while True:
+    measurement = adafruit_ble_broadcastnet.AdafruitSensorMeasurement()
+    measurement.light = cp.light
+    measurement.temperature = cp.temperature
+    measurement.acceleration = cp.acceleration
+
+    print(measurement)
+    adafruit_ble_broadcastnet.broadcast(measurement)
+    time.sleep(60)


### PR DESCRIPTION
This could be an addition to this guide: https://learn.adafruit.com/bluetooth-le-broadcastnet-sensor-node-raspberry-pi-wifi-bridge

It is "untested" (the code works on the CPB, but I have not configured my Pi yet).

One limitation is that the circuitplayground library has a sound_level propertie, but I did not find a matching propertie in the broadcastnet library.