### PR TITLE
Fix parsing the vaccination data

### DIFF
--- a/MagTag_Covid_Vaccination/code.py
+++ b/MagTag_Covid_Vaccination/code.py
@@ -58,8 +58,8 @@ try:
     value = magtag.fetch().split("\n")[-2].split(",")
     print("Response is", value)
 
-    vaccinated = int(value[-2]) / 331984513
-    fully_vaccinated = int(value[-1]) / 331984513
+    vaccinated = int(value[7]) / 331984513
+    fully_vaccinated = int(value[8]) / 331984513
 
     magtag.set_text(f"{value[0]} Vaccination Rates", 0, False)
     magtag.set_text(value[1], 1, False)
@@ -74,8 +74,11 @@ try:
     magtag.refresh()
 
     seconds_to_sleep = 24 * 60 * 60  # Sleep for one day
-    print(f"Sleeping for {seconds_to_sleep} seconds")
-    magtag.exit_and_deep_sleep(seconds_to_sleep)
 
 except (ValueError, RuntimeError) as e:
-    print("Some error occured, retrying! -", e)
+    print("Some error occured, retrying in one hour! -", e)
+    seconds_to_sleep = 60 * 60  # Sleep for one hour
+
+print(f"Sleeping for {seconds_to_sleep} seconds")
+magtag.exit_and_deep_sleep(seconds_to_sleep)
+


### PR DESCRIPTION
The code apparently broke when a new column was added to the CSV data to show the number of boosters.  This field is blank in the US data, so the code would crash trying to turn the empty string into an integer.

Since upstream seems to add columns at the far right (a sensible choice) we should index using positive numbers instead.

This also changes the code so that in the event of a failure it actually *DOES* retry. I designed it to wait for 1 hour in deep sleep before retrying, so that it doesn't immediately run down the battery in case of transient errors.

Note that if you test this code with version 7 prereleases at least up to beta.0, you may be affected by a CircuitPython bug:
 * https://github.com/adafruit/circuitpython/issues/5021

this bug can cause a very inconvenient boot loop.