### PR TITLE
Correct 30 minute calculation in MOON PHASE CLOCK

### DIFF
--- a/Matrix_Portal_Moon_Clock/code.py
+++ b/Matrix_Portal_Moon_Clock/code.py
@@ -290,7 +290,7 @@ while True:
             # respond. That's OK, keep running with our current time, and
             # push sync time ahead to retry in 30 minutes (don't overwhelm
             # the server with repeated queries).
-            LAST_SYNC += 30 * 60 * 60 # 30 minutes -> seconds
+            LAST_SYNC += 30 * 60 # 30 minutes -> seconds
 
     # If PERIOD has expired, move data down and fetch new +24-hour data
     if NOW >= PERIOD[1].midnight:


### PR DESCRIPTION
Based on Line 283, the LAST_SYNC is in seconds, which means the exception case currently represents 30 hours, not 30 minutes, as the comment indicates it should.