### PR TITLE
Fix TOTP Code

### DIFF
--- a/CircuitPy_OTP/code.py
+++ b/CircuitPy_OTP/code.py
@@ -82,7 +82,7 @@ def base32_decode(encoded):
                 n = ord(c) - ord('A')
             elif '2' <= c <= '7':
                 n = ord(c) - ord('2') + 26
-            elif n == '=':
+            elif c == '=':
                 continue
             else:
                 raise ValueError("Not base32")

--- a/Macropad_2FA_TOTP/code.py
+++ b/Macropad_2FA_TOTP/code.py
@@ -129,7 +129,7 @@ def base32_decode(encoded):
                 n = ord(c) - ord('A')
             elif '2' <= c <= '7':
                 n = ord(c) - ord('2') + 26
-            elif n == '=':
+            elif c == '=':
                 continue
             else:
                 raise ValueError("Not base32")

--- a/PyPortal_TOTP_Friend/code.py
+++ b/PyPortal_TOTP_Friend/code.py
@@ -92,7 +92,7 @@ def base32_decode(encoded):
                 n = ord(c) - ord('A')
             elif '2' <= c <= '7':
                 n = ord(c) - ord('2') + 26
-            elif n == '=':
+            elif c == '=':
                 continue
             else:
                 raise ValueError("Not base32")


### PR DESCRIPTION
The following comment was posted to the [MacroPad 2FA TOTP guide](https://learn.adafruit.com/macropad-2fa-totp-authentication-friend/overview):

> A secret length of anything other than 16 characters seems to cause the code to fail. Is there any way to support longer secrets?

Can use this stand alone code to test the actual TOTP generation:
```python
import adafruit_hashlib as hashlib

def HMAC(k, m):
    """# HMAC implementation, as hashlib/hmac wouldn't fit
    From https://en.wikipedia.org/wiki/Hash-based_message_authentication_code

    """
    SHA1_BLOCK_SIZE = 64
    KEY_BLOCK = k + (b'\0' * (SHA1_BLOCK_SIZE - len(k)))
    KEY_INNER = bytes((x ^ 0x36) for x in KEY_BLOCK)
    KEY_OUTER = bytes((x ^ 0x5C) for x in KEY_BLOCK)
    inner_message = KEY_INNER + m
    outer_message = KEY_OUTER + hashlib.sha1(inner_message).digest()
    return hashlib.sha1(outer_message)

def base32_decode(encoded):
    missing_padding = len(encoded) % 8
    if missing_padding != 0:
        encoded += '=' * (8 - missing_padding)
    encoded = encoded.upper()
    chunks = [encoded[i:i + 8] for i in range(0, len(encoded), 8)]

    out = []
    for chunk in chunks:
        bits = 0
        bitbuff = 0
        for c in chunk:
            if 'A' <= c <= 'Z':
                n = ord(c) - ord('A')
            elif '2' <= c <= '7':
                n = ord(c) - ord('2') + 26
            elif n == '=':
                continue
            else:
                raise ValueError("Not base32")
            # 5 bits per 8 chars of base32
            bits += 5
            # shift down and add the current value
            bitbuff <<= 5
            bitbuff |= n
            # great! we have enough to extract a byte
            if bits >= 8:
                bits -= 8
                byte = bitbuff >> bits  # grab top 8 bits
                bitbuff &= ~(0xFF << bits)  # and clear them
                out.append(byte)  # store what we got
    return out

def int_to_bytestring(int_val, padding=8):
    result = []
    while int_val != 0:
        result.insert(0, int_val & 0xFF)
        int_val >>= 8
    result = [0] * (padding - len(result)) + result
    return bytes(result)

def generate_otp(int_input, secret_key, digits=6):
    """ HMAC -> OTP generator, pretty much same as
    https://github.com/pyotp/pyotp/blob/master/src/pyotp/otp.py

    """
    if int_input < 0:
        raise ValueError('input must be positive integer')
    hmac_hash = bytearray(
        HMAC(bytes(base32_decode(secret_key)),
             int_to_bytestring(int_input)).digest()
    )
    offset = hmac_hash[-1] & 0xf
    code = ((hmac_hash[offset] & 0x7f) << 24 |
            (hmac_hash[offset + 1] & 0xff) << 16 |
            (hmac_hash[offset + 2] & 0xff) << 8 |
            (hmac_hash[offset + 3] & 0xff))
    str_code = str(code % 10 ** digits)
    while len(str_code) < digits:
        str_code = '0' + str_code

    return str_code

# use to check: https://totp.danhersam.com/
otp = generate_otp(1625004750, "JBSWY3DPEHPK3PXP")
print(otp)
```

It works for:
```python
otp = generate_otp(1625004750, "JBSWY3DPEHPK3PXP")
```
which gets expected output:
```python
Adafruit CircuitPython 7.0.0-alpha.5 on 2021-07-21; Adafruit Macropad RP2040 with rp2040
>>> import totp_test
056995
>>> 
```
But add more characters:
```python
otp = generate_otp(1625004750, "JBSWY3DPEHPK3PXPABBA")
```
and get:
```python
Adafruit CircuitPython 7.0.0-alpha.5 on 2021-07-21; Adafruit Macropad RP2040 with rp2040
>>> import totp_test
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "totp_test.py", line 82, in <module>
  File "totp_test.py", line 67, in generate_otp
  File "totp_test.py", line 37, in base32_decode
ValueError: Not base32
>>>  
```

It looks like `=` is added for padding, but the check is being done on `n` instead of `c`. The simple change in this PR seems to fix it. But not sure if there are more subtle things going on?

Example with PR code:
```python
Adafruit CircuitPython 7.0.0-alpha.5 on 2021-07-21; Adafruit Macropad RP2040 with rp2040
>>> import totp_test
679663
>>> 
```

Tested as above and PR'ing fix to other guides that use same code.
