### PR TITLE
update progress bar imports

### DIFF
--- a/CircuitPython_JEplayer_mp3/code.py
+++ b/CircuitPython_JEplayer_mp3/code.py
@@ -34,7 +34,7 @@ import time
 
 import adafruit_bitmap_font.bitmap_font
 import adafruit_display_text.label
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 import adafruit_sdcard
 import analogjoy
 import audioio

--- a/Clue_Step_Counter/clue_step_counter.py
+++ b/Clue_Step_Counter/clue_step_counter.py
@@ -6,7 +6,7 @@ from simpleio import map_range
 from adafruit_bitmap_font import bitmap_font
 from adafruit_lsm6ds.lsm6ds33 import LSM6DS33
 from adafruit_lsm6ds import Rate, AccelRange
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 from adafruit_display_text.label import Label
 
 #  turns off onboard NeoPixel to conserve battery

--- a/MagTag_Covid_Vaccination/code.py
+++ b/MagTag_Covid_Vaccination/code.py
@@ -1,5 +1,5 @@
 from adafruit_magtag.magtag import MagTag
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 
 # Set up where we'll be fetching data from
 DATA_SOURCE = "https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/country_data/United%20States.csv"

--- a/MagTag_Progress_Displays/weblate_translated_percent.py
+++ b/MagTag_Progress_Displays/weblate_translated_percent.py
@@ -11,7 +11,7 @@ into fonts/ on your CIRCUITPY drive.
 """
 import time
 from adafruit_magtag.magtag import MagTag
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 
 # Set up where we'll be fetching data from
 DATA_SOURCE = "https://hosted.weblate.org/api/projects/circuitpython/statistics/"

--- a/MagTag_Progress_Displays/year_progress_percent.py
+++ b/MagTag_Progress_Displays/year_progress_percent.py
@@ -9,7 +9,7 @@ Copy epilogue18.bdf into fonts/ on your CIRCUITPY drive.
 """
 import time
 from adafruit_magtag.magtag import MagTag
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 import rtc
 
 def days_in_year(date_obj):

--- a/PyPortal_TOTP_Friend/code.py
+++ b/PyPortal_TOTP_Friend/code.py
@@ -9,7 +9,7 @@ from simpleio import map_range
 import adafruit_hashlib as hashlib
 import adafruit_touchscreen
 from adafruit_button import Button
-from adafruit_progressbar import ProgressBar
+from adafruit_progressbar.progressbar import ProgressBar
 from adafruit_display_text.label import Label
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_ntp import NTP


### PR DESCRIPTION
This updates the progressbar imports to the new syntax. 

These changes go along with this PR: https://github.com/adafruit/Adafruit_CircuitPython_ProgressBar/pull/25