### PR TITLE
Update PyPortal Hurricane Tracker

### DIFF
--- a/PyPortal_Hurricane_Tracker/hurricane_tracker.py
+++ b/PyPortal_Hurricane_Tracker/hurricane_tracker.py
@@ -20,10 +20,11 @@ LAT_RANGE = (45, 5)  # set to match map
 LON_RANGE = (-100, -40)  # set to match map
 # --------------------------------------------------------------------
 
+URL = "https://www.nhc.noaa.gov/CurrentStorms.json"
+JSON_PATH = ["activeStorms"]
+
 # setup pyportal
 pyportal = PyPortal(
-    url="https://www.nhc.noaa.gov/CurrentStorms.json",
-    json_path=["activeStorms"],
     status_neopixel=board.NEOPIXEL,
     default_bg="/map.bmp",
 )
@@ -67,7 +68,8 @@ def update_display():
 
     # get latest storm data
     try:
-        storm_data = pyportal.fetch()
+        resp = pyportal.network.fetch(URL)
+        storm_data = pyportal.network.process_json(resp.json(), (JSON_PATH,))[0]
     except RuntimeError:
         return
     print("Number of storms:", len(storm_data))

--- a/PyPortal_Hurricane_Tracker/hurricane_tracker.py
+++ b/PyPortal_Hurricane_Tracker/hurricane_tracker.py
@@ -62,6 +62,7 @@ Y_OFFSET = VIRTUAL_HEIGHT / 2 - Y_OFFSET
 
 
 def update_display():
+    # pylint: disable=too-many-locals
     # clear out existing icons
     while len(storm_icons):
         _ = storm_icons.pop()


### PR DESCRIPTION
For #1778.

Restructures the network stuff to use more lower level funcs and prevent some of the automated (but not needed) stuff that was kicking in when using the higher level funcs. The automated stuff is what was exceeding available memory and was probably not part of the library when guide code was originally written. 