### PR TITLE
pyportal quarantine clock cp7 updates

### DIFF
--- a/PyPortal_Quarantine_Clock/code.py
+++ b/PyPortal_Quarantine_Clock/code.py
@@ -74,13 +74,13 @@ font_large.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123
 font_small.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890- ()')
 
 # Set up label for the day
-label_day = label.Label(font_large, color=LABEL_DAY_COLOR, max_glyphs=200)
+label_day = label.Label(font_large, color=LABEL_DAY_COLOR)
 label_day.x = board.DISPLAY.width // 7
 label_day.y = 80
 pyportal.splash.append(label_day)
 
 # Set up label for the time
-label_time = label.Label(font_small, color=LABEL_TIME_COLOR, max_glyphs=200)
+label_time = label.Label(font_small, color=LABEL_TIME_COLOR)
 label_time.x = board.DISPLAY.width // 4
 label_time.y = 150
 pyportal.splash.append(label_time)

--- a/PyPortal_Quarantine_Clock/month_clock.py
+++ b/PyPortal_Quarantine_Clock/month_clock.py
@@ -94,13 +94,13 @@ font_large.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123
 font_small.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890- ()')
 
 # Set up label for the month
-label_month = label.Label(font_large, color=LABEL_DAY_COLOR, max_glyphs=200)
+label_month = label.Label(font_large, color=LABEL_DAY_COLOR)
 label_month.x = board.DISPLAY.width // 10
 label_month.y = 80
 pyportal.splash.append(label_month)
 
 # Set up label for the time
-label_time = label.Label(font_small, color=LABEL_TIME_COLOR, max_glyphs=200)
+label_time = label.Label(font_small, color=LABEL_TIME_COLOR)
 label_time.x = board.DISPLAY.width // 3
 label_time.y = 150
 pyportal.splash.append(label_time)


### PR DESCRIPTION
updates for cp7 Ref: #1603

I tried to test this on PyPortal 7.0.0 alpha5 but I was getting failed requests to fetch the time for several minutes of retries. I don't think that is related to this PRs change. But I will plan to circle back and try some more when I am able to get back to it.

Guide: https://learn.adafruit.com/pyportal-quarantine-clock/overview
there don't appear to be any changes needed in the guide.