### PR TITLE
Adding shorter boot.py

### DIFF
--- a/Getting_Started_With_Raspberry_Pi_Pico/data_logger_no_ground_wire_boot.py
+++ b/Getting_Started_With_Raspberry_Pi_Pico/data_logger_no_ground_wire_boot.py
@@ -1,0 +1,7 @@
+"""
+boot.py file for Pico data logging example. If this file is present when
+the pico starts up, make the filesystem writeable by CircuitPython.
+"""
+import storage
+
+storage.remount("/", readonly=False)


### PR DESCRIPTION
Added section at the end that covers removing/renaming boot.py from the REPL to allow for data logging without a ground wire.