### PR TITLE
increased max_glyphs to 9 for time_text

### DIFF
--- a/PyPortal_OpenWeather/openweather_graphics.py
+++ b/PyPortal_OpenWeather/openweather_graphics.py
@@ -36,7 +36,7 @@ class OpenWeather_Graphics(displayio.Group):
         self.large_font.load_glyphs(('°',))  # a non-ascii character we need for sure
         self.city_text = None
 
-        self.time_text = Label(self.medium_font, max_glyphs=8)
+        self.time_text = Label(self.medium_font, max_glyphs=9)
         self.time_text.x = 200
         self.time_text.y = 12
         self.time_text.color = 0xFFFFFF


### PR DESCRIPTION
based on guide feedback, increased number of max_glyphs to 9 for time_text 

> When creating the time label the max_glyphs is set to 8. When the time went from 9:59 AM to 10:00 AM, the code threw a warning not enough glyph space for text. After rebooting, the M was loft off time and lower labels did not display. Changing max_glyphs = 9 fixed the problem.