### PR TITLE
Change CircuitPython Essentials examples to use board.I2C()

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_I2C_Scan.py
+++ b/CircuitPython_Essentials/CircuitPython_I2C_Scan.py
@@ -3,9 +3,8 @@
 import time
 
 import board
-import busio
 
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = board.I2C()
 
 while not i2c.try_lock():
     pass

--- a/CircuitPython_Essentials/CircuitPython_I2C_TSL2561.py
+++ b/CircuitPython_Essentials/CircuitPython_I2C_TSL2561.py
@@ -4,9 +4,8 @@ import time
 
 import adafruit_tsl2561
 import board
-import busio
 
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = board.I2C()
 
 # Lock the I2C device before we try to scan
 while not i2c.try_lock():


### PR DESCRIPTION
A user in discord was confused by this example code vs some newer code that used `board.I2C()`. Change the simple examples to use `board.I2C()`. Once this is changed the page text will be updated.