### PR TITLE
Fix a minor typo in the documentation

### DIFF
--- a/Stream_Deck_Message_Panel/MessagePanel/MessagePanel.ino
+++ b/Stream_Deck_Message_Panel/MessagePanel/MessagePanel.ino
@@ -17,7 +17,7 @@
 // Pin A4 works on the Adafruit Metro M4 (if using the Adafruit RGB
 // Matrix Shield, cut trace between CLK pads and run a wire to A4).
 
-//#define CLK  8   // USE THIS ON ADAFRUIT METRO M0 ir adapting to use Airlift, etc.
+//#define CLK  8   // USE THIS ON ADAFRUIT METRO M0 or adapting to use Airlift, etc.
 #define CLK A4 // USE THIS ON METRO M4 (not M0)
 #define OE   9
 #define LAT 10


### PR DESCRIPTION
- This commit corrects a comment the author explaining if they want to use the Metro Airlift M0 or M4, and so forth.

- There aren't breaking changes in this pull request. It just corrects a typo in the spelling.

- Tests should correctly pass because of a minor correction in the comments of the file in question.
