### PR TITLE
SharpDisplay demo: Always use anchor_point/anchored_position

### DIFF
--- a/CircuitPython_SharpDisplay_Displayio/code.py
+++ b/CircuitPython_SharpDisplay_Displayio/code.py
@@ -166,9 +166,9 @@ display.show(blm_group)
 # Create a 3 line set of text for BLM
 blm_font = [None, None, None]
 for line in range(3):
-    label = adafruit_display_text.label.Label(
-        font, color=0xFFFFFF, x=8, y=line * 84+12, max_glyphs=16,
-    )
+    label = adafruit_display_text.label.Label(font, color=0xFFFFFF, max_glyphs=16)
+    label.anchor_point = (0, 0)
+    label.anchored_position = (8, line*84+8)
     blm_font[line] = label
     blm_group.append(label)
 


### PR DESCRIPTION
Between adafruit_display_text release 2.8.0 on July 24 and the current version, the behavior of specifying just x/y changed.  The same code works with both versions if anchor_point / anchored_position is specified, so go with that even though it's a bit more verbose