### PR TITLE
Bugfix: Typo in months for `magtag_weather.py`

### DIFF
--- a/MagTag_Weather/magtag_weather.py
+++ b/MagTag_Weather/magtag_weather.py
@@ -26,7 +26,7 @@ MONTHS = (
     "May",
     "June",
     "July",
-    "Augsut",
+    "August",
     "September",
     "October",
     "November",


### PR DESCRIPTION
Minor typo in the `MONTHS` tuple element for August. 