### PR TITLE
Hour 12 is 12PM; display it as 12p not 12a

### DIFF
--- a/MagTag_Cat_Fed_Clock/code.py
+++ b/MagTag_Cat_Fed_Clock/code.py
@@ -39,6 +39,8 @@ def hh_mm(time_struct, twelve_hour=True):
         elif time_struct.tm_hour > 0:
             hour_string = str(time_struct.tm_hour) # 1-12
             postfix = "a"
+            if time_struct.tm_hour == 12:
+                postfix = "p" # 12 -> 12 (pm)
         else:
             hour_string = '12' # 0 -> 12 (am)
             postfix = "a"


### PR DESCRIPTION
This is a simple change for the Cat Fed Clock project.
When using 12-hour AM/PM time, hour 12 is called 12 PM.  This changes the hh_mm function code to display it as such.
Tested on our personal cat fed clock at noon - cats are still eating :)