### PR TITLE
Add a workflow to generate folder images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,52 @@
+name: Generate folder images
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+concurrency:
+  group: folder-images
+  cancel-in-progress: true
+
+jobs:
+  update-images:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
+    - uses: actions/checkout@v2.2.0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Checkout screenshot maker
+      run: git clone --depth=1 https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker
+
+    - name: Install dependencies
+      run: pip install -r CircuitPython_Library_Screenshot_Maker/requirements.txt
+
+    - name: Generate images
+      run: |
+        cd CircuitPython_Library_Screenshot_Maker
+        env LEARN_GUIDE_REPO=../ python3 ./create_requirement_images.py
+
+    - name: Commit updates
+      run: |
+        cd CircuitPython_Library_Screenshot_Maker/generated_images
+        git config --global user.name "${GITHUB_ACTOR} (github actions cron)"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git config --global init.defaultBranch main
+        git init
+        for i in *.png; do echo "<a href=\"$i\">$i</a><br>"; done > index.html
+        git add *.png index.html
+        git remote add origin https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        if git commit -m"update images"; then git push -f origin HEAD:folder-images; fi
+


### PR DESCRIPTION
This workflow will generate a bunch of images and place them on a branch called "folder-images", which (once enabled via github pages) will appear on adafruit.github.io.

The workflow is triggered:
 * on commits to the main branch, including merged pull requests
 * daily, after the bundle is updated
 * on request via the github web page

Typically, this means that the images will be available (well) within an hour after a pull request is merged, and will be updated daily if required by changes to the requirements of libraries.

There is an HTML index by name, to make it "easier" to find the relevant image.

Here is the site generated under my personal github pages: http://www.unpythonic.net/Adafruit_Learning_System_Guides/

Index:
![image](https://user-images.githubusercontent.com/1517291/117038274-0d849d00-accd-11eb-8d3a-5012f5cb8e23.png)

Typical image (from http://www.unpythonic.net/Adafruit_Learning_System_Guides/BLE_Client_Server.png):

![image](https://user-images.githubusercontent.com/1517291/117038302-15dcd800-accd-11eb-94ba-df5cc5a957ff.png)
