### PR TITLE
Baudot_TTY: Remove max_size usage from displayio.Group

### DIFF
--- a/Baudot_TTY/baudot_tty_GUI.py
+++ b/Baudot_TTY/baudot_tty_GUI.py
@@ -26,7 +26,7 @@ messages = [
 
 
 clue.display.brightness = 1.0
-screen = displayio.Group(max_size=5)
+screen = displayio.Group()
 
 VFD_GREEN = 0x00FFD2
 VFD_BG = 0x000505
@@ -65,11 +65,13 @@ messages_config = [
 
 messages_labels = {}  # dictionary of configured messages_labels
 
-message_group = displayio.Group(max_size=5, scale=1)
+message_group = displayio.Group(scale=1)
 
 for message_config in messages_config:
     (name, textline, color, x, y) = message_config  # unpack tuple into five var names
-    message_label = label.Label(terminalio.FONT, text=textline, color=color, max_glyphs=50)
+    message_label = label.Label(
+        terminalio.FONT, text=textline, color=color, max_glyphs=50
+    )
     message_label.x = x
     message_label.y = y
     messages_labels[name] = message_label

--- a/Baudot_TTY/baudot_tty_ble.py
+++ b/Baudot_TTY/baudot_tty_ble.py
@@ -19,7 +19,7 @@ from adafruit_ble.services.nordic import UARTService
 ble = BLERadio()
 uart_server = UARTService()
 advertisement = ProvideServicesAdvertisement(uart_server)
-ble._adapter.name = "TTY_MACHINE" # pylint: disable=protected-access
+ble._adapter.name = "TTY_MACHINE"  # pylint: disable=protected-access
 
 # constants for sine wave generation
 SIN_LENGTH = 100  # more is less choppy
@@ -148,7 +148,8 @@ def baudot_bit(pitch=bit_1, duration=0.022):  # spec says 20ms, but adjusted as 
     # dac.stop()
 
 
-def baudot_carrier(duration=0.15):  # Carrier is transmitted 150 ms before first character is sent
+def baudot_carrier(duration=0.15):
+    # Carrier is transmitted 150 ms before first character is sent
     baudot_bit(carrier, duration)
     dac.stop()
 


### PR DESCRIPTION
Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603

No apparent changes are need in the Learn Guide:
https://learn.adafruit.com/clue-teletype-transmitter/overview
