### PR TITLE
Remove the dependency on PyPortal in the PyPortal_EZ_Make_Oven learn …

### DIFF
--- a/PyPortal_EZ_Make_Oven/code.py
+++ b/PyPortal_EZ_Make_Oven/code.py
@@ -17,7 +17,7 @@ import adafruit_touchscreen
 from adafruit_mcp9600 import MCP9600
 
 TITLE = "EZ Make Oven Controller"
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 print(TITLE, "version ", VERSION)
 time.sleep(2)


### PR DESCRIPTION
Inspired by @foamyguy 's Friday stream and the suggestions made in chat, I've removed the dependency on PyPortal as only some audio code was being used. This code has been copied into the Beep class.

Tested on a PyPortal Pynt

Before:

Screen size: 320x240
Mem before imports: 185312
Mem after imports: 61408
WxH: 320x240
Mem after gc before main loop: 18672

Screen size: 400x300
Mem before imports: 185280
Mem after imports: 60448
WxH: 400x300
Mem after gc before main loop: 9872
Traceback (most recent call last):
  File "<stdin>", line 649, in <module>
  File "/lib/adafruit_display_text/__init__.py", line 379, in text
  File "/lib/adafruit_display_text/bitmap_label.py", line 561, in _set_text
  File "/lib/adafruit_display_text/bitmap_label.py", line 237, in _reset_text
MemoryError: memory allocation failed, allocating 616 bytes

After:

Screen size: 320x240
Mem before imports: 184896
Mem after imports: 142528
WxH: 320x240
Mem after gc before main loop: 103808

Screen size: 400x300
Mem before imports: 184896
Mem after imports: 142528
WxH: 400x300
Mem after gc before main loop: 96048

Screen size: 800x600
Mem before imports: 184896
Mem after imports: 142528
WxH: 800x600
Mem after gc before main loop: 21248
