### PR TITLE
Fixed rotation for real eInk bonnet

### DIFF
--- a/EInk_Bonnet_Event_Calendar/event_calendar.py
+++ b/EInk_Bonnet_Event_Calendar/event_calendar.py
@@ -38,7 +38,7 @@ display = Adafruit_SSD1675(
     122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
 )
 
-display.rotation = 3
+display.rotation = 1
 
 # RGB Colors
 WHITE = (255, 255, 255)

--- a/EInk_Bonnet_Weather_Station/weather.py
+++ b/EInk_Bonnet_Weather_Station/weather.py
@@ -41,7 +41,7 @@ display = Adafruit_SSD1675(
     122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
 )
 
-display.rotation = 3
+display.rotation = 1
 
 gfx = Weather_Graphics(display, am_pm=True, celsius=False)
 weather_refresh = None


### PR DESCRIPTION
After trying out the examples on the real eInk bonnet, I think these should be changed.