### PR TITLE
EZ Make cal: Add message upon sensor connection failure.

### DIFF
--- a/PyPortal_EZ_Make_Oven/codecalibrate.py
+++ b/PyPortal_EZ_Make_Oven/codecalibrate.py
@@ -2,12 +2,18 @@ import time
 import board
 import busio
 import digitalio
+import sys
 from adafruit_mcp9600 import MCP9600
 
 SENSOR_ADDR = 0X67
 
 i2c = busio.I2C(board.SCL, board.SDA,frequency=200000)
-sensor = MCP9600(i2c,SENSOR_ADDR,"K")
+try:
+    sensor = MCP9600(i2c,SENSOR_ADDR,"K")
+except ValueError as e:
+    print(e)
+    print("Unable to connect to the thermocouple sensor.")
+    sys.exit(1)
 
 oven = digitalio.DigitalInOut(board.D4)
 oven.direction = digitalio.Direction.OUTPUT


### PR DESCRIPTION
Display the following error message if codecalibrate.py
is unable to communicate with the thermocouple amplifier:

    No I2C device at address: 0x67
    Unable to connect to the thermocouple sensor.

This replaces the standard standard exception stack trace
containing the following message:

    ValueError: No I2C device at address: 0x67

Adding the sensor name and eliminating the stack detail should
aid troubleshooting.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
