### PR TITLE
Update Air Quality Sensor to support pmsa003l and BME680

### DIFF
--- a/Adafruit_IO_Air_Quality/code.py
+++ b/Adafruit_IO_Air_Quality/code.py
@@ -15,7 +15,6 @@ USE_CELSIUS = False
 # Interval the sensor publishes to Adafruit IO, in minutes
 PUBLISH_INTERVAL = 10
 
-
 ### WiFi ###
 
 # Get wifi details and more from a secrets.py file
@@ -34,7 +33,6 @@ spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
 
 # Connect to a PM2.5 sensor over UART
 reset_pin = None
@@ -122,9 +120,9 @@ def sample_aq_sensor():
     return aq_reading
 
 
-def read_bme280(is_celsius=False):
+def read_bme(is_celsius=False):
     """Returns temperature and humidity
-    from BME280 environmental sensor, as a tuple.
+    from BME280/BME680 environmental sensor, as a tuple.
 
     :param bool is_celsius: Returns temperature in degrees celsius
                             if True, otherwise fahrenheit.
@@ -179,7 +177,7 @@ while True:
 
         # temp and humidity
         print("Sampling environmental sensor...")
-        temperature, humidity = read_bme280(USE_CELSIUS)
+        temperature, humidity = read_bme(USE_CELSIUS)
         print("Temperature: %0.1f F" % temperature)
         print("Humidity: %0.1f %%" % humidity)
 

--- a/Adafruit_IO_Air_Quality/code.py
+++ b/Adafruit_IO_Air_Quality/code.py
@@ -6,15 +6,16 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 from adafruit_io.adafruit_io import IO_HTTP
 from simpleio import map_range
-
 import adafruit_pm25
-import adafruit_bme280
 
 ### Configure Sensor ###
-# Return BME280 environmental sensor readings in degrees Celsius
+# Return environmental sensor readings in degrees Celsius
 USE_CELSIUS = False
 # Interval the sensor publishes to Adafruit IO, in minutes
 PUBLISH_INTERVAL = 10
+
+# Set this to True if you are using a PMSA003I breakout, False otherwise
+USE_PMSA003I = False
 
 ### WiFi ###
 
@@ -35,13 +36,23 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
-# Connect to a PM2.5 sensor over UART
-uart = busio.UART(board.TX, board.RX, baudrate=9600)
-pm25 = adafruit_pm25.PM25_UART(uart)
 
-# Connect to a BME280 sensor over I2C
-i2c = busio.I2C(board.SCL, board.SDA)
-bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+# Create i2c object, use 'slow' 100KHz frequency!
+i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
+reset_pin = None
+if USE_PMSA003I:
+    import adafruit_bme680
+    # Connect to a PM2.5 sensor over I2C
+    pm25 = adafruit_pm25.PM25_I2C(i2c, reset_pin)
+    # Connect to a BME680 sensor over I2C
+    bme_sensor = adafruit_bme680.Adafruit_BME680_I2C(i2c)
+else:
+    import adafruit_bme280
+    # Connect to a PM2.5 sensor over UART
+    uart = busio.UART(board.TX, board.RX, baudrate=9600)
+    pm25 = adafruit_pm25.PM25_UART(uart, reset_pin)
+    # Connect to a BME280 sensor over I2C
+    bme_sensor = adafruit_bme280.Adafruit_BME280_I2C(i2c)
 
 ### Sensor Functions ###
 def calculate_aqi(pm_sensor_reading):
@@ -118,11 +129,11 @@ def read_bme280(is_celsius=False):
     :param bool is_celsius: Returns temperature in degrees celsius
                             if True, otherwise fahrenheit.
     """
-    humid = bme280.humidity
-    temp = bme280.temperature
+    humid = bme_sensor.humidity
+    temp = bme_sensor.temperature
     if not is_celsius:
         temp = temp * 1.8 + 32
-    return temperature, humid
+    return temp, humid
 
 
 # Create an instance of the Adafruit IO HTTP client

--- a/Adafruit_IO_Air_Quality/code.py
+++ b/Adafruit_IO_Air_Quality/code.py
@@ -7,6 +7,7 @@ from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 from adafruit_io.adafruit_io import IO_HTTP
 from simpleio import map_range
 import adafruit_pm25
+import adafruit_bme280
 
 ### Configure Sensor ###
 # Return environmental sensor readings in degrees Celsius
@@ -14,8 +15,6 @@ USE_CELSIUS = False
 # Interval the sensor publishes to Adafruit IO, in minutes
 PUBLISH_INTERVAL = 10
 
-# Set this to True if you are using a PMSA003I breakout, False otherwise
-USE_PMSA003I = False
 
 ### WiFi ###
 
@@ -37,22 +36,23 @@ status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 
-# Create i2c object, use 'slow' 100KHz frequency!
-i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
+# Connect to a PM2.5 sensor over UART
 reset_pin = None
-if USE_PMSA003I:
-    import adafruit_bme680
-    # Connect to a PM2.5 sensor over I2C
-    pm25 = adafruit_pm25.PM25_I2C(i2c, reset_pin)
-    # Connect to a BME680 sensor over I2C
-    bme_sensor = adafruit_bme680.Adafruit_BME680_I2C(i2c)
-else:
-    import adafruit_bme280
-    # Connect to a PM2.5 sensor over UART
-    uart = busio.UART(board.TX, board.RX, baudrate=9600)
-    pm25 = adafruit_pm25.PM25_UART(uart, reset_pin)
-    # Connect to a BME280 sensor over I2C
-    bme_sensor = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+uart = busio.UART(board.TX, board.RX, baudrate=9600)
+pm25 = adafruit_pm25.PM25_UART(uart, reset_pin)
+
+# Create i2c object
+i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
+
+# Connect to a BME280 over I2C
+bme_sensor = adafruit_bme280.Adafruit_BME280_I2C(i2c)
+
+# Uncomment below for PMSA003I Air Quality Breakout
+# pm25 = adafruit_pm25.PM25_I2C(i2c, reset_pin)
+
+# Uncomment below for BME680
+# import adafruit_bme680
+# bme_sensor = adafruit_bme680.Adafruit_BME680_I2C(i2c)
 
 ### Sensor Functions ###
 def calculate_aqi(pm_sensor_reading):


### PR DESCRIPTION
Adding optional initialization for an alternate build using the pmsa003l and bme680.

Generalizes language/methods for BME sensors types.

Fixes incorrect value being returned by `read_bme`


Tested on:
Feather M4 + AirLift Featherwing + BME280 + PMS5003
and
Feather M4 + AirLift Featherwing + BME680 + pmsa003l