### PR TITLE
Change chip select pin to D6 to match other samples

### DIFF
--- a/CircuitPython_SharpDisplay_Displayio/code.py
+++ b/CircuitPython_SharpDisplay_Displayio/code.py
@@ -153,7 +153,7 @@ def sample(population, k):
 # if necessary
 displayio.release_displays()
 bus = board.SPI()
-framebuffer = sharpdisplay.SharpMemoryFramebuffer(bus, board.D2, 400, 240)
+framebuffer = sharpdisplay.SharpMemoryFramebuffer(bus, board.D6, 400, 240)
 display = framebufferio.FramebufferDisplay(framebuffer, auto_refresh = True)
 
 # Load our font


### PR DESCRIPTION
The other sample code snippets use D6, so this code should too even if I was testing with D2 on a Particle Xenon.