### PR TITLE
Update payload variable in send function

### DIFF
--- a/lorawan_sensing_network/lora_device.py
+++ b/lorawan_sensing_network/lora_device.py
@@ -80,10 +80,10 @@ while True:
     # Send the packet data
     print('Sending data...')
     LED.value = True
-    rfm9x.send(bme280_data)
+    rfm9x.send(bme280_data_bytes)
     print('Sent data!')
     LED.value = False
 
     # Wait to send the packet again
     time.sleep(SENSOR_SEND_DELAY * 60)
-  
+


### PR DESCRIPTION
**What Changed**
This change simply changes the payload in `rfm9x.send()` to the expected argument, `bme280_data_bytes`. @brentru 
This fixes #1281 
**Tests**
No matching test suites were found, but I did look at the source code and noticed that it is, in fact, expecting some bytes. See [here](https://github.com/adafruit/Adafruit_CircuitPython_RFM9x/blob/6590c91a9146f41a7984a52febce9b21d0df8748/adafruit_rfm9x.py#L599)