### PR TITLE
cp7 updates and text position

### DIFF
--- a/Say_Their_Names_LEDMatrix/code.py
+++ b/Say_Their_Names_LEDMatrix/code.py
@@ -137,7 +137,7 @@ display = framebufferio.FramebufferDisplay(matrix)
 blm_font = [None, None, None]
 for line in range(3):
     label = adafruit_display_text.label.Label(
-        terminalio.FONT, color=0xFFFFFF, x=2, y=line * 10 - 2, max_glyphs=16
+        terminalio.FONT, color=0xFFFFFF, x=2, y=line * 10 + 5
     )
     blm_font[line] = label
 
@@ -147,14 +147,12 @@ for line in range(2):
     label = adafruit_display_text.label.Label(
         terminalio.FONT,
         color=0xFFFFFF,
-        x=36,
-        y=line * 14,  # these will center text when anchor is top-middle
-        max_glyphs=16,
+        anchored_position=(32, line * 14)  # these will center text when anchor is top-middle
     )
     label.anchor_point = (0.5, 0)
     names_font[line] = label
 
-g = displayio.Group(max_size=10)
+g = displayio.Group()
 for line in blm_font:
     g.append(line)
 for line in names_font:


### PR DESCRIPTION
This updates the code for CP7 breaking changes.

I noticed that the "Black Lives Matter" text was shifted a few pixels too high, the top half of "Black" was off the top edge of the matrix display. And the names text was a few pixels off-center to the right. So I fixed both of those things to get "Black Lives Matter" onto the display, and center the names text.

Tested on MatrixPortal 7.0.0 alpha5

I didn't find any guides that go with this project. It's linked from a blog post here: https://blog.adafruit.com/2020/06/08/how-to-make-python-powered-protest-signs-black-lives-matter-say-their-names/