### PR TITLE
Fix CI for nrf52832/cpb

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Setup Python
-    - uses: actions/setup-python@v2
+      uses: actions/setup-python@v2
       with:
         # 3.9 has issue with intelhex https://github.com/python-intelhex/intelhex/issues/45
         python-version: '3.8'

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/setup-python@v1
+    - name: Setup Python
+    - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        # 3.9 has issue with intelhex https://github.com/python-intelhex/intelhex/issues/45
+        python-version: '3.8'
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v1
       with:
-        # 3.9 has issue with intelhex https://github.com/python-intelhex/intelhex/issues/45
-        python-version: '3.8'
+        python-version: '3.x'
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Python 3.9 has issue with intelhex, https://github.com/python-intelhex/intelhex/issues/45.

While waiting for Intellihex, CI script updated to match https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/171

Affected PR's, will need to re-run after this is approved and merged in: https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/1268