### PR TITLE
Pyportal alarm clock cp7

### DIFF
--- a/PyPortal_Alarm_Clock/code.py
+++ b/PyPortal_Alarm_Clock/code.py
@@ -258,20 +258,21 @@ class Time_State(State):
                 except IndexError:
                     pass
                 filename = "/icons/"+weather_icon_name+".bmp"
+
                 if filename:
+                    # CircuitPython 6 & 7 compatible
                     if self.icon_file:
                         self.icon_file.close()
                     self.icon_file = open(filename, "rb")
                     icon = displayio.OnDiskBitmap(self.icon_file)
-                    try:
-                        icon_sprite = displayio.TileGrid(icon,
-                                                         pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                         x=0, y=0)
-                    except TypeError:
-                        icon_sprite = displayio.TileGrid(icon,
-                                                         pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                         position=(0, 0))
 
+                    icon_sprite = displayio.TileGrid(icon,
+                                                     pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
+                                                     x=0, y=0)
+
+                    # # CircuitPython 7+ compatible
+                    # icon = displayio.OnDiskBitmap(filename)
+                    # icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
                     self.weather_icon.append(icon_sprite)
 

--- a/PyPortal_Alarm_Clock/code.py
+++ b/PyPortal_Alarm_Clock/code.py
@@ -334,18 +334,18 @@ class Time_State(State):
             pyportal.splash.append(ta)
         pyportal.splash.append(self.weather_icon)
         if snooze_time:
+            # CircuitPython 6 & 7 compatible
             if self.snooze_file:
                 self.snooze_file.close()
             self.snooze_file = open('/icons/zzz.bmp', "rb")
             icon = displayio.OnDiskBitmap(self.snooze_file)
-            try:
-                icon_sprite = displayio.TileGrid(icon,
-                                                 pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                 x=0, y=0)
-            except TypeError:
-                icon_sprite = displayio.TileGrid(icon,
-                                                 pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                 position=(0, 0))
+            icon_sprite = displayio.TileGrid(icon,
+                                             pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
+
+            # # CircuitPython 7+ compatible
+            # icon = displayio.OnDiskBitmap("/icons/zzz.bmp")
+            # icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+
             self.snooze_icon.append(icon_sprite)
             pyportal.splash.append(self.snooze_icon)
         if alarm_enabled:


### PR DESCRIPTION
Ref: #1747 

Add cp 7+ compatibility code in comment and remove fallback for very old version of TileGrid with position argument.

There are two code snippets to update on this page: https://learn.adafruit.com/pyportal-alarm-clock/the-time-state