### PR TITLE
RPN Calculator: Update for CP7

### DIFF
--- a/CircuitPython_RPN_Calculator/code.py
+++ b/CircuitPython_RPN_Calculator/code.py
@@ -7,6 +7,7 @@ from adafruit_display_text.label import Label
 from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
 from jepler_udecimal import Decimal, getcontext, localcontext
+import jepler_udecimal.utrig  # Needed for trig functions in Decimal
 import board
 import digitalio
 import displayio

--- a/CircuitPython_RPN_Calculator/code.py
+++ b/CircuitPython_RPN_Calculator/code.py
@@ -6,16 +6,13 @@ import time
 from adafruit_display_text.label import Label
 from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
-from adafruit_hid.keycode import Keycode
 from jepler_udecimal import Decimal, getcontext, localcontext
-import jepler_udecimal.utrig
 import board
 import digitalio
 import displayio
 import framebufferio
 import microcontroller
 import sharpdisplay
-import supervisor
 import terminalio
 
 try:
@@ -199,15 +196,15 @@ class Impl:
         self.keyboard = None
         self.keyboard_layout = None
 
-        g = displayio.Group(max_size=7)
+        g = displayio.Group()
 
         self.labels = labels = []
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=2, color=0))
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=3, color=0))
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=3, color=0))
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=3, color=0))
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=3, color=0))
-        labels.append(Label(terminalio.FONT, max_glyphs=32, scale=3, color=0))
+        labels.append(Label(terminalio.FONT, scale=2, color=0))
+        labels.append(Label(terminalio.FONT, scale=3, color=0))
+        labels.append(Label(terminalio.FONT, scale=3, color=0))
+        labels.append(Label(terminalio.FONT, scale=3, color=0))
+        labels.append(Label(terminalio.FONT, scale=3, color=0))
+        labels.append(Label(terminalio.FONT, scale=3, color=0))
 
         for li in labels:
             g.append(li)


### PR DESCRIPTION
Remove unused imports
Remove usage of max_size from displayio.Group
Remove usage of max_glyphs from Label

Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603

Learn Guide:
https://learn.adafruit.com/diy-rpn-desktop-calculator-with-circuitpython/overview

Changes Needed: *nothing apparent*