### PR TITLE
pyportal remote cp7 updates

### DIFF
--- a/PyPortal_Remote/code.py
+++ b/PyPortal_Remote/code.py
@@ -154,7 +154,7 @@ def switchpage(tup):
 # Verifies the Roku and Pyportal are connected and visible
 channels = getchannels()
 
-my_display_group = displayio.Group(max_size=25)
+my_display_group = displayio.Group()
 
 image_1, palette_1 = adafruit_imageload.load(
     "images/page_1.bmp", bitmap=displayio.Bitmap, palette=displayio.Palette


### PR DESCRIPTION
updates for cp7 Ref: #1603 

tested on PyPortal 7.0.0 alpha5

There is one instance of `max_size` to remove in a code snippet on this page: https://learn.adafruit.com/pyportal-roku-remote/code-run-through