### PR TITLE
PyPortal Calculator: Update for CP7

### DIFF
--- a/PyPortal_Calculator/code.py
+++ b/PyPortal_Calculator/code.py
@@ -30,7 +30,7 @@ GRAY = 0x888888
 LABEL_OFFSET = 290
 
 # Make the display context
-calc_group = displayio.Group(max_size=25)
+calc_group = displayio.Group()
 board.DISPLAY.show(calc_group)
 
 # Make a background color fill
@@ -68,7 +68,7 @@ def find_button(label):
     return result
 
 border = Rect(20, 8, 280, 35, fill=WHITE, outline=BLACK, stroke=2)
-calc_display = Label(font, text="0", color=BLACK, max_glyphs=MAX_DIGITS)
+calc_display = Label(font, text="0", color=BLACK)
 calc_display.y = 25
 
 clear_button = add_button(0, 0, "AC")

--- a/PyPortal_Calculator/titano_code.py
+++ b/PyPortal_Calculator/titano_code.py
@@ -33,7 +33,7 @@ ts = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
                                       size=(SCREEN_WIDTH, SCREEN_HEIGHT))
 
 # Make the display context
-calc_group = displayio.Group(max_size=25)
+calc_group = displayio.Group()
 board.DISPLAY.show(calc_group)
 
 # Make a background color fill
@@ -75,7 +75,7 @@ def find_button(label):
     return result
 
 border = Rect(int(SCREEN_WIDTH/18), 8, (LABEL_OFFSET), 35, fill=WHITE, outline=BLACK, stroke=2)
-calc_display = Label(font, text="0", color=BLACK, max_glyphs=MAX_DIGITS)
+calc_display = Label(font, text="0", color=BLACK)
 calc_display.y = 25
 
 clear_button = add_button(0, 0, "AC")


### PR DESCRIPTION
Remove max_size usage with displayio.Group
Remove max_glyphs usage with Display_Text Label

Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603

Learn Guide: https://learn.adafruit.com/pyportal-calculator-using-the-displayio-ui-elements
Changes needed:
Page: https://learn.adafruit.com/pyportal-calculator-using-the-displayio-ui-elements/ui-quickstart
* Section: Groups - remove `max_size`

Page: https://learn.adafruit.com/pyportal-calculator-using-the-displayio-ui-elements/circuitpython-code
* https://learn.adafruit.com/pages/16651/elements/3033366/download - Remove `max_size`
* https://learn.adafruit.com/pages/16651/elements/3033375/download - Remove `max_glyphs`