### PR TITLE
Add starter examples for Windows, distinguish Mac/Win in title

### DIFF
--- a/Macropad_Hotkeys/macros/mac-adobe-illustrator.py
+++ b/Macropad_Hotkeys/macros/mac-adobe-illustrator.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                     # REQUIRED dict, must be named 'app'
-    'name' : 'Illustrator', # Application name
-    'macros' : [            # List of button macros...
+app = {                         # REQUIRED dict, must be named 'app'
+    'name' : 'Mac Illustrator', # Application name
+    'macros' : [                # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, 'Undo', [Keycode.COMMAND, 'z']),

--- a/Macropad_Hotkeys/macros/mac-adobe-photoshop.py
+++ b/Macropad_Hotkeys/macros/mac-adobe-photoshop.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                   # REQUIRED dict, must be named 'app'
-    'name' : 'Photoshop', # Application name
-    'macros' : [          # List of button macros...
+app = {                       # REQUIRED dict, must be named 'app'
+    'name' : 'Mac Photoshop', # Application name
+    'macros' : [              # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, 'Undo', [Keycode.COMMAND, 'z']),

--- a/Macropad_Hotkeys/macros/mac-safari.py
+++ b/Macropad_Hotkeys/macros/mac-safari.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                # REQUIRED dict, must be named 'app'
-    'name' : 'Safari', # Application name
-    'macros' : [       # List of button macros...
+app = {                    # REQUIRED dict, must be named 'app'
+    'name' : 'Mac Safari', # Application name
+    'macros' : [           # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, '< Back', [Keycode.COMMAND, '[']),

--- a/Macropad_Hotkeys/macros/win-adobe-illustrator.py
+++ b/Macropad_Hotkeys/macros/win-adobe-illustrator.py
@@ -1,0 +1,29 @@
+# MACROPAD Hotkeys example: Adobe Illustrator for Windows
+
+from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
+
+app = {                     # REQUIRED dict, must be named 'app'
+    'name' : 'Illustrator', # Application name
+    'macros' : [            # List of button macros...
+        # COLOR    LABEL    KEY SEQUENCE
+        # 1st row ----------
+        (0x004000, 'Undo', [Keycode.CONTROL, 'z']),
+        (0x004000, 'Redo', [Keycode.CONTROL, 'Z']),
+        (0x303000, 'Pen', 'p'),     # Path-drawing tool
+        # 2nd row ----------
+
+        (0x101010, 'Select', 'v'),  # Select (path)
+        (0x400000, 'Reflect', 'o'), # Reflect selection
+        (0x303000, 'Rect', 'm'),    # Draw rectangle
+        # 3rd row ----------
+        (0x101010, 'Direct', 'a'),  # Direct (point) selection
+        (0x400000, 'Rotate', 'r'),  # Rotate selection
+        (0x303000, 'Oval', 'l'),    # Draw ellipse
+        # 4th row ----------
+        (0x101010, 'Eyedrop', 'i'), # Cycle eyedropper/measure modes
+        (0x400000, 'Scale', 's'),   # Scale selection
+        (0x303000, 'Text', 't'),    # Type tool
+        # Encoder button ---
+        (0x000000, '', [Keycode.CONTROL, Keycode.ALT, 'S']) # Save for web
+    ]
+}

--- a/Macropad_Hotkeys/macros/win-adobe-illustrator.py
+++ b/Macropad_Hotkeys/macros/win-adobe-illustrator.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                     # REQUIRED dict, must be named 'app'
-    'name' : 'Illustrator', # Application name
-    'macros' : [            # List of button macros...
+app = {                         # REQUIRED dict, must be named 'app'
+    'name' : 'Win Illustrator', # Application name
+    'macros' : [                # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, 'Undo', [Keycode.CONTROL, 'z']),

--- a/Macropad_Hotkeys/macros/win-adobe-photoshop.py
+++ b/Macropad_Hotkeys/macros/win-adobe-photoshop.py
@@ -1,0 +1,28 @@
+# MACROPAD Hotkeys example: Adobe Photoshop for Windows
+
+from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
+
+app = {                   # REQUIRED dict, must be named 'app'
+    'name' : 'Photoshop', # Application name
+    'macros' : [          # List of button macros...
+        # COLOR    LABEL    KEY SEQUENCE
+        # 1st row ----------
+        (0x004000, 'Undo', [Keycode.CONTROL, 'z']),
+        (0x004000, 'Redo', [Keycode.CONTROL, 'Z']),
+        (0x000040, 'Brush', 'B'),   # Cycle brush modes
+        # 2nd row ----------
+        (0x101010, 'B&W', 'd'),     # Default colors
+        (0x101010, 'Marquee', 'M'), # Cycle rect/ellipse marquee (select)
+        (0x000040, 'Eraser', 'E'),  # Cycle eraser modes
+        # 3rd row ----------
+        (0x101010, 'Swap', 'x'),    # Swap foreground/background colors
+        (0x101010, 'Move', 'v'),    # Move layer
+        (0x000040, 'Fill', 'G'),    # Cycle fill/gradient modes
+        # 4th row ----------
+        (0x101010, 'Eyedrop', 'I'), # Cycle eyedropper/measure modes
+        (0x101010, 'Wand', 'W'),    # Cycle "magic wand" (selection) modes
+        (0x000040, 'Heal', 'J'),    # Cycle "healing" modes
+        # Encoder button ---
+        (0x000000, '', [Keycode.CONTROL, Keycode.ALT, 'S']) # Save for web
+    ]
+}

--- a/Macropad_Hotkeys/macros/win-adobe-photoshop.py
+++ b/Macropad_Hotkeys/macros/win-adobe-photoshop.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                   # REQUIRED dict, must be named 'app'
-    'name' : 'Photoshop', # Application name
-    'macros' : [          # List of button macros...
+app = {                       # REQUIRED dict, must be named 'app'
+    'name' : 'Win Photoshop', # Application name
+    'macros' : [              # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, 'Undo', [Keycode.CONTROL, 'z']),

--- a/Macropad_Hotkeys/macros/win-edge.py
+++ b/Macropad_Hotkeys/macros/win-edge.py
@@ -2,9 +2,9 @@
 
 from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
 
-app = {                # REQUIRED dict, must be named 'app'
-    'name' : 'Edge',   # Application name
-    'macros' : [       # List of button macros...
+app = {                      # REQUIRED dict, must be named 'app'
+    'name' : 'Windows Edge', # Application name
+    'macros' : [             # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
         (0x004000, '< Back', [Keycode.ALT, Keycode.LEFT_ARROW]),

--- a/Macropad_Hotkeys/macros/win-edge.py
+++ b/Macropad_Hotkeys/macros/win-edge.py
@@ -1,0 +1,31 @@
+# MACROPAD Hotkeys example: Microsoft Edge web browser for Windows
+
+from adafruit_hid.keycode import Keycode # REQUIRED if using Keycode.* values
+
+app = {                # REQUIRED dict, must be named 'app'
+    'name' : 'Edge',   # Application name
+    'macros' : [       # List of button macros...
+        # COLOR    LABEL    KEY SEQUENCE
+        # 1st row ----------
+        (0x004000, '< Back', [Keycode.ALT, Keycode.LEFT_ARROW]),
+        (0x004000, 'Fwd >', [Keycode.ALT, Keycode.RIGHT_ARROW]),
+        (0x400000, 'Up', [Keycode.SHIFT, ' ']),      # Scroll up
+        # 2nd row ----------
+        (0x202000, '- Size', [Keycode.CONTROL, Keycode.KEYPAD_MINUS]),
+        (0x202000, 'Size +', [Keycode.CONTROL, Keycode.KEYPAD_PLUS]),
+        (0x400000, 'Down', ' '),                     # Scroll down
+        # 3rd row ----------
+        (0x000040, 'Reload', [Keycode.CONTROL, 'r']),
+        (0x000040, 'Home', [Keycode.ALT, Keycode.HOME]),
+        (0x000040, 'Private', [Keycode.CONTROL, 'N']),
+        # 4th row ----------
+        (0x000000, 'Ada', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+                           'www.adafruit.com\n']),   # Adafruit in new window
+        (0x800000, 'Digi', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+                            'www.digikey.com\n']),   # Digi-Key in new window
+        (0x101010, 'Hacks', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+                             'www.hackaday.com\n']), # Hack-a-Day in new win
+        # Encoder button ---
+        (0x000000, '', [Keycode.CONTROL, 'w']) # Close tab
+    ]
+}


### PR DESCRIPTION
Essentially the same three (Adobe Photoshop and Illustrator, and system default browser). Additionally, “Mac” and “Win” have been added to the banner label shown on the display, so users have some extra feedback if they’ve installed the wrong files (e.g. if they just drag-and-drop the lot instead of pick and choose).