### PR TITLE
add main loop in displayio examples

### DIFF
--- a/CircuitPython_displayio/displayio_display_driver.py
+++ b/CircuitPython_displayio/displayio_display_driver.py
@@ -37,3 +37,7 @@ tile_grid = displayio.TileGrid(bitmap, pixel_shader=palette)
 group = displayio.Group()
 group.append(tile_grid)
 display.show(group)
+
+# Loop forever so you can enjoy your image
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_display_manual.py
+++ b/CircuitPython_displayio/displayio_display_manual.py
@@ -64,3 +64,7 @@ tile_grid = displayio.TileGrid(bitmap, pixel_shader=palette)
 group = displayio.Group()
 group.append(tile_grid)
 display.show(group)
+
+# Loop forever so you can enjoy your image
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_font.py
+++ b/CircuitPython_displayio/displayio_font.py
@@ -18,3 +18,7 @@ text_area.y = 20
 
 # Show it
 display.show(text_area)
+
+# Loop forever so you can enjoy your text
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_parallelbus.py
+++ b/CircuitPython_displayio/displayio_parallelbus.py
@@ -62,3 +62,7 @@ tile_grid = displayio.TileGrid(bitmap, pixel_shader=palette)
 group = displayio.Group()
 group.append(tile_grid)
 display.show(group)
+
+# Loop forever so you can enjoy your image
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_pixels.py
+++ b/CircuitPython_displayio/displayio_pixels.py
@@ -30,3 +30,7 @@ bitmap[80, 50] = 1
 for x in range(150, 170):
     for y in range(100, 110):
         bitmap[x, y] = 1
+
+# Loop forever so you can enjoy your image
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_text.py
+++ b/CircuitPython_displayio/displayio_text.py
@@ -18,3 +18,7 @@ text_area.y = 80
 
 # Show it
 display.show(text_area)
+
+# Loop forever so you can enjoy your image
+while True:
+    pass

--- a/CircuitPython_displayio/displayio_tilegrids.py
+++ b/CircuitPython_displayio/displayio_tilegrids.py
@@ -64,3 +64,7 @@ sprite.y = 70
 
 # Add the Group to the Display
 display.show(group)
+
+# Loop forever so you can enjoy your image
+while True:
+    pass


### PR DESCRIPTION
These examples are used in the main displayio guide here: https://learn.adafruit.com/circuitpython-display-support-using-displayio/introduction

Many of them were missing main loops so if you attempted to run them they would technically work but you would not be able to see the result on the display since the program would end immediately afterward.

This adds main loops to the ones that were missing it so that you can actually see the result on the display.