### PR TITLE
fix colorwheel location

### DIFF
--- a/Adafruit_MacroPad/MacroPad/code.py
+++ b/Adafruit_MacroPad/MacroPad/code.py
@@ -4,7 +4,7 @@ import digitalio
 import rotaryio
 import neopixel
 import keypad
-from _pixelbuf import colorwheel
+from rainbowio import colorwheel
 
 
 key_pins = (board.KEY1, board.KEY2, board.KEY3, board.KEY4, board.KEY5, board.KEY6,


### PR DESCRIPTION
Apparently _pixelbuf no longer has colorwheel in it (https://github.com/adafruit/circuitpython/issues/4992). But it does live in the builtin rainbowio lib,


- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
Moving colorwheel import to built in rainbowio lib


- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

Simple import change - just makes the code work now

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Just opened my adabox019 and started playing - and the first demo program was broken. Verified this change works on my shiny new macropad.

