### PR TITLE
Include the 100/400 year check for leap years in MagTag Year Progress demo

### DIFF
--- a/MagTag_Progress_Displays/year_progress_percent.py
+++ b/MagTag_Progress_Displays/year_progress_percent.py
@@ -14,7 +14,7 @@ import rtc
 
 def days_in_year(date_obj):
     # check for leap year
-    if date_obj.tm_year % 4 == 0:
+    if (date_obj.tm_year % 100 != 0 or date_obj.tm_year % 400 == 0) and date_obj.tm_year % 4 == 0:
         return 366
     return 365
 


### PR DESCRIPTION
I noticed the example code in the MagTag Year Progress demo uses an incorrect check for leap years. I for one hope both Adafruit and my MagTag are still working in the year 2100, so let's fix the check to account for years that are multiples of 100 and/or 400. 

I chose the order of the conditional checks based on the discussion in the the Answer 12 comment here: https://www.mmbyte.com/article/8959.html . 