### PR TITLE
Fix pylint errors in qrio guide code

### DIFF
--- a/CircuitPython_qrio/repl/.circuitpython.skip
+++ b/CircuitPython_qrio/repl/.circuitpython.skip
@@ -1,1 +1,0 @@
-CircuitPython_qrio/repl/code.py 10: Unused import ssl (unused-import)

--- a/CircuitPython_qrio/repl/code.py
+++ b/CircuitPython_qrio/repl/code.py
@@ -7,7 +7,6 @@ This demo is designed for the Kaluga development kit version 1.3 with the
 ILI9341 display.
 """
 
-import ssl
 from ulab import numpy as np
 from terminalio import FONT
 import board

--- a/CircuitPython_qrio/usb_hid/.circuitpython.skip
+++ b/CircuitPython_qrio/usb_hid/.circuitpython.skip
@@ -1,2 +1,0 @@
-CircuitPython_qrio/usb_hid/code.py 20: Unused adafruit_minimqtt.adafruit_minimqtt imported as MQTT (unused-import)
-CircuitPython_qrio/usb_hid/code.py 24: Unused Keycode imported from adafruit_hid.keycode (unused-import)

--- a/CircuitPython_qrio/usb_hid/code.py
+++ b/CircuitPython_qrio/usb_hid/code.py
@@ -17,11 +17,9 @@ import qrio
 import adafruit_ov2640
 from adafruit_display_text.bitmap_label import Label
 from adafruit_ili9341 import ILI9341
-import adafruit_minimqtt.adafruit_minimqtt as MQTT
 import usb_hid
 from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
-from adafruit_hid.keycode import Keycode
 
 print("Initializing display")
 displayio.release_displays()


### PR DESCRIPTION
These errors were exposed with #1772 but hidden again by the addition of skip files.