### PR TITLE
Add blink for QT Py.

### DIFF
--- a/Welcome_to_CircuitPython/QT_Py_blink.py
+++ b/Welcome_to_CircuitPython/QT_Py_blink.py
@@ -1,0 +1,21 @@
+"""
+Blink example for QT Py using onboard NeoPixel.
+
+Requires two libraries from the Adafruit CircuitPython Library Bundle. Download the bundle
+from circuitpython.org/libraries and copy the following files to your CIRCUITPY/lib folder:
+* neopixel.mpy
+* adafruit_pypixelbuf.mpy
+
+Once the libraries are copied, save this file as code.py to your CIRCUITPY drive to run it.
+"""
+import time
+import board
+import neopixel
+
+pixels = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+while True:
+    pixels.fill((255, 0, 0))
+    time.sleep(0.5)
+    pixels.fill((0, 0, 0))
+    time.sleep(0.5)


### PR DESCRIPTION
Significant amount of feedback on the QT Py guide about the blink example not working on QT Py, and requests to resolve it. As this is a due to a hardware limitation, there is no easy resolution to using the exact blink code in the Welcome guide on QT Py. I intend to link to this example on the Creating and Editing Code page of the Welcome to CircuitPython guide, and indicate if you're using QT Py, you can use this example to follow along instead (as the changes suggested are to the `time.sleep()` which is present in both).