### PR TITLE
matrix slot machine cp7 updates

### DIFF
--- a/RGB_Matrix_Slot_Machine/code.py
+++ b/RGB_Matrix_Slot_Machine/code.py
@@ -101,7 +101,7 @@ the_bitmap, the_palette = adafruit_imageload.load(
 
 # Our fruit machine has 3 wheels, let's create them with a correct horizontal
 # (x) offset and arbitrary vertical (y) offset.
-g = displayio.Group(max_size=3)
+g = displayio.Group()
 wheels = []
 for idx in range(3):
     wheel = Wheel(the_bitmap, the_palette)


### PR DESCRIPTION
updates for CP7 ref: #1603

tested on MatrixPortal 7.0.0 alpha5

There is one instance of `max_size` in a code snippet that will need to be updated on this page: https://learn.adafruit.com/rgb-matrix-slot-machine/circuitpython-code-walkthrough