### PR TITLE
neopixel gemma torch code

### DIFF
--- a/NeoPixel_Gemma_Torch/code.py
+++ b/NeoPixel_Gemma_Torch/code.py
@@ -1,0 +1,25 @@
+import board
+import neopixel
+import adafruit_dotstar
+
+LED = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1) #Setup Internal Dotar
+LED.brightness = 0.8 #DotStar brightness
+
+NUMPIX = 7        # Number of NeoPixels
+PIXPIN = board.D2  # Pin where NeoPixels are connected
+PIXELS = neopixel.NeoPixel(PIXPIN, NUMPIX) # NeoPixel object setup
+
+RED = 7 #Number of pixels to be red
+BLUE = 0 #First pixel
+
+while True:  # Loop forever...
+    #Make the internal dotstar light up.
+    LED[0] = (100, 0, 255)
+
+    #Select these pixels starting with the second pixel.
+    for i in range(1, RED):
+        # Make the pixels red
+        PIXELS[i] = (100, 0, 0)
+
+    #Make the first neopixel this color
+    PIXELS[BLUE] = (0, 0, 100)


### PR DESCRIPTION
adding neopixel gemma torch code. Ran pylint on code.py using following version:

pylint 2.4.3
astroid 2.3.2
Python 3.7.4

************* Module code
code.py:1:0: C0114: Missing module docstring (missing-module-docstring)
code.py:1:0: E0401: Unable to import 'board' (import-error)
code.py:2:0: E0401: Unable to import 'neopixel' (import-error)
code.py:3:0: E0401: Unable to import 'adafruit_dotstar' (import-error)

--------------------------------------------------------------------
Your code has been rated at -0.67/10 (previous run: -0.67/10, +0.00) 

Safe to ignoring the rating since they're just import errors?