### PR TITLE
CircuitPython_Display_Text: Update for CP7

### DIFF
--- a/CircuitPython_Display_Text/background_color_example.py
+++ b/CircuitPython_Display_Text/background_color_example.py
@@ -13,7 +13,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 reg_label = label.Label(

--- a/CircuitPython_Display_Text/background_tight_example.py
+++ b/CircuitPython_Display_Text/background_tight_example.py
@@ -14,7 +14,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 font = bitmap_font.load_font("fonts/Fayette-HandwrittenScript-48.bdf")

--- a/CircuitPython_Display_Text/base_alignment_test.py
+++ b/CircuitPython_Display_Text/base_alignment_test.py
@@ -14,7 +14,7 @@ from adafruit_display_text import bitmap_label as label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 

--- a/CircuitPython_Display_Text/color_example.py
+++ b/CircuitPython_Display_Text/color_example.py
@@ -13,7 +13,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 reg_label = label.Label(

--- a/CircuitPython_Display_Text/colormask_example.py
+++ b/CircuitPython_Display_Text/colormask_example.py
@@ -34,7 +34,7 @@ bg_palette = displayio.Palette(1)
 bg_palette[0] = 0xDDDD00
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 font = bitmap_font.load_font("fonts/LeagueSpartan-Bold-16.bdf")

--- a/CircuitPython_Display_Text/display_text_anchored_position.py
+++ b/CircuitPython_Display_Text/display_text_anchored_position.py
@@ -14,7 +14,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 DISPLAY_WIDTH = 320
 DISPLAY_HEIGHT = 240
@@ -64,7 +64,7 @@ text_area_bottom_right = label.Label(
 text_area_bottom_right.anchor_point = (1.0, 1.0)
 text_area_bottom_right.anchored_position = (DISPLAY_WIDTH - 8, DISPLAY_HEIGHT - 8)
 
-text_group = displayio.Group(max_size=9)
+text_group = displayio.Group()
 text_group.append(text_area_top_middle)
 text_group.append(text_area_top_left)
 text_group.append(text_area_top_right)

--- a/CircuitPython_Display_Text/font_example.py
+++ b/CircuitPython_Display_Text/font_example.py
@@ -15,7 +15,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 font = bitmap_font.load_font("fonts/LeagueSpartan-Bold-16.bdf")

--- a/CircuitPython_Display_Text/line_spacing_example.py
+++ b/CircuitPython_Display_Text/line_spacing_example.py
@@ -13,7 +13,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 # font = bitmap_font.load_font("Fayette-HandwrittenScript-48.bdf")

--- a/CircuitPython_Display_Text/padding_example.py
+++ b/CircuitPython_Display_Text/padding_example.py
@@ -13,7 +13,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 # font = bitmap_font.load_font("Fayette-HandwrittenScript-48.bdf")

--- a/CircuitPython_Display_Text/scale_example.py
+++ b/CircuitPython_Display_Text/scale_example.py
@@ -14,7 +14,7 @@ from adafruit_display_text import label
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 font = terminalio.FONT


### PR DESCRIPTION
Remove max_size usage from displayio.Group

Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603

Changes are need in the Learn Guide: https://learn.adafruit.com/circuitpython-display_text-library/overview

Page: https://learn.adafruit.com/circuitpython-display_text-library/types-of-labels
Section: Most of the page
@FoamyGuy This can have the `max_size` related comments removed, but the `max_glyphs` comments need to remain for now. There is a pending PR which will remove `max_glyphs` - https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/154