### PR TITLE
update clue metal detector for ulab renames

### DIFF
--- a/CLUE_Metal_Detector/clue-metal-detector.py
+++ b/CLUE_Metal_Detector/clue-metal-detector.py
@@ -523,7 +523,7 @@ mag_mag = 0.0
 # Keep some historical voltage data to calculate median for re-baselining
 # aiming for about 10 reads per second so this gives
 # 20 seconds
-voltage_hist = ulab.zeros(20 * 10 + 1, dtype=ulab.float)
+voltage_hist = ulab.numpy.zeros(20 * 10 + 1, dtype=ulab.numpy.float)
 voltage_hist_idx = 0
 voltage_hist_complete = False
 voltage_hist_median = None
@@ -699,7 +699,7 @@ while True:
 
     # Adjust the reference base_voltage to the median of historical values
     if voltage_hist_complete and update_median:
-        voltage_hist_median = ulab.numerical.sort(voltage_hist)[len(voltage_hist) // 2]
+        voltage_hist_median = ulab.numpy.sort(voltage_hist)[len(voltage_hist) // 2]
         base_voltage = voltage_hist_median
 
     d_print(2, counter, sample_start_time_ns / 1e9,


### PR DESCRIPTION
These changes update CLUE metal detector code to use the latest version of `ulab` which contained extensive renaming.

I tested the updated code successfully on `Adafruit CircuitPython 7.0.0-alpha.5 on 2021-07-21; Adafruit CLUE nRF52840 Express with nRF52840`