### PR TITLE
Adding static single-pixel example.

### DIFF
--- a/CircuitPython_Templates/neopixel_blink_one_pixel.py
+++ b/CircuitPython_Templates/neopixel_blink_one_pixel.py
@@ -1,0 +1,12 @@
+"""CircuitPython blink example for built-in NeoPixel LED"""
+import time
+import board
+import neopixel
+
+pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+while True:
+    pixel.fill((255, 0, 0))
+    time.sleep(0.5)
+    pixel.fill((0, 0, 0))
+    time.sleep(0.5)


### PR DESCRIPTION
Multi-pixel boards have their own template, so this can be included in the single-pixel template.