### PR TITLE
pyportal phillips hue cp7 updates

### DIFF
--- a/PyPortal_Philips_Hue_Controller/code.py
+++ b/PyPortal_Philips_Hue_Controller/code.py
@@ -59,7 +59,7 @@ ts = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
 
 
 # Make the display context
-button_group = displayio.Group(max_size=20)
+button_group = displayio.Group()
 board.DISPLAY.show(button_group)
 # preload the font
 print('loading font...')


### PR DESCRIPTION
updates for cp7 Ref: #1603

I don't have the hue light for testing.

There is one instance of `max_size` to remove on this guide page: https://learn.adafruit.com/pyportal-philips-hue-lighting-controller/code-walkthrough