### PR TITLE
Update aws_gfx_helper.py

### DIFF
--- a/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
+++ b/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
@@ -106,7 +106,7 @@ class AWS_GFX(displayio.Group):
                 self.temp_data_label.color = 0xFD2EE
             elif temp_data <= 32:
                 self.temp_data_label.color = 0xFF0000
-            self.temp_data_label = '%0.0f°F'%temp_data
+            self.temp_data_label.text = '%0.0f°F'%temp_data
             temp_data = '%0.0f'%temp_data
             return int(temp_data)
         else:


### PR DESCRIPTION
PyPortal display was not updating Fahrenheit temperature due to missing .text