### PR TITLE
snowglobe cp7 updates and background fix

### DIFF
--- a/TFT_Gizmo_Snowglobe/snowglobe_fancy.py
+++ b/TFT_Gizmo_Snowglobe/snowglobe_fancy.py
@@ -33,7 +33,7 @@ try:
                                                     bitmap=displayio.Bitmap,
                                                     palette=displayio.Palette)
 # Or just use solid color
-except (OSError, TypeError):
+except (OSError, TypeError, AttributeError):
     BACKGROUND = BACKGROUND if isinstance(BACKGROUND, int) else 0x000000
     bg_bitmap = displayio.Bitmap(display.width, display.height, 1)
     bg_palette = displayio.Palette(1)
@@ -52,7 +52,7 @@ if FLAKE_TRAN_COLOR is not None:
             break
 NUM_SPRITES = flake_bitmap.width // FLAKE_WIDTH * flake_bitmap.height // FLAKE_HEIGHT
 flake_pos = [0.0] * NUM_FLAKES
-flakes = displayio.Group(max_size=NUM_FLAKES)
+flakes = displayio.Group()
 for _ in range(NUM_FLAKES):
     flakes.append(displayio.TileGrid(flake_bitmap, pixel_shader=flake_palette,
                                      width = 1,

--- a/TFT_Gizmo_Snowglobe/snowglobe_simple.py
+++ b/TFT_Gizmo_Snowglobe/snowglobe_simple.py
@@ -26,7 +26,7 @@ try:
                                                     bitmap=displayio.Bitmap,
                                                     palette=displayio.Palette)
 # Or just use solid color
-except (OSError, TypeError):
+except (OSError, TypeError, AttributeError):
     BACKGROUND = BACKGROUND if isinstance(BACKGROUND, int) else 0x000000
     bg_bitmap = displayio.Bitmap(display.width, display.height, 1)
     bg_palette = displayio.Palette(1)
@@ -50,7 +50,7 @@ flake_sheet = displayio.Bitmap(12, 4, len(palette))
 for i, value in enumerate(FLAKES):
     flake_sheet[i] = value
 flake_pos = [0.0] * NUM_FLAKES
-flakes = displayio.Group(max_size=NUM_FLAKES)
+flakes = displayio.Group()
 for _ in range(NUM_FLAKES):
     flakes.append(displayio.TileGrid(flake_sheet, pixel_shader=palette,
                                      width = 1,


### PR DESCRIPTION
updates for cp7. Ref: #1603 

Also noticed an issue with using a color in the background causing an `AttributeError` I suspect the type of error raised by the core code was changed and this type was not one the ones that were caught so it caused the code to crash. Fixed by adding it to the types that are caught so the code will successfully move on and set the background color.

Tested with CircuitPlayground Bluefruit 7.0.0 alpha5 + TFT Gizmo

Guide: https://learn.adafruit.com/circuit-playground-tft-gizmo-snow-globe/overview-2
No changes needed in the guide