### PR TITLE
Minor formatting change in stats.py

### DIFF
--- a/Pi_Hole_Ad_Blocker/stats.py
+++ b/Pi_Hole_Ad_Blocker/stats.py
@@ -114,7 +114,7 @@ while True:
         continue
 
     draw.text((x, top), "IP: " + str(IP) +
-              "( " + HOST + ")", font=font, fill=255)
+              " (" + HOST + ")", font=font, fill=255)
     draw.text((x, top + 8), "Ads Blocked: " +
               str(ADSBLOCKED), font=font, fill=255)
     draw.text((x, top + 16), "Clients:     " +


### PR DESCRIPTION
Space after IP, before parenthesis looks more correct.

Before:

```
192.168.1.2( pi-hole)
```

After:

```
192.168.1.2 (pi-hole)
```