### PR TITLE
workflows: Use 18.04 for arduino-ci

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arduino-platform: ["uno", "nrf52832", "cpx_ada", "pyportal", "protrinket_3v", "protrinket_5v", "metro_m0", "esp8266", "esp32", "trinket_3v", "trinket_5v", "gemma", "flora", "feather32u4", "feather_m0_express", "gemma_m0", "trinket_m0", "hallowing_m0", "monster_m4sk", "hallowing_m4", "neotrellis_m4", "pybadge", "cpb", "cpc"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/setup-python@v2


### PR DESCRIPTION
The workflow doesn't ask for a specific version of Ubuntu, but when it gets 20.04, ci-arduino causes a failure because it requests installation of a specific version of llvm that is not available in 20.04:
```
E: Version '1:8-3~ubuntu18.04.2' for 'libllvm8' was not found
```

We should decide between this and actually fixing arduino-ci.