### PR TITLE
Moved to sidereal days

### DIFF
--- a/Astrophotography_Tracker/code.py
+++ b/Astrophotography_Tracker/code.py
@@ -10,7 +10,7 @@ steps = 200 # Steps per revolution
 microsteps = 64 # Microstepping resolution
 total_steps = steps * microsteps # Total microsteps per revolution
 
-wait = 1/ ((gear_ratio * total_steps) / 86400)
+wait = 1/ ((gear_ratio * total_steps) / 86164.1)
 
 step = digitalio.DigitalInOut(board.D6)
 direct = digitalio.DigitalInOut(board.D5)


### PR DESCRIPTION
~~Basically the earth actually takes 23hrs 56mins and 4.1 seconds to make a full rotation.~~
So basically the Earth takes 23hrs 56mins and 4.1 seconds to make one rotation in respect to distant astronomical objects. To be honest, I don't really understand why this is. I think it's got something to do with solar days being affected by the movement of the Earth around the sun but sidereal days not being affected since all the other stars are really far away from us, but the Wikipedia article just made me really confused.

Regardless, this change should allow the astrophotography tracker to be more accurate at longer exposures.