### PR TITLE
Remove UTF-8 "byte order mark" from Python files

### DIFF
--- a/CircuitPython_Made_Easy_On_CPX/cpx_buttons_1_neopixel.py
+++ b/CircuitPython_Made_Easy_On_CPX/cpx_buttons_1_neopixel.py
@@ -1,4 +1,4 @@
-﻿from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground.express import cpx
 
 cpx.pixels.brightness = 0.3
 

--- a/CircuitPython_Made_Easy_On_CPX/cpx_buttons_neopixels.py
+++ b/CircuitPython_Made_Easy_On_CPX/cpx_buttons_neopixels.py
@@ -1,4 +1,4 @@
-﻿from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground.express import cpx
 
 cpx.pixels.brightness = 0.3
 

--- a/CircuitPython_Made_Easy_On_CPX/cpx_temperture_plotter.py
+++ b/CircuitPython_Made_Easy_On_CPX/cpx_temperture_plotter.py
@@ -1,4 +1,4 @@
-﻿import time
+import time
 from adafruit_circuitplayground.express import cpx
 
 while True:

--- a/Sensor_Plotting_With_Mu_CircuitPython/audio.py
+++ b/Sensor_Plotting_With_Mu_CircuitPython/audio.py
@@ -1,4 +1,4 @@
-﻿import array
+import array
 import math
 import time
 

--- a/Sensor_Plotting_With_Mu_CircuitPython/color.py
+++ b/Sensor_Plotting_With_Mu_CircuitPython/color.py
@@ -1,4 +1,4 @@
-﻿import analogio
+import analogio
 import board
 import neopixel
 

--- a/Sensor_Plotting_With_Mu_CircuitPython/temperature.py
+++ b/Sensor_Plotting_With_Mu_CircuitPython/temperature.py
@@ -1,4 +1,4 @@
-﻿import time
+import time
 
 import adafruit_thermistor
 import board


### PR DESCRIPTION
These confuse CircuitPython_Library_Screenshot_Maker.

The diff may not show usefully on github, but the byte sequence `b"\xef\xbb\xbf"` is removed from the beginning of each file.

Standard Python, and probably CircuitPython, is not affected by this, but `findimports` does not know how to handle it.

