### PR TITLE
EZ Make: Fixed _speaker_enable.

### DIFF
--- a/PyPortal_EZ_Make_Oven/code.py
+++ b/PyPortal_EZ_Make_Oven/code.py
@@ -89,7 +89,7 @@ class Beep(object):
     def play(self, duration=0.1):
         if not pyportal.peripherals._speaker_enable.value:
             pyportal.peripherals._speaker_enable.value = True
-            pyportal.audio.play(self.sine_wave_sample, loop=True)
+            pyportal.peripherals.audio.play(self.sine_wave_sample, loop=True)
             self.start = time.monotonic()
             self.duration = duration
             if duration <= .5:
@@ -101,7 +101,7 @@ class Beep(object):
     def stop(self):
         if pyportal.peripherals._speaker_enable.value:
             self.duration = 0
-            pyportal.audio.stop()
+            pyportal.peripherals.audio.stop()
             pyportal.peripherals._speaker_enable.value = False
 
     def refresh(self):

--- a/PyPortal_EZ_Make_Oven/code.py
+++ b/PyPortal_EZ_Make_Oven/code.py
@@ -87,8 +87,8 @@ class Beep(object):
 
     # pylint: disable=protected-access
     def play(self, duration=0.1):
-        if not pyportal._speaker_enable.value:
-            pyportal._speaker_enable.value = True
+        if not pyportal.peripherals._speaker_enable.value:
+            pyportal.peripherals._speaker_enable.value = True
             pyportal.audio.play(self.sine_wave_sample, loop=True)
             self.start = time.monotonic()
             self.duration = duration
@@ -99,10 +99,10 @@ class Beep(object):
                 self.stop()
 
     def stop(self):
-        if pyportal._speaker_enable.value:
+        if pyportal.peripherals._speaker_enable.value:
             self.duration = 0
             pyportal.audio.stop()
-            pyportal._speaker_enable.value = False
+            pyportal.peripherals._speaker_enable.value = False
 
     def refresh(self):
         if time.monotonic() - self.start >= self.duration:


### PR DESCRIPTION
Fix exception when attempting to access a missing attribute.

The attribute used to be at PyPortal._speaker_enable, but is now
PyPortal.peripherals._speaker_enable.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
