### PR TITLE
AHT20-OLED: Remove max_size usage from displayio.Group

### DIFF
--- a/AHT20_OLED/code.py
+++ b/AHT20_OLED/code.py
@@ -25,7 +25,7 @@ display_bus = displayio.I2CDisplay(i2c, device_address=0x3C)
 display = adafruit_displayio_ssd1306.SSD1306(display_bus, width=128, height=32)
 
 # Make the display context
-splash = displayio.Group(max_size=8)
+splash = displayio.Group()
 display.show(splash)
 
 text = "hello world"


### PR DESCRIPTION
Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603

**Question:** Is this directory used? The obvious Learn Guide search for `AHT20` does not use this. It uses the `simpletest` from the library.
https://learn.adafruit.com/adafruit-aht20/python-circuitpython