### PR TITLE
Update Macropad TOTP

### DIFF
--- a/Macropad_2FA_TOTP/macropad_totp.py
+++ b/Macropad_2FA_TOTP/macropad_totp.py
@@ -27,12 +27,6 @@ DISPLAY_TIMEOUT = 60   # screen saver timeout in seconds
 DISPLAY_RATE = 1       # screen refresh rate
 #-------------------------------------------------------------------------
 
-# TODO: remove this once this is resolved:
-# https://github.com/adafruit/circuitpython/issues/4893
-# and this gets merged:
-# https://github.com/adafruit/circuitpython/pull/4961
-EPOCH_OFFSET = 946684800 # delta from above issue thread
-
 # Get sekrets from a secrets.py file
 try:
     from secrets import secrets
@@ -95,7 +89,7 @@ display.show(splash)
 #                    H E L P E R    F U N C S
 #-------------------------------------------------------------------------
 def timebase(timetime):
-    return (timetime + EPOCH_OFFSET - (UTC_OFFSET*3600)) // 30
+    return (timetime - (UTC_OFFSET*3600)) // 30
 
 def compute_codes(timestamp):
     codes = []


### PR DESCRIPTION
CP 7.0.0 alpha's up to 4 used a different epoch based on the year 2000. CP 7.0.0 alpha 5 reverts back to 1970 base epoch. This changes the code, originally written with CP 7.0.0 alpha 3, to work with latest CP update.

related issue and PR:
https://github.com/adafruit/circuitpython/issues/4893
https://github.com/adafruit/circuitpython/pull/4961
