### PR TITLE
CircuitPython Essentials: Update board.D13 to board.LED

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_Digital_In_Out.py
+++ b/CircuitPython_Essentials/CircuitPython_Digital_In_Out.py
@@ -4,7 +4,7 @@ import board
 from digitalio import DigitalInOut, Direction, Pull
 
 # LED setup.
-led = DigitalInOut(board.D13)
+led = DigitalInOut(board.LED)
 # For QT Py M0. QT Py M0 does not have a D13 LED, so you can connect an external LED instead.
 # led = DigitalInOut(board.SCK)
 led.direction = Direction.OUTPUT

--- a/CircuitPython_Essentials/CircuitPython_HID_Keyboard.py
+++ b/CircuitPython_Essentials/CircuitPython_HID_Keyboard.py
@@ -31,7 +31,7 @@ for pin in keypress_pins:
     key_pin_array.append(key_pin)
 
 # For most CircuitPython boards:
-led = digitalio.DigitalInOut(board.D13)
+led = digitalio.DigitalInOut(board.LED)
 # For QT Py M0:
 # led = digitalio.DigitalInOut(board.SCK)
 led.direction = digitalio.Direction.OUTPUT

--- a/CircuitPython_Essentials/CircuitPython_Logger.py
+++ b/CircuitPython_Essentials/CircuitPython_Logger.py
@@ -5,7 +5,7 @@ import digitalio
 import microcontroller
 
 # For most CircuitPython boards:
-led = digitalio.DigitalInOut(board.D13)
+led = digitalio.DigitalInOut(board.LED)
 # For QT Py M0:
 # led = digitalio.DigitalInOut(board.SCK)
 led.switch_to_output()

--- a/CircuitPython_Essentials/CircuitPython_PWM.py
+++ b/CircuitPython_Essentials/CircuitPython_PWM.py
@@ -4,7 +4,7 @@ import board
 import pwmio
 
 # LED setup for most CircuitPython boards:
-led = pwmio.PWMOut(board.D13, frequency=5000, duty_cycle=0)
+led = pwmio.PWMOut(board.LED, frequency=5000, duty_cycle=0)
 # LED setup for QT Py M0:
 # led = pwmio.PWMOut(board.SCK, frequency=5000, duty_cycle=0)
 

--- a/CircuitPython_Essentials/CircuitPython_UART.py
+++ b/CircuitPython_Essentials/CircuitPython_UART.py
@@ -4,7 +4,7 @@ import busio
 import digitalio
 
 # For most CircuitPython boards:
-led = digitalio.DigitalInOut(board.D13)
+led = digitalio.DigitalInOut(board.LED)
 # For QT Py M0:
 # led = digitalio.DigitalInOut(board.SCK)
 led.direction = digitalio.Direction.OUTPUT


### PR DESCRIPTION
This updates the led usage to board.LED instead of board.D13.

Learn guide updates are needed to the following pages:
https://learn.adafruit.com/circuitpython-essentials/circuitpython-digital-in-out
https://learn.adafruit.com/circuitpython-essentials/circuitpython-pwm
https://learn.adafruit.com/circuitpython-essentials/circuitpython-uart-serial