### PR TITLE
Add hotkey 'list' support to send concurrent keycodes

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -137,6 +137,8 @@ while True:
                     MACROPAD.keyboard.press(item)
                 else:
                     MACROPAD.keyboard.release(item)
+            if isinstance(item, list):
+                    MACROPAD.keyboard.send(*item)
             else:
                 MACROPAD.keyboard_layout.write(item)
     else:

--- a/Macropad_Hotkeys/macros/linux-firefox.py
+++ b/Macropad_Hotkeys/macros/linux-firefox.py
@@ -19,10 +19,10 @@ app = {                    # REQUIRED dict, must be named 'app'
         (0x000040, 'Home', [Keycode.CONTROL, 'h']),
         (0x000040, 'Private', [Keycode.CONTROL, Keycode.SHIFT, 'p']),
         # 4th row ----------
-        (0x101010, 'Ada', [Keycode.CONTROL, 't', -Keycode.CONTROL,
+        (0x101010, 'Ada', [[Keycode.CONTROL, KEYCODE.N],
                            'www.adafruit.com\n']),   # adafruit.com in a new tab
         (0x000040, 'Dev Mode', [Keycode.F12]),    # dev mode
-        (0x101010, 'Digi', [Keycode.CONTROL, 't', -Keycode.CONTROL,
+        (0x101010, 'Digi', [[Keycode.CONTROL, KEYCODE.N],
                              'digikey.com\n']), # digikey in a new tab
         # Encoder button ---
         (0x000000, '', [Keycode.CONTROL, 'w']) # Close window/tab

--- a/Macropad_Hotkeys/macros/mac-safari.py
+++ b/Macropad_Hotkeys/macros/mac-safari.py
@@ -19,11 +19,11 @@ app = {                    # REQUIRED dict, must be named 'app'
         (0x000040, 'Home', [Keycode.COMMAND, 'H']),
         (0x000040, 'Private', [Keycode.COMMAND, 'N']),
         # 4th row ----------
-        (0x000000, 'Ada', [Keycode.COMMAND, 'n', -Keycode.COMMAND,
+        (0x000000, 'Ada', [[Keycode.COMMAND, KEYCODE.N],
                            'www.adafruit.com\n']),   # Adafruit in new window
-        (0x800000, 'Digi', [Keycode.COMMAND, 'n', -Keycode.COMMAND,
+        (0x800000, 'Digi', [[Keycode.COMMAND, KEYCODE.N],
                             'www.digikey.com\n']),   # Digi-Key in new window
-        (0x101010, 'Hacks', [Keycode.COMMAND, 'n', -Keycode.COMMAND,
+        (0x101010, 'Hacks', [[Keycode.COMMAND, KEYCODE.N],
                              'www.hackaday.com\n']), # Hack-a-Day in new win
         # Encoder button ---
         (0x000000, '', [Keycode.COMMAND, 'w']) # Close window/tab

--- a/Macropad_Hotkeys/macros/win-edge.py
+++ b/Macropad_Hotkeys/macros/win-edge.py
@@ -19,11 +19,11 @@ app = {                      # REQUIRED dict, must be named 'app'
         (0x000040, 'Home', [Keycode.ALT, Keycode.HOME]),
         (0x000040, 'Private', [Keycode.CONTROL, 'N']),
         # 4th row ----------
-        (0x000000, 'Ada', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+        (0x000000, 'Ada', [[Keycode.CONTROL, KEYCODE.N],
                            'www.adafruit.com\n']),   # Adafruit in new window
-        (0x800000, 'Digi', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+        (0x800000, 'Digi', [[Keycode.CONTROL, KEYCODE.N],
                             'www.digikey.com\n']),   # Digi-Key in new window
-        (0x101010, 'Hacks', [Keycode.CONTROL, 'n', -Keycode.COMMAND,
+        (0x101010, 'Hacks', [[Keycode.CONTROL, KEYCODE.N],
                              'www.hackaday.com\n']), # Hack-a-Day in new win
         # Encoder button ---
         (0x000000, '', [Keycode.CONTROL, 'w']) # Close tab


### PR DESCRIPTION
To better support multiple key macros in a row.

Rather than needing to send +key.a, +key.b, -key.a, -key.b, +key.1, +key.2, etc. specifying up and down for each, you can define the chords more simply:

[[key.a, key.b], [key.1, key.2]]

The macro definition is simpler, and less error prone (see win-edge.py, was pressing control and releasing command).

Also shorthands multiple presses in a row:

[[Keycode.ENTER], [Keycode.ENTER], [Keycode.ENTER]] will press and release enter 3x in a row.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
