### PR TITLE
Release keys should work on positive integers

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -136,7 +136,7 @@ while True:
                 if item >= 0:
                     MACROPAD.keyboard.press(item)
                 else:
-                    MACROPAD.keyboard.release(item)
+                    MACROPAD.keyboard.release(-item)
             else:
                 MACROPAD.keyboard_layout.write(item)
     else:


### PR DESCRIPTION
https://github.com/adafruit/Adafruit_CircuitPython_HID/blob/d5b6ea50f49ef4575a1fbe52259c2dff44bcab2b/adafruit_hid/keyboard.py#L144

In hid, if you press the positive numbers, it won't actually remove them if you pass in negative numbers.
