### PR TITLE
RBG Matrix: Update for CP7

### DIFF
--- a/RBG_Matrix/code.py
+++ b/RBG_Matrix/code.py
@@ -46,11 +46,24 @@ g.append(G)
 display.show(g)
 display.auto_refresh = True
 
+
+# CircuitPython 6 & 7 compatible
 bitmap_file = open("/rbg.bmp", "rb")
 # Setup the file as the bitmap data source
 bitmap = displayio.OnDiskBitmap(bitmap_file)
 # Create a TileGrid to hold the bitmap
-tile_grid = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter()))
+tile_grid = displayio.TileGrid(
+    bitmap,
+    pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
+)
+
+# # CircuitPython 7+ compatible
+# # Setup the filename as the bitmap data source
+# bitmap = displayio.OnDiskBitmap("/rbg.bmp")
+# # Create a TileGrid to hold the bitmap
+# tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
+
+
 print(dir(tile_grid))
 
 while True:


### PR DESCRIPTION
Update OnDiskBitmap code to take a filename string with CP7.

Ref: https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1747

Learn Guide: *Unknown*
The only guide that I can find that uses a `rbg.bmp` (Ruth Bader Ginsburg) is https://learn.adafruit.com/image-correction-for-rgb-led-matrices but there is no CircuitPython code in that.

@TheKitty for review