### PR TITLE
cp7 update for pwmio

### DIFF
--- a/MetroX_CircuitPython/fading_led.py
+++ b/MetroX_CircuitPython/fading_led.py
@@ -5,10 +5,11 @@
 fades a LED using pulseio's PWM
 """
 
-import pulseio
+import pwmio
 import board
+import time
 
-led = pulseio.PWMOut(board.D13, frequency=500, duty_cycle=0)
+led = pwmio.PWMOut(board.D13, frequency=500, duty_cycle=0)
 
 while True:
     for i in range(100):
@@ -16,3 +17,4 @@ while True:
             led.duty_cycle = int(i * 2 * 65535 / 100)
         else:  # fade down
             led.duty_cycle = 65535 - int((i - 50) * 2 * 65535 / 100)
+        time.sleep(0.05)

--- a/MetroX_CircuitPython/mib_button_press_pwm.py
+++ b/MetroX_CircuitPython/mib_button_press_pwm.py
@@ -7,10 +7,10 @@ fade a led in and out using two buttons
 import time
 import digitalio
 import board
-import pulseio
+import pwmio
 
 
-led = pulseio.PWMOut(board.D13)
+led = pwmio.PWMOut(board.D13)
 btn1 = digitalio.DigitalInOut(board.D3)
 btn2 = digitalio.DigitalInOut(board.D2)
 btn1.switch_to_input()

--- a/MetroX_CircuitPython/mib_motor.py
+++ b/MetroX_CircuitPython/mib_motor.py
@@ -7,10 +7,10 @@ spins a DC motor using pulseio
 
 import time
 import board
-import pulseio
+import pwmio
 
 motor_pin = board.D9
-motor = pulseio.PWMOut(motor_pin, frequency=1000)
+motor = pwmio.PWMOut(motor_pin, frequency=1000)
 
 
 def motor_on_then_off_with_speed():

--- a/MetroX_CircuitPython/mib_potentiometer_pwm.py
+++ b/MetroX_CircuitPython/mib_potentiometer_pwm.py
@@ -7,9 +7,9 @@ fades a led using a potentiometer
 
 import analogio
 import board
-import pulseio
+import pwmio
 
-led = pulseio.PWMOut(board.D9)
+led = pwmio.PWMOut(board.D9)
 pot = analogio.AnalogIn(board.A0)
 
 while True:

--- a/MetroX_CircuitPython/mib_servo.py
+++ b/MetroX_CircuitPython/mib_servo.py
@@ -9,11 +9,11 @@ requires:
 import time
 import analogio
 import board
-import pulseio
+import pwmio
 from adafruit_motor import servo
 
 
-SERVO = servo.Servo(pulseio.PWMOut(board.D9))
+SERVO = servo.Servo(pwmio.PWMOut(board.D9))
 POTE = analogio.AnalogIn(board.A0)
 
 

--- a/MetroX_CircuitPython/photo_sensor.py
+++ b/MetroX_CircuitPython/photo_sensor.py
@@ -6,10 +6,10 @@ uses LIGHT to control a LED
 """
 import analogio
 import board
-import pulseio
+import pwmio
 from simpleio import map_range
 
-LED = pulseio.PWMOut(board.D9)
+LED = pwmio.PWMOut(board.D9)
 LIGHT = analogio.AnalogIn(board.A0)
 
 

--- a/MetroX_CircuitPython/servo.py
+++ b/MetroX_CircuitPython/servo.py
@@ -8,10 +8,10 @@ requires:
 """
 import time
 import board
-import pulseio
+import pwmio
 from adafruit_motor import servo
 
-SERVO = servo.Servo(pulseio.PWMOut(board.D9))
+SERVO = servo.Servo(pwmio.PWMOut(board.D9))
 
 while True:
     SERVO.angle = 0

--- a/MetroX_CircuitPython/squeeze.py
+++ b/MetroX_CircuitPython/squeeze.py
@@ -7,10 +7,10 @@ force sensitive resistor (fsr) with circuitpython
 
 import analogio
 import board
-import pulseio
+import pwmio
 
 FORCE_SENS_RESISTOR = analogio.AnalogIn(board.A2)
-LED = pulseio.PWMOut(board.D10)
+LED = pwmio.PWMOut(board.D10)
 
 while True:
     LED.duty_cycle = FORCE_SENS_RESISTOR.value


### PR DESCRIPTION
In CP7 PWMOut has been removed from `pulseio` and exists only in `pwmio` now.

MetroX_Circuitpython was the only code I found in this repo that was using the older no longer supported pulsio version.

I was unable to find any guides in the learn system that are referencing this code. My guess is that the main product guides for the Metro M0 and M4 may have referenced this in the past (i.e. pages like these https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51/circuitpython-essentials) but now these embed the more generic CircuitPython Essentials code which covers largely the same topics.

I tested the fading_led script on a Metro M0 with CircuitPython 7.0.0 alpha5, but did not test any of the other examples.

In fading_led I noticed that the fade goes too fast to see with human eye so I added a small `time.sleep()` to slow it down enough to become visible. The other scripts are unchanged except for the change from `pulsio` to `pwmio` 