### PR TITLE
Add MP3 code sample to Essentials guide

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_Audio_Out_MP3.py
+++ b/CircuitPython_Essentials/CircuitPython_Audio_Out_MP3.py
@@ -1,0 +1,39 @@
+import board
+import digitalio
+
+from audiomp3 import MP3Decoder
+
+try:
+    from audioio import AudioOut
+except ImportError:
+    try:
+        from audiopwmio import PWMAudioOut as AudioOut
+    except ImportError:
+        pass  # not always supported by every board!
+
+button = digitalio.DigitalInOut(board.A1)
+button.switch_to_input(pull=digitalio.Pull.UP)
+
+# The listed mp3files will be played in order
+mp3files = ["begins.mp3", "xfiles.mp3"]
+
+# You have to specify some mp3 file when creating the decoder
+mp3 = open(mp3files[0], "rb")
+decoder = MP3Decoder(mp3)
+audio = AudioOut(board.A0)
+
+while True:
+    for filename in mp3files:
+        # Updating the .file property of the existing decoder
+        # helps avoid running out of memory (MemoryError exception)
+        decoder.file = open(filename, "rb")
+        audio.play(decoder)
+        print("playing", filename)
+
+        # This allows you to do other things while the audio plays!
+        while audio.playing:
+            pass
+
+        print("Waiting for button press to continue!")
+        while button.value:
+            pass


### PR DESCRIPTION
A new page in the CircuitPython Essentials guide will explain how to use MP3 playback on supported devices.  This is the code sample/example.