### PR TITLE
cp7 version of OnDiskBitmap and TileGrid usage

### DIFF
--- a/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
+++ b/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
@@ -130,16 +130,17 @@ class AWS_GFX(displayio.Group):
 
         if not filename:
             return  # we're done, no icon desired
+
+        # CircuitPython 6 & 7 compatible
         if self._icon_file:
             self._icon_file.close()
         self._icon_file = open(filename, "rb")
         icon = displayio.OnDiskBitmap(self._icon_file)
-        try:
-            self._icon_sprite = displayio.TileGrid(icon,
-                                                   pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-        except TypeError:
-            self._icon_sprite = displayio.TileGrid(icon,
-                                                   pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                   position=(0,0))
+        self._icon_sprite = displayio.TileGrid(icon,
+                                               pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
+
+        # # CircuitPython 7+ compatible
+        # icon = displayio.OnDiskBitmap(filename)
+        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)


### PR DESCRIPTION
cp7 OnDiskBitmap and TileGrid updates ref: #1747 

Guide: https://learn.adafruit.com/pyportal-iot-plant-monitor-with-aws-iot-and-circuitpython/overview
The lower level details of the gfx_helper aren't discussed on any of the guide pages. Appears to me that there are no changes needed in the guide.