### PR TITLE
Cleaning up a few things in the WiFi test example

### DIFF
--- a/ESP32_S2_WiFi_Tests/code.py
+++ b/ESP32_S2_WiFi_Tests/code.py
@@ -20,7 +20,7 @@ print("ESP32-S2 WebClient Test")
 
 print("My MAC addr:", [hex(i) for i in wifi.radio.mac_address])
 
-print("Avaliable WiFi networks:")
+print("Available WiFi networks:")
 for network in wifi.radio.start_scanning_networks():
     print("\t%s\t\tRSSI: %d\tChannel: %d" % (str(network.ssid, "utf-8"),
             network.rssi, network.channel))
@@ -28,7 +28,7 @@ wifi.radio.stop_scanning_networks()
 
 print("Connecting to %s"%secrets["ssid"])
 wifi.radio.connect(secrets["ssid"], secrets["password"])
-print(print("Connected to %s!"%secrets["ssid"]))
+print("Connected to %s!"%secrets["ssid"])
 print("My IP address is", wifi.radio.ipv4_address)
 
 ipv4 = ipaddress.ip_address("8.8.4.4")


### PR DESCRIPTION
Fixed up a few visual things I noticed while playing around with the WiFi examples on my UnexpectedMaker FeatherS2 board.

Just a typo for "Available" and a double-wrapped `print()` statement that caused the terminal to print the text as well as a line just containing `None`.