### PR TITLE
Move to rainbowio

### DIFF
--- a/3D_Printed_LED_Microphone_Flag/code.py
+++ b/3D_Printed_LED_Microphone_Flag/code.py
@@ -31,6 +31,7 @@ import time
 
 import board
 import neopixel
+from rainbowio import colorwheel
 from analogio import AnalogIn
 
 n_pixels = 16  # Number of pixels you are using
@@ -51,21 +52,6 @@ dotcount = 0  # Frame counter for peak dot
 dothangcount = 0  # Frame counter for holding peak dot
 
 strip = neopixel.NeoPixel(led_pin, n_pixels, brightness=1, auto_write=False)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
 
 
 def remapRange(value, leftMin, leftMax, rightMin, rightMax):
@@ -168,7 +154,7 @@ while True:
 
     # Fill the strip with rainbow gradient
     for i in range(0, len(strip)):
-        strip[i] = wheel(remapRange(i, 0, (n_pixels - 1), 30, 150))
+        strip[i] = colorwheel(remapRange(i, 0, (n_pixels - 1), 30, 150))
 
     # Scale the input logarithmically instead of linearly
     c = fscale(input_floor, input_ceiling, (n_pixels - 1), 0, peaktopeak, 2)
@@ -182,7 +168,7 @@ while True:
 
     # Set the peak dot to match the rainbow gradient
     y = n_pixels - peak
-    strip.fill = (y - 1, wheel(remapRange(y, 0, (n_pixels - 1), 30, 150)))
+    strip.fill = (y - 1, colorwheel(remapRange(y, 0, (n_pixels - 1), 30, 150)))
     strip.write()
 
     # Frame based peak dot animation

--- a/3D_Printed_Unicorn_Horn/code.py
+++ b/3D_Printed_Unicorn_Horn/code.py
@@ -2,6 +2,7 @@ import time
 
 import board
 import neopixel
+from rainbowio import colorwheel
 from digitalio import DigitalInOut, Direction
 
 pixpin = board.D1
@@ -13,26 +14,11 @@ led.direction = Direction.OUTPUT
 strip = neopixel.NeoPixel(pixpin, numpix, brightness=1, auto_write=True)
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos*3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
     for j in range(255 * 5):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
 
 
@@ -40,7 +26,7 @@ def rainbow(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int(i + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
 
 

--- a/Adafruit_FunHouse/dotstar_rainbow/code.py
+++ b/Adafruit_FunHouse/dotstar_rainbow/code.py
@@ -2,7 +2,7 @@
 import time
 import board
 import adafruit_dotstar
-from _pixelbuf import colorwheel
+from rainbowio import colorwheel
 
 dots = adafruit_dotstar.DotStar(board.DOTSTAR_CLOCK, board.DOTSTAR_DATA, 5, auto_write=False)
 dots.brightness = 0.3

--- a/Adafruit_Neo_Trinkey/cap_touch_neopixel_brightness/code.py
+++ b/Adafruit_Neo_Trinkey/cap_touch_neopixel_brightness/code.py
@@ -3,7 +3,7 @@ import time
 import board
 import touchio
 import neopixel
-from _pixelbuf import colorwheel
+from rainbowio import colorwheel
 
 touch1 = touchio.TouchIn(board.TOUCH1)
 touch2 = touchio.TouchIn(board.TOUCH2)

--- a/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_3W_LED_Simpletest/code.py
+++ b/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_3W_LED_Simpletest/code.py
@@ -1,6 +1,7 @@
 """Simple rainbow swirl example for 3W LED"""
 import pwmio
 import board
+from rainbowio import colorwheel
 import digitalio
 
 enable = digitalio.DigitalInOut(board.D10)
@@ -11,24 +12,9 @@ red = pwmio.PWMOut(board.D11, duty_cycle=0, frequency=20000)
 green = pwmio.PWMOut(board.D12, duty_cycle=0, frequency=20000)
 blue = pwmio.PWMOut(board.D13, duty_cycle=0, frequency=20000)
 
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
-
-
 while True:
     for i in range(255):
-        r, g, b = wheel(i)
+        r, g, b = colorwheel(i)
         red.duty_cycle = int(r * 65536 / 256)
         green.duty_cycle = int(g * 65536 / 256)
         blue.duty_cycle = int(b * 65536 / 256)

--- a/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_NeoPixel_Simpletest/code.py
+++ b/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_NeoPixel_Simpletest/code.py
@@ -1,6 +1,7 @@
 """Simple rainbow example for 30-pixel NeoPixel strip"""
 import digitalio
 import board
+from rainbowio import colorwheel
 import neopixel
 
 NUM_PIXELS = 30  # NeoPixel strip length (in pixels)
@@ -11,21 +12,6 @@ enable.value = True
 
 strip = neopixel.NeoPixel(board.D5, NUM_PIXELS, brightness=1)
 
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
-
-
 while True:
     for i in range(255):
-        strip.fill((wheel(i)))
+        strip.fill((colorwheel(i)))

--- a/Animated_NeoPixel_Glow_Fur_Scarf/code.py
+++ b/Animated_NeoPixel_Glow_Fur_Scarf/code.py
@@ -63,21 +63,6 @@ heat_colors = [0x330000, 0x660000, 0x990000, 0xCC0000, 0xFF0000,
                0xFFFF33, 0xFFFF66, 0xFFFF99, 0xFFFFCC]
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def remapRange(value, leftMin, leftMax, rightMin, rightMax):
     # this remaps a value fromhere original (left) range to new (right) range
     # Figure out how 'wide' each range is

--- a/Black_Lives_Matter_Kit/Capacitive_Touch_and_NeoPixels/code.py
+++ b/Black_Lives_Matter_Kit/Capacitive_Touch_and_NeoPixels/code.py
@@ -3,7 +3,7 @@ import board
 import touchio
 import digitalio
 import neopixel
-from adafruit_pypixelbuf import colorwheel
+from rainbowio import colorwheel
 
 pixels = neopixel.NeoPixel(board.NEOPIXEL, 6, auto_write=False)
 red_led = digitalio.DigitalInOut(board.D13)

--- a/Black_Lives_Matter_Kit/Sound_Reactive_NeoPixels/code.py
+++ b/Black_Lives_Matter_Kit/Sound_Reactive_NeoPixels/code.py
@@ -3,7 +3,7 @@ import math
 import board
 import audiobusio
 import neopixel
-from adafruit_pypixelbuf import colorwheel
+from rainbowio import colorwheel
 
 # Increase this number to use this example in louder environments. As you increase the number, it
 # increases the level of sound needed to change the color of the LEDs. 5 is good for quiet up to

--- a/CP101_StateMachines/brute-force/code.py
+++ b/CP101_StateMachines/brute-force/code.py
@@ -23,6 +23,7 @@ import adafruit_ds3231
 import audioio
 import audiocore
 import pwmio
+from rainbowio import colorwheel
 from adafruit_motor import servo
 import neopixel
 from adafruit_debouncer import Debouncer
@@ -131,30 +132,18 @@ def random_color():
     blue = random_color_byte()
     return (red, green, blue)
 
+
 # Color cycling.
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos*3), int(pos*3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos*3), int(pos*3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos*3))
-
 def cycle_sequence(seq):
     while True:
         for elem in seq:
             yield elem
 
+
 def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
-        strip.fill(wheel(next(g)))
+        strip.fill(colorwheel(next(g)))
         strip.show()
         yield
 

--- a/CP101_StateMachines/classes/code.py
+++ b/CP101_StateMachines/classes/code.py
@@ -23,6 +23,7 @@ import adafruit_ds3231
 import audioio
 import audiocore
 import pwmio
+from rainbowio import colorwheel
 from adafruit_motor import servo
 import neopixel
 from adafruit_debouncer import Debouncer
@@ -113,19 +114,6 @@ def random_color():
 
 # Color cycling.
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos*3), int(pos*3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos*3), int(pos*3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos*3))
-
 def cycle_sequence(seq):
     while True:
         for elem in seq:
@@ -134,7 +122,7 @@ def cycle_sequence(seq):
 def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
-        strip.fill(wheel(next(g)))
+        strip.fill(colorwheel(next(g)))
         strip.show()
         yield
 

--- a/CircuitPlayground_Christmas_Tree/code.py
+++ b/CircuitPlayground_Christmas_Tree/code.py
@@ -23,9 +23,10 @@ pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=brightness, auto_wr
                            pixel_order=ORDER)
 
 
-def wheel(pos):
+def colorwheel(pos):
     # Input a value 0 to 255 to get a color value.
     # The colours are a transition r - g - b - back to r.
+    # Works with RGB or RGBW LEDs.
     if pos < 0 or pos > 255:
         r = g = b = 0
     elif pos < 85:
@@ -49,7 +50,7 @@ def rainbow_swirl(wait):
     for j in range(255):
         for i in range(num_pixels):
             pixel_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(pixel_index & 255)
+            pixels[i] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(wait)
 
@@ -58,7 +59,7 @@ def rainbow_fill(wait):
     for j in range(255):
         for i in range(num_pixels):
             pixel_index = int(i + j)
-            pixels[i] = wheel(pixel_index & 255)
+            pixels[i] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_AT_Hand_Raiser/code.py
+++ b/CircuitPython_AT_Hand_Raiser/code.py
@@ -8,6 +8,7 @@
 
 from time import sleep
 import board
+from rainbowio import colorwheel
 import adafruit_dotstar
 import supervisor
 
@@ -65,19 +66,6 @@ curColor = black
 # wheel - change hue around the colorwheel (curColor is ignored)
 
 mode='wheel'
-
-# standard function to rotate around the colorwheel
-def wheel(cpos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if cpos < 85:
-        return (int(cpos * 3), int(255 - (cpos * 3)), 0)
-    elif cpos < 170:
-        cpos -= 85
-        return (int(255 - (cpos * 3)), 0, int(cpos * 3))
-    else:
-        cpos -= 170
-        return (0, int(cpos * 3), int(255 - cpos * 3))
 
 # We start by turning off pixels
 pixels.fill(black)
@@ -148,7 +136,7 @@ while True:
         elif mode == 'wheel':
             sleep(.05)
             pos = (pos + 1) % 255
-            pixels.fill(wheel(pos))
+            pixels.fill(colorwheel(pos))
             pixels.show()
         elif mode == 'solid':
             pixels.fill(targetColor)

--- a/CircuitPython_Display_Text/colormask_example/code.py
+++ b/CircuitPython_Display_Text/colormask_example/code.py
@@ -8,23 +8,9 @@ create a color mask cutout
 
 import board
 import displayio
+from rainbowio import colorwheel
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text import bitmap_label as label
-
-
-def wheel(pos):
-    # input a value 0 to 255 to get a color value
-    # the colors are a transition r-g-b-back to r.
-    if pos < 1 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
-
 
 # Make the display context. Change size if you want
 display = board.DISPLAY
@@ -58,7 +44,7 @@ rainbow_bitmap = displayio.Bitmap(
 rainbow_palette = displayio.Palette(255)
 
 for i in range(0, 255):
-    rainbow_palette[i] = int("".join("%02x" % i for i in wheel(i)), 16)
+    rainbow_palette[i] = int("".join("%02x" % i for i in colorwheel(i)), 16)
 
 for y in range(rainbow_bitmap.height):
     for x in range(rainbow_bitmap.width):

--- a/CircuitPython_Essentials/CircuitPython_DotStar/code.py
+++ b/CircuitPython_Essentials/CircuitPython_DotStar/code.py
@@ -1,24 +1,11 @@
 """CircuitPython Essentials DotStar example"""
 import time
+from rainbowio import colorwheel
 import adafruit_dotstar
 import board
 
 num_pixels = 30
 pixels = adafruit_dotstar.DotStar(board.A1, board.A2, num_pixels, brightness=0.1, auto_write=False)
-
-
-def colorwheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 
 def color_fill(color, wait):

--- a/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_rainbow/code.py
+++ b/CircuitPython_Essentials/CircuitPython_Internal_RGB_LED_rainbow/code.py
@@ -1,6 +1,7 @@
 """CircuitPython Essentials Internal RGB LED rainbow example"""
 import time
 import board
+from rainbowio import colorwheel
 
 # For Trinket M0, Gemma M0, ItsyBitsy M0 Express and ItsyBitsy M4 Express
 import adafruit_dotstar
@@ -8,21 +9,6 @@ led = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1)
 # For Feather M0 Express, Metro M0 Express, Metro M4 Express, Circuit Playground Express, QT Py M0
 # import neopixel
 # led = neopixel.NeoPixel(board.NEOPIXEL, 1)
-
-
-def colorwheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
-
 
 led.brightness = 0.3
 

--- a/CircuitPython_Essentials/CircuitPython_NeoPixel/code.py
+++ b/CircuitPython_Essentials/CircuitPython_NeoPixel/code.py
@@ -1,26 +1,13 @@
 """CircuitPython Essentials NeoPixel example"""
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 
 pixel_pin = board.A1
 num_pixels = 8
 
 pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.3, auto_write=False)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 
 def color_chase(color, wait):
@@ -35,7 +22,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_Essentials/CircuitPython_NeoPixel_RGBW/code.py
+++ b/CircuitPython_Essentials/CircuitPython_NeoPixel_RGBW/code.py
@@ -10,7 +10,7 @@ pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.3, auto_write=Fal
                            pixel_order=(1, 0, 2, 3))
 
 
-def wheel(pos):
+def colorwheel(pos):
     # Input a value 0 to 255 to get a color value.
     # The colours are a transition r - g - b - back to r.
     if pos < 0 or pos > 255:
@@ -36,7 +36,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_Heart_Sculpture/code.py
+++ b/CircuitPython_Heart_Sculpture/code.py
@@ -1,6 +1,6 @@
 import time
 import adafruit_dotstar
-import adafruit_pypixelbuf
+from rainbowio import colorwheel
 import board
 import touchio
 
@@ -13,5 +13,5 @@ while True:
     hue = hue + touch.value * 3
     if hue > 255:  # Wrap back around to red
         hue = hue - 255
-    pixel[0] = adafruit_pypixelbuf.colorwheel(hue)
+    pixel[0] = colorwheel(hue)
     time.sleep(.05)

--- a/CircuitPython_Pico_PIO_Neopixel/neopio.py
+++ b/CircuitPython_Pico_PIO_Neopixel/neopio.py
@@ -16,7 +16,7 @@
 import adafruit_pioasm
 import bitops
 import microcontroller
-import _pixelbuf
+import adafruit_pixelbuf
 import rp2pio
 
 _program = """
@@ -68,7 +68,7 @@ def _pin_directly_follows(a, b):
         return False
     return _gpio_order.index(a) + 1 == _gpio_order.index(b)
 
-class NeoPIO(_pixelbuf.PixelBuf):
+class NeoPIO(adafruit_pixelbuf.PixelBuf):
     """
     A sequence of neopixels.
 

--- a/CircuitPython_Quick_Starts/CircuitPython_DotStar/code.py
+++ b/CircuitPython_Quick_Starts/CircuitPython_DotStar/code.py
@@ -1,27 +1,13 @@
 # CircuitPython demo - Dotstar
 
 import time
-
+from rainbowio import colorwheel
 import adafruit_dotstar
 import board
 
 num_pixels = 30
 pixels = adafruit_dotstar.DotStar(
     board.A1, board.A2, num_pixels, brightness=0.1, auto_write=False)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 
 def color_fill(color, wait):
@@ -88,7 +74,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_Quick_Starts/CircuitPython_Internal_RGB_LED_rainbow/code.py
+++ b/CircuitPython_Quick_Starts/CircuitPython_Internal_RGB_LED_rainbow/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import adafruit_dotstar
 import board
 
@@ -10,25 +10,10 @@ led = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1)
 # For Feather M0 Express, Metro M0 Express, and Circuit Playground Express
 # led = neopixel.NeoPixel(board.NEOPIXEL, 1)
 
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
-
-
 led.brightness = 0.3
 
 i = 0
 while True:
     i = (i + 1) % 256  # run from 0 to 255
-    led.fill(wheel(i))
+    led.fill(colorwheel(i))
     time.sleep(0.1)

--- a/CircuitPython_Quick_Starts/CircuitPython_NeoPixel/code.py
+++ b/CircuitPython_Quick_Starts/CircuitPython_NeoPixel/code.py
@@ -1,8 +1,8 @@
 # CircuitPython demo - NeoPixel
 
 import time
-
 import board
+from rainbowio import colorwheel
 import neopixel
 
 pixel_pin = board.A1
@@ -10,20 +10,6 @@ num_pixels = 8
 
 pixels = neopixel.NeoPixel(pixel_pin, num_pixels,
                            brightness=0.3, auto_write=False)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 
 def color_chase(color, wait):
@@ -38,7 +24,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_Quick_Starts/CircuitPython_NeoPixel_RGBW/code.py
+++ b/CircuitPython_Quick_Starts/CircuitPython_NeoPixel_RGBW/code.py
@@ -13,7 +13,7 @@ pixels = neopixel.NeoPixel(pixel_pin, num_pixels,
                            pixel_order=(1, 0, 2, 3))
 
 
-def wheel(pos):
+def colorwheel(pos):
     # Input a value 0 to 255 to get a color value.
     # The colours are a transition r - g - b - back to r.
     if pos < 0 or pos > 255:
@@ -39,7 +39,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/CircuitPython_RGBMatrix/scroller/code.py
+++ b/CircuitPython_RGBMatrix/scroller/code.py
@@ -9,7 +9,7 @@
 
 import array
 
-from _pixelbuf import wheel
+from rainbowio import colorwheel
 import board
 import displayio
 import framebufferio
@@ -92,7 +92,7 @@ def scroll(t, b):
     for i in range(maxlen-linelen):
         # Set the letter displayed at each position, and its color
         for j in range(linelen):
-            sh[j][1] = wheel(3 * (2*i+j))
+            sh[j][1] = colorwheel(3 * (2*i+j))
             tg1[j][0] = charmap[t[i+j]]
             tg2[j][0] = charmap[b[i+j]]
         # And then for each pixel position, move the two labels

--- a/CircuitPython_Templates/status_led_one_neopixel_rainbow/code.py
+++ b/CircuitPython_Templates/status_led_one_neopixel_rainbow/code.py
@@ -1,14 +1,8 @@
 """CircuitPython status NeoPixel rainbow example."""
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
-try:
-    from rainbowio import colorwheel
-except ImportError:
-    try:
-        from _pixelbuf import colorwheel
-    except ImportError:
-        from adafruit_pypixelbuf import colorwheel
 
 pixel = neopixel.NeoPixel(board.NEOPIXEL, 1, auto_write=False)
 

--- a/CircuitPython_Templates/status_multi_dotstar_rainbow/code.py
+++ b/CircuitPython_Templates/status_multi_dotstar_rainbow/code.py
@@ -18,14 +18,8 @@ the pylint: disable.
 
 import time
 import board
+from rainbowio import colorwheel
 import adafruit_dotstar
-try:
-    from rainbowio import colorwheel
-except ImportError:
-    try:
-        from _pixelbuf import colorwheel
-    except ImportError:
-        from adafruit_pypixelbuf import colorwheel
 
 dots = adafruit_dotstar.DotStar(board.DOTSTAR_CLOCK, board.DOTSTAR_DATA, NUMBER_OF_PIXELS, auto_write=False)
 dots.brightness = 0.3

--- a/Crickits/carousel/code.py
+++ b/Crickits/carousel/code.py
@@ -7,6 +7,7 @@ import supervisor
 import audioio
 import audiocore
 import board
+from rainbowio import colorwheel
 import neopixel
 
 # NeoPixels
@@ -62,17 +63,6 @@ def map_range(x, in_min, in_max, out_min, out_max):
         return max(min(mapped, out_max), out_min)
     return min(max(mapped, out_max), out_min)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - (pos * 3)), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
 
 time.sleep(2)
 
@@ -100,7 +90,7 @@ while True:
     pixel_height = map_range(light.value, DARK, BRIGHT, 0, num_pixels)
     pixels.fill((0, 0, 0))
     for p in range(pixel_height):
-        pixels[p] = wheel(int(p / num_pixels * 255))
+        pixels[p] = colorwheel(int(p / num_pixels * 255))
         pixels.show()
 
     # determine squeek

--- a/Cyberpunk_Spikes/code.py
+++ b/Cyberpunk_Spikes/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 from digitalio import DigitalInOut, Direction
@@ -37,7 +37,7 @@ def rainbow(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int(i + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
 
 
@@ -48,27 +48,8 @@ def rainbow_cycle(wait):
     for j in range(255 * 5):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
-
-
-# Input a value 0 to 255 to get a color value.
-# The colours are a transition r - g - b - back to r.
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
 
 
 def flash_random(wait, howmany):

--- a/Disco_Tie/code.py
+++ b/Disco_Tie/code.py
@@ -14,6 +14,7 @@ import array
 import math
 import audiobusio
 import board
+from rainbowio import colorwheel
 import neopixel
 
 from adafruit_ble import BLERadio
@@ -86,34 +87,15 @@ input_floor = normalized_rms(samples) + 10
 input_ceiling = input_floor + 500
 peak = 0
 
-def wheel(wheel_pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if wheel_pos < 0 or wheel_pos > 255:
-        r = g = b = 0
-    elif wheel_pos < 85:
-        r = int(wheel_pos * 3)
-        g = int(255 - wheel_pos*3)
-        b = 0
-    elif wheel_pos < 170:
-        wheel_pos -= 85
-        r = int(255 - wheel_pos*3)
-        g = 0
-        b = int(wheel_pos*3)
-    else:
-        wheel_pos -= 170
-        r = 0
-        g = int(wheel_pos*3)
-        b = int(255 - wheel_pos*3)
-    return (r, g, b)
 
 def rainbow_cycle(delay):
     for j in range(255):
         for i in range(NUM_PIXELS):
             pixel_index = (i * 256 // NUM_PIXELS) + j
-            pixels[i] = wheel(pixel_index & 255)
+            pixels[i] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(delay)
+
 
 def audio_meter(new_peak):
     mic.record(samples, len(samples))

--- a/Gemma_Hoop_Earrings/code.py
+++ b/Gemma_Hoop_Earrings/code.py
@@ -2,7 +2,7 @@
 # few LEDs on at any time...uses MUCH less juice than rainbow display!
 
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 import adafruit_dotstar
@@ -19,25 +19,10 @@ numpix = 16  # Number of NeoPixels (e.g. 16-pixel ring)
 pixpin = board.D0  # Pin where NeoPixels are connected
 strip = neopixel.NeoPixel(pixpin, numpix, brightness=.3, auto_write=False)
 
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(255 - pos*3), int(pos*3), 0)
-    if pos < 170:
-        pos -= 85
-        return (0, int(255 - pos*3), int(pos*3))
-    pos -= 170
-    return (int(pos * 3), 0, int(255 - (pos*3)))
-
-
 mode = 0  # Current animation effect
 offset = 0  # Position of spinner animation
 hue = 0  # Starting hue
-color = wheel(hue & 255)  # hue -> RGB color
+color = colorwheel(hue & 255)  # hue -> RGB color
 prevtime = time.monotonic()  # Time of last animation mode switch
 
 while True:  # Loop forever...
@@ -50,7 +35,7 @@ while True:  # Loop forever...
         # pixel will be refreshed on the next pass.
         strip[i] = [0, 0, 0]
         time.sleep(0.008)  # 8 millisecond delay
-    elif mode == 1:  # Spinny wheel (4 LEDs on at a time)
+    elif mode == 1:  # Spinny colorwheel (4 LEDs on at a time)
         for i in range(numpix):  # For each LED...
             if ((offset + i) & 7) < 2:  # 2 pixels out of 8...
                 strip[i] = color    # are set to current color
@@ -69,6 +54,6 @@ while True:  # Loop forever...
         if mode > 1:  # End of modes?
             mode = 0  # Start over from beginning
             hue += 80  # And change color
-            color = wheel(hue & 255)
+            color = colorwheel(hue & 255)
         strip.fill([0, 0, 0])  # Turn off all pixels
         prevtime = t  # Record time of last mode change

--- a/Gemma_LightTouch/gemma_lighttouch/code.py
+++ b/Gemma_LightTouch/gemma_lighttouch/code.py
@@ -1,6 +1,6 @@
 """Interactive light show using built-in LED and capacitive touch"""
 import time
-
+from rainbowio import colorwheel
 import adafruit_dotstar
 import board
 import touchio
@@ -9,20 +9,6 @@ led = adafruit_dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1)
 touch_A0 = touchio.TouchIn(board.A0)
 touch_A1 = touchio.TouchIn(board.A1)
 touch_A2 = touchio.TouchIn(board.A2)
-
-
-def wheel(pos):
-    """ Input a value 0 to 255 to get a color value.
-    The colours are a transition r - g - b - back to r."""
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
 
 
 def cycle_sequence(seq):
@@ -37,7 +23,7 @@ def rainbow_cycle(seq):
     rainbow_sequence = cycle_sequence(seq)
     while True:
         # pylint: disable=stop-iteration-return
-        led[0] = (wheel(next(rainbow_sequence)))
+        led[0] = (colorwheel(next(rainbow_sequence)))
         yield
 
 

--- a/Getting_Started_With_Raspberry_Pi_Pico/neopixels_rainbow/code.py
+++ b/Getting_Started_With_Raspberry_Pi_Pico/neopixels_rainbow/code.py
@@ -6,8 +6,8 @@ REQUIRED HARDWARE:
 """
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
-from _pixelbuf import colorwheel
 
 # Update this to match the number of NeoPixel LEDs connected to your board.
 num_pixels = 30

--- a/Hacking_Ikea_Lamps_With_CPX/CPX_Spoka_Generators/code.py
+++ b/Hacking_Ikea_Lamps_With_CPX/CPX_Spoka_Generators/code.py
@@ -1,25 +1,9 @@
 import time
-
+from rainbowio import colorwheel
 from adafruit_circuitplayground.express import cpx
 
 
 # pylint: disable=stop-iteration-return
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
-
-
 def cycle_sequence(seq):
     while True:
         for elem in seq:
@@ -29,7 +13,7 @@ def cycle_sequence(seq):
 def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
-        cpx.pixels.fill(wheel(next(g)))
+        cpx.pixels.fill(colorwheel(next(g)))
         yield
 
 

--- a/Hacking_Ikea_Lamps_With_CPX/CPX_Spoka_Motion_Lamp/code.py
+++ b/Hacking_Ikea_Lamps_With_CPX/CPX_Spoka_Motion_Lamp/code.py
@@ -1,20 +1,6 @@
 import time
-
+from rainbowio import colorwheel
 from adafruit_circuitplayground.express import cpx
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
 
 
 # pylint: disable=redefined-outer-name
@@ -49,7 +35,7 @@ def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
         # pylint: disable=stop-iteration-return
-        cpx.pixels.fill(wheel(next(g)))
+        cpx.pixels.fill(colorwheel(next(g)))
         yield
 
 

--- a/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_NeoPixel/code.py
+++ b/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_NeoPixel/code.py
@@ -1,6 +1,7 @@
 # Circuit Playground NeoPixel
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 
 pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, brightness=0.2, auto_write=False)
@@ -11,20 +12,6 @@ color_chase_demo = 1
 flash_demo = 1
 rainbow_demo = 1
 rainbow_cycle_demo = 1
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 
 def color_chase(color, wait):
@@ -39,7 +26,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(10):
             rc_index = (i * 256 // 10) + j * 5
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 
@@ -48,7 +35,7 @@ def rainbow(wait):
     for j in range(255):
         for i in range(len(pixels)):
             idx = int(i + j)
-            pixels[i] = wheel(idx & 255)
+            pixels[i] = colorwheel(idx & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_Neopixel_cpx/code.py
+++ b/Introducing_CircuitPlaygroundExpress/CircuitPlaygroundExpress_Neopixel_cpx/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 from adafruit_circuitplayground.express import cpx
 
 # choose which demos to play
@@ -16,20 +16,6 @@ AQUA = (0, 10, 10)
 BLUE = (0, 0, 10)
 PURPLE = (10, 0, 10)
 BLACK = (0, 0, 0)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - (pos * 3)), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
-
 
 while True:
     cpx.pixels.brightness = 0.2
@@ -86,7 +72,7 @@ while True:
         for j in range(255):
             for i in range(len(cpx.pixels)):
                 idx = int(i + j)
-                cpx.pixels[i] = wheel(idx & 255)
+                cpx.pixels[i] = colorwheel(idx & 255)
             time.sleep(.001)
 
     if rainbowCycleDemo:
@@ -94,5 +80,5 @@ while True:
         for j in range(255):
             for i in range(len(cpx.pixels)):
                 idx = int((i * 256 / len(cpx.pixels)) + j * 10)
-                cpx.pixels[i] = wheel(idx & 255)
+                cpx.pixels[i] = colorwheel(idx & 255)
             time.sleep(.001)

--- a/Introducing_Gemma_M0/Gemma_DotStar/code.py
+++ b/Introducing_Gemma_M0/Gemma_DotStar/code.py
@@ -1,7 +1,7 @@
 # CircuitPython demo - Dotstar
 
 import time
-
+from rainbowio import colorwheel
 import adafruit_dotstar
 import board
 
@@ -9,26 +9,11 @@ numpix = 64
 strip = adafruit_dotstar.DotStar(board.D2, board.D0, numpix, brightness=0.2)
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         strip.show()
         time.sleep(wait)
 

--- a/Introducing_Gemma_M0/Gemma_NeoPixel/code.py
+++ b/Introducing_Gemma_M0/Gemma_NeoPixel/code.py
@@ -1,7 +1,7 @@
 # CircuitPython demo - NeoPixel
 
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 
@@ -11,26 +11,11 @@ numpix = 10
 strip = neopixel.NeoPixel(pixpin, numpix, brightness=0.3, auto_write=False)
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         strip.write()
         time.sleep(wait)
 

--- a/ItsyBitsy_Heart_Necklace/code.py
+++ b/ItsyBitsy_Heart_Necklace/code.py
@@ -1,5 +1,6 @@
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
@@ -27,34 +28,13 @@ ble = BLERadio()
 uart_service = UARTService()
 advertisement = ProvideServicesAdvertisement(uart_service)
 
-#Wheel function for rainbows
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        r = g = b = 0
-    elif pos < 85:
-        r = int(pos * 3)
-        g = int(255 - pos * 3)
-        b = 0
-    elif pos < 170:
-        pos -= 85
-        r = int(255 - pos * 3)
-        g = 0
-        b = int(pos * 3)
-    else:
-        pos -= 170
-        r = 0
-        g = int(pos * 3)
-        b = int(255 - pos * 3)
-    return (r, g, b) if ORDER in (neopixel.RGB, neopixel.GRB) else (r, g, b, 0)
 
 #Rainbow Swirl Animation
 def rainbow_swirl(wait):
     for j in range(255):
         for i in range(num_pixels):
             pixel_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(pixel_index & 255)
+            pixels[i] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(wait)
 
@@ -63,7 +43,7 @@ def rainbow_fill(wait):
     for j in range(255):
         for i in range(num_pixels):
             pixel_index = int(i + j)
-            pixels[i] = wheel(pixel_index & 255)
+            pixels[i] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/ItsyBitsy_Infinity_Collar/code.py
+++ b/ItsyBitsy_Infinity_Collar/code.py
@@ -4,6 +4,7 @@ and color to be controlled by input from the Adafruit Bluefruit App
 """
 import board
 import random
+from rainbowio import colorwheel
 import neopixel
 import digitalio
 from adafruit_debouncer import Debouncer
@@ -14,7 +15,6 @@ from adafruit_led_animation.animation.chase import Chase
 from adafruit_led_animation.animation.rainbowcomet import RainbowComet
 from adafruit_led_animation.animation.pulse import Pulse
 from adafruit_led_animation.sequence import AnimationSequence
-from adafruit_led_animation.color import colorwheel
 
 
 # Bluetooth modules

--- a/LED_Masquerade_Masks/NeoPixel_Gemma_Mask/code.py
+++ b/LED_Masquerade_Masks/NeoPixel_Gemma_Mask/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 
@@ -8,25 +8,9 @@ pixpin = board.D1  # Pin where NeoPixels are connected
 hue = 0  # Starting color
 strip = neopixel.NeoPixel(pixpin, numpix, brightness=0.4)
 
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return [0, 0, 0]
-    elif pos < 85:
-        return [int(pos * 3), int(255 - (pos * 3)), 0]
-    elif pos < 170:
-        pos -= 85
-        return [int(255 - pos * 3), 0, int(pos * 3)]
-    else:
-        pos -= 170
-        return [0, int(pos * 3), int(255 - pos * 3)]
-
-
 while True:  # Loop forever...
     for i in range(numpix):
-        strip[i] = wheel((hue + i * 8) & 255)
+        strip[i] = colorwheel((hue + i * 8) & 255)
     strip.write()
     time.sleep(0.02)  # 20 ms = ~50 fps
     hue = (hue + 1) & 255  # Increment hue and 'wrap around' at 255

--- a/LED_Snowboard/code.py
+++ b/LED_Snowboard/code.py
@@ -17,6 +17,7 @@ import time
 import board
 import digitalio
 from digitalio import DigitalInOut, Direction, Pull
+from rainbowio import colorwheel
 import adafruit_lis3dh
 import neopixel
 from adafruit_led_animation.helper import PixelMap
@@ -29,7 +30,6 @@ from adafruit_led_animation.animation.rainbowcomet import RainbowComet
 from adafruit_led_animation.animation.solid import Solid
 from adafruit_led_animation.animation.chase import Chase
 from adafruit_led_animation.animation.comet import Comet
-from adafruit_led_animation.color import colorwheel
 from adafruit_led_animation.color import (
     BLACK,
     RED,

--- a/Labo_Piano_Light_FX/code.py
+++ b/Labo_Piano_Light_FX/code.py
@@ -1,4 +1,5 @@
 import board
+from rainbowio import colorwheel
 import neopixel
 from analogio import AnalogIn
 
@@ -17,21 +18,6 @@ strip = neopixel.NeoPixel(board.NEOPIXEL, n_pixels,
                           brightness=0.1, auto_write=False)
 strip.fill(0)
 strip.show()
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return (0, int(pos * 3), int(255 - pos * 3))
 
 
 def remapRangeSafe(value, leftMin, leftMax, rightMin, rightMax):
@@ -67,7 +53,7 @@ while True:
     # Color pixels based on rainbow gradient
     vlvl = remapRangeSafe(lvl, 0, 255, wheelStart, wheelEnd)
     for i in range(0, len(strip)):
-        strip[i] = wheel(vlvl)
+        strip[i] = colorwheel(vlvl)
         # Set strip brightness based oncode audio level
         brightness = remapRangeSafe(lvl, 50, 255, 0, maxbrt)
         strip.brightness = float(brightness) / 255.0

--- a/Make_It_Glow_With_Crickit/Crickit-CPX-NeoPixels/code.py
+++ b/Make_It_Glow_With_Crickit/Crickit-CPX-NeoPixels/code.py
@@ -1,6 +1,7 @@
 # Drive NeoPixels on the NeoPixels Block on Crickit for
 #  Circuit Playground Express
 import time
+from rainbowio import colorwheel
 import neopixel
 import board
 
@@ -10,18 +11,6 @@ num_pixels = 30  # Number of pixels driven from Crickit NeoPixel terminal
 pixels = neopixel.NeoPixel(board.A1, num_pixels, brightness=0.3,
                            auto_write=False)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 def color_chase(color, wait):
     for i in range(num_pixels):
@@ -30,11 +19,12 @@ def color_chase(color, wait):
         pixels.show()
     time.sleep(0.5)
 
+
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/Make_It_Glow_With_Crickit/Crickit-Feather-NeoPixels/code.py
+++ b/Make_It_Glow_With_Crickit/Crickit-Feather-NeoPixels/code.py
@@ -1,5 +1,6 @@
 # Drive NeoPixels on the NeoPixels Block on Crickit FeatherWing
 import time
+from rainbowio import colorwheel
 from adafruit_crickit import crickit
 from adafruit_seesaw.neopixel import NeoPixel
 
@@ -7,19 +8,6 @@ num_pixels = 30  # Number of pixels driven from Crickit NeoPixel terminal
 
 # The following line sets up a NeoPixel strip on Seesaw pin 20 for Feather
 pixels = NeoPixel(crickit.seesaw, 20, num_pixels)
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 def color_chase(color, wait):
     for i in range(num_pixels):
@@ -32,7 +20,7 @@ def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/Music_Box_with_Crickit/code.py
+++ b/Music_Box_with_Crickit/code.py
@@ -3,6 +3,7 @@
 
 from adafruit_crickit import crickit
 from analogio import AnalogIn
+from rainbowio import colorwheel
 import neopixel
 import audioio
 import audiocore
@@ -27,22 +28,10 @@ pixels.fill((0, 0, 0))
 # light sensor
 light = AnalogIn(board.LIGHT)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
 
 def rainbow(value):
     for i in range(10):
-        pixels[i] = wheel((value * i) & 255)
+        pixels[i] = colorwheel((value * i) & 255)
 
 
 while True:

--- a/NY_Ball_Drop/code.py
+++ b/NY_Ball_Drop/code.py
@@ -17,6 +17,7 @@ All text above must be included in any redistribution.
 import time
 import random
 import board
+from rainbowio import colorwheel
 from digitalio import DigitalInOut, Direction, Pull
 import busio
 import adafruit_ds3231
@@ -130,18 +131,6 @@ def random_color():
     blue = random_color_byte()
     return (red, green, blue)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos*3), int(pos*3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos*3), int(pos*3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos*3))
 
 def cycle_sequence(seq):
     while True:
@@ -151,7 +140,7 @@ def cycle_sequence(seq):
 def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
-        strip.fill(wheel(next(g)))
+        strip.fill(colorwheel(next(g)))
         strip.show()
         yield
 

--- a/NeoPixel_Basketball_Hoop/NeoPixel_Basketball_Hoop-Point_Sensor/code.py
+++ b/NeoPixel_Basketball_Hoop/NeoPixel_Basketball_Hoop-Point_Sensor/code.py
@@ -1,5 +1,6 @@
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 import adafruit_irremote
 import pwmio
@@ -21,19 +22,6 @@ pwm = pwmio.PWMOut(ir_led, frequency=38000)
 pulses = pulseio.PulseIn(ir_sensor, maxlen=200, idle_state=True)
 decoder = adafruit_irremote.GenericDecode()
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
 
 def timed_rainbow_cycle(seconds, wait):
     # Get the starting time in seconds.
@@ -45,7 +33,7 @@ def timed_rainbow_cycle(seconds, wait):
     while (time.monotonic() - start) < seconds:
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         strip.show()
         # Wait the desired number of milliseconds.
         time.sleep(wait)

--- a/NeoPixel_Basketball_Hoop/NeoPixel_Basketball_Hoop/code.py
+++ b/NeoPixel_Basketball_Hoop/NeoPixel_Basketball_Hoop/code.py
@@ -1,5 +1,6 @@
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 
 pixpin = board.D1
@@ -7,39 +8,29 @@ numpix = 60
 
 strip = neopixel.NeoPixel(pixpin, numpix, brightness=1, auto_write=True)
 
+
 # Fill the dots one after the other with a color
 def colorWipe(color, wait):
     for j in range(len(strip)):
         strip[j] = (color)
         time.sleep(wait)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
 
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
+
 
 def rainbow(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int(i + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
+
 
 while True:
     colorWipe((255, 0, 0), .05)  # red and delay

--- a/NeoPixel_Jewel_10_Minute_Necklace/code.py
+++ b/NeoPixel_Jewel_10_Minute_Necklace/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 
@@ -19,26 +19,11 @@ offset = 0
 prevtime = 0
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
-    for j in range(255 * 6):  # 6 cycles of all colors on wheel
+    for j in range(255 * 6):  # 6 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
@@ -47,25 +32,25 @@ def rainbow(wait):
     for j in range(255):
         for index in range(len(pixels)):
             idx = int(index + j)
-            pixels[index] = wheel(idx & 255)
+            pixels[index] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
 
 def rainbow_cycle_slow(wait):
-    for j in range(255 * 3):  # 3 cycles of all colors on wheel
+    for j in range(255 * 3):  # 3 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
 
 def rainbow_hold(wait):
-    for j in range(255 * 1):  # 3 cycles of all colors on wheel
+    for j in range(255 * 1):  # 3 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
     pixels.write()
     time.sleep(wait)
 

--- a/NeoPixel_Punk_Collar/code.py
+++ b/NeoPixel_Punk_Collar/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 from digitalio import DigitalInOut, Direction
@@ -19,26 +19,11 @@ def colorWipe(color, wait):
         time.sleep(wait)
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int((i * 256 / len(strip)) + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
 
 
@@ -46,7 +31,7 @@ def rainbow(wait):
     for j in range(255):
         for i in range(len(strip)):
             idx = int(i + j)
-            strip[i] = wheel(idx & 255)
+            strip[i] = colorwheel(idx & 255)
         time.sleep(wait)
 
 

--- a/NeoTrellis_M4_Grains_of_Sand/code.py
+++ b/NeoTrellis_M4_Grains_of_Sand/code.py
@@ -31,6 +31,7 @@ import board
 import audioio
 import audiocore
 import busio
+from rainbowio import colorwheel
 import adafruit_trellism4
 import adafruit_adxl34x
 
@@ -107,18 +108,6 @@ def already_present(limit, x, y):
             return True
     return False
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos*3), int(pos*3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos*3), int(pos*3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos*3))
 
 for g in grains:
     placed = False
@@ -147,16 +136,16 @@ while True:
         # Random color every refresh
         if color_mode == 0:
             if occupied_bits[i]:
-                trellis.pixels[(i%8, i//8)] = wheel(random.randint(1, 254))
+                trellis.pixels[(i%8, i//8)] = colorwheel(random.randint(1, 254))
             else:
                 trellis.pixels[(i%8, i//8)] = (0, 0, 0)
         # Color by pixel
         if color_mode == 1:
-            trellis.pixels[(i%8, i//8)] = wheel(i*2) if occupied_bits[i] else (0, 0, 0)
+            trellis.pixels[(i%8, i//8)] = colorwheel(i*2) if occupied_bits[i] else (0, 0, 0)
 
         # Change color to random on button press, or cycle when you hold one down
         if color_mode == 2:
-            trellis.pixels[(i%8, i//8)] = wheel(color) if occupied_bits[i] else (0, 0, 0)
+            trellis.pixels[(i%8, i//8)] = colorwheel(color) if occupied_bits[i] else (0, 0, 0)
 
     # Change color to a new random color on button press
     pressed = set(trellis.pressed_keys)

--- a/NeoTrellis_M4_Memory_Game/code.py
+++ b/NeoTrellis_M4_Memory_Game/code.py
@@ -16,6 +16,7 @@ All text above must be included in any redistribution.
 
 import time
 import random
+from rainbowio import colorwheel
 import adafruit_trellism4
 
 COLORS = [0xFF0000, 0xFFFF00, 0x00FF00, 0x00FFFF, 0x0000FF, 0xFF00FF]
@@ -35,18 +36,6 @@ def index_of(coord):
     x, y = coord
     return y * 8 + x
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos*3), int(pos*3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos*3), int(pos*3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos*3))
 
 def cycle_sequence(seq):
     while True:
@@ -56,7 +45,7 @@ def cycle_sequence(seq):
 def rainbow_lamp(seq):
     g = cycle_sequence(seq)
     while True:
-        trellis.pixels.fill(wheel(next(g)))
+        trellis.pixels.fill(colorwheel(next(g)))
         yield
 
 def splash():

--- a/NeoTrellis_M4_Simple_Drum_Machine/code.py
+++ b/NeoTrellis_M4_Simple_Drum_Machine/code.py
@@ -42,18 +42,6 @@ trellis = adafruit_trellism4.TrellisM4Express(rotation=90)
 i2c = busio.I2C(board.ACCELEROMETER_SCL, board.ACCELEROMETER_SDA)
 accelerometer = adafruit_adxl34x.ADXL345(i2c)
 
-def wheel(pos): # Input a value 0 to 255 to get a color value.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    elif pos < 85:
-        return(int(pos * 3), int(255 - pos*3), 0)
-    elif pos < 170:
-        pos -= 85
-        return(int(255 - pos*3), 0, int(pos * 3))
-    else:
-        pos -= 170
-        return(0, int(pos * 3), int(255 - pos*3))
-
 # Play the welcome wav (if its there)
 with audioio.AudioOut(board.A1, right_channel=board.A0) as audio:
     try:

--- a/NeoTrinkey_Zoom_Shortcuts/code.py
+++ b/NeoTrinkey_Zoom_Shortcuts/code.py
@@ -3,6 +3,7 @@ import board
 import neopixel
 import touchio
 import usb_hid
+from rainbowio import colorwheel
 from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
 from adafruit_hid.keycode import Keycode
@@ -23,26 +24,12 @@ keyboard_layout = KeyboardLayoutUS(keyboard)
 #  variable for the ALT key
 alt_key = Keycode.ALT
 
-#  rainbow cycle animation
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
-
 
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // num_pixels) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/PaperCraft_Gems/code.py
+++ b/PaperCraft_Gems/code.py
@@ -12,13 +12,14 @@ Code by Roy Hooper using Adafruit's LED Animation Library:
 #Import libraries
 import board
 import neopixel
+from rainbowio import colorwheel
 from adafruit_circuitplayground import cp
 from adafruit_led_animation.animation.solid import Solid
 from adafruit_led_animation.animation import Animation
 from adafruit_led_animation.animation.rainbow import Rainbow
 from adafruit_led_animation.animation.sparkle import Sparkle
 from adafruit_led_animation.sequence import AnimationSequence
-from adafruit_led_animation.color import WHITE, colorwheel
+from adafruit_led_animation.color import WHITE
 
 speeds = (0.25, 0.125, 0.1, 0.08, 0.05, 0.02, 0.01)  # Customize speed levels here
 # periods = (7, 6, 5, 4, 3, 2, 1)

--- a/Pixel_Chase_Game/code.py
+++ b/Pixel_Chase_Game/code.py
@@ -1,6 +1,7 @@
 import time
 import random
 import board
+from rainbowio import colorwheel
 import neopixel
 import digitalio
 import adafruit_led_animation.color as color
@@ -16,23 +17,11 @@ num_pixels = 61
 
 pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.2, auto_write=False)
 
-#  wheel and rainbow_cycle setup
-def wheel(pos):
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
-
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(num_pixels):
             rc_index = (i * 256 // 10) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/Playa_Bike/code.py
+++ b/Playa_Bike/code.py
@@ -1,5 +1,6 @@
 import time
 import board
+from rainbowio import colorwheel
 import adafruit_rgbled
 import digitalio
 
@@ -24,23 +25,10 @@ led = adafruit_rgbled.RGBLED(RED_LED, GREEN_LED, BLUE_LED)
 # Optionally, you can also create the RGB LED object with inverted PWM
 # led = adafruit_rgbled.RGBLED(RED_LED, GREEN_LED, BLUE_LED, invert_pwm=True)
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
-
 def rainbow_cycle(wait):
     for i in range(255):
         i = (i + 1) % 256
-        led.color = wheel(i)
+        led.color = colorwheel(i)
         time.sleep(wait)
 
 while True:

--- a/Pumpkin_Theremin/code.py
+++ b/Pumpkin_Theremin/code.py
@@ -1,5 +1,6 @@
 import time
 import board
+from rainbowio import colorwheel
 import adafruit_hcsr04
 from adafruit_circuitplayground.express import cpx
 
@@ -7,19 +8,6 @@ from adafruit_circuitplayground.express import cpx
 sonar = adafruit_hcsr04.HCSR04(trigger_pin=board.D9, echo_pin=board.D6, timeout=0.1)
 pixels = cpx.pixels
 pitchMultiplier = 300   # Change this value to modify the pitch of the theremin.
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 while True:
     try:
@@ -34,7 +22,7 @@ while True:
     # Limits on the distances that trigger sound/light to between 3 and 25 cm.
     if (handDistance >= 3) & (handDistance < 25):
         cpx.play_tone(pitch, 0.1)
-        pixels.fill(wheel(handDistance*10))
+        pixels.fill(colorwheel(handDistance*10))
         pixels.show()
         time.sleep(.00001)
         print(pitch)

--- a/PyLeap_NeoPixel_demo/.circuitpython.skip
+++ b/PyLeap_NeoPixel_demo/.circuitpython.skip
@@ -1,2 +1,0 @@
-PyLeap_NeoPixel_demo/code.py 11: Access to a protected member _pixelbuf of a client class (protected-access)
-PyLeap_NeoPixel_demo/code.py 1: Unused import time (unused-import)

--- a/PyLeap_NeoPixel_demo/code.py
+++ b/PyLeap_NeoPixel_demo/code.py
@@ -1,29 +1,21 @@
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 
 pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, brightness=0.2, auto_write=False)
 rainbow_cycle_demo = 1
 
-def colorwheel(pos):
-            if pos < 0 or pos > 255:
-                return (0, 0, 0)
-            if pos < 85:
-                return (255 - pos * 3, pos * 3, 0)
-            if pos < 170:
-                pos -= 85
-                return (0, 255 - pos * 3, pos * 3)
-            pos -= 170
-            return (pos * 3, 0, 255 - pos * 3)
 
 def rainbow_cycle(wait):
-            for j in range(255):
-                for i in range(10):
-                    rc_index = (i * 256 // 10) + j * 5
-                    pixels[i] = colorwheel(rc_index & 255)
-                pixels.show()
-                time.sleep(wait)
+    for j in range(255):
+        for i in range(10):
+            rc_index = (i * 256 // 10) + j * 5
+            pixels[i] = colorwheel(rc_index & 255)
+        pixels.show()
+        time.sleep(wait)
+
 
 while True:
-            if rainbow_cycle_demo:
-                rainbow_cycle(0.05)
+    if rainbow_cycle_demo:
+        rainbow_cycle(0.05)

--- a/PyRuler_Simon_Game/code.py
+++ b/PyRuler_Simon_Game/code.py
@@ -9,6 +9,7 @@ Code adapted from Miguel Grinberg's Simon game for Circuit Playground Express
 import time
 import random
 import board
+from rainbowio import colorwheel
 from digitalio import DigitalInOut, Direction
 import touchio
 import adafruit_dotstar
@@ -35,24 +36,12 @@ for p in (board.LED4, board.LED5, board.LED6, board.LED7):
 
 cap_touches = [False, False, False, False]
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
 
 def rainbow_cycle(wait):
     for j in range(255):
         for i in range(len(pixels)):
             rc_index = (i * 256 // len(pixels)) + j
-            pixels[i] = wheel(rc_index & 255)
+            pixels[i] = colorwheel(rc_index & 255)
         time.sleep(wait)
 
 def read_caps():

--- a/QT_Py_Bracelet/code.py
+++ b/QT_Py_Bracelet/code.py
@@ -2,6 +2,7 @@
 # the QT Py LED cuff bracelet LEDs.
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
 
 # Total number of LEDs on both strips
@@ -10,18 +11,6 @@ NUM_PIXELS = 14
 pixels = neopixel.NeoPixel(board.MOSI, NUM_PIXELS, pixel_order=neopixel.GRB, auto_write=False, brightness = 0.4
 )
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return (0, 0, 0)
-    if pos < 85:
-        return (255 - pos * 3, pos * 3, 0)
-    if pos < 170:
-        pos -= 85
-        return (0, 255 - pos * 3, pos * 3)
-    pos -= 170
-    return (pos * 3, 0, 255 - pos * 3)
     
 # Scales a tuple by a fraction of 255
 def scale(tup, frac):
@@ -31,7 +20,7 @@ def scale(tup, frac):
 def sawtooth(x):
     return int(2*(127.5 - abs((x % 255) - 127.5)))
 
-# Hue value at the opposite side of the color wheel
+# Hue value at the opposite side of the color colorwheel
 def oppositeHue(x):
     return ((x + 128) % 256)
 
@@ -42,9 +31,9 @@ brightnessSpeed = 3  # bigger value = faster shifts in brightness
 while True:
     bright = sawtooth(brightnessIndex)
     
-    # get RGB color from wheel function and scale it by the brightness
-    mainColor = scale(wheel(hueIndex),bright)
-    oppColor = scale(wheel(oppositeHue(hueIndex)), 255 - bright)
+    # get RGB color from colorwheel function and scale it by the brightness
+    mainColor = scale(colorwheel(hueIndex),bright)
+    oppColor = scale(colorwheel(oppositeHue(hueIndex)), 255 - bright)
 
     # hue and brightness alternate along each strip
     for i in range(NUM_PIXELS//2):

--- a/QT_Py_NeoPixels/code.py
+++ b/QT_Py_NeoPixels/code.py
@@ -1,8 +1,8 @@
 """Basic NeoPixel LED animations for the QT Py."""
 import time
 import board
+from rainbowio import colorwheel
 import neopixel
-import adafruit_pypixelbuf
 
 # Update this to match the pin to which you connected the NeoPixels
 pixel_pin = board.A3
@@ -61,7 +61,7 @@ def rainbow_cycle(wait):
     for color_index in range(255):
         for pixel in range(num_pixels):
             pixel_index = (pixel * 256 // num_pixels) + color_index
-            pixels[pixel] = adafruit_pypixelbuf.colorwheel(pixel_index & 255)
+            pixels[pixel] = colorwheel(pixel_index & 255)
         pixels.show()
         time.sleep(wait)
 

--- a/Rotary_Trinkey/CircuitPython_ColorPicker_Example/code.py
+++ b/Rotary_Trinkey/CircuitPython_ColorPicker_Example/code.py
@@ -2,8 +2,8 @@
 import rotaryio
 import digitalio
 import board
+from rainbowio import colorwheel
 import neopixel
-import _pixelbuf
 
 print("Rotary Trinkey color picker example")
 
@@ -25,7 +25,7 @@ while True:
             else:
                 color -= 1
             color = (color + 256) % 256  # wrap around to 0-256
-            pixel.fill(_pixelbuf.colorwheel(color))
+            pixel.fill(colorwheel(color))
         else:
             # change the brightness
             if position > last_position:  # increase

--- a/Sound_Reactive_NeoPixel_Peace_Pendant/code.py
+++ b/Sound_Reactive_NeoPixel_Peace_Pendant/code.py
@@ -1,5 +1,5 @@
 import array
-
+from rainbowio import colorwheel
 import board
 import neopixel
 from analogio import AnalogIn
@@ -25,20 +25,6 @@ vol = array.array('H', [0] * samples)
 mic_pin = AnalogIn(board.A1)
 
 strip = neopixel.NeoPixel(led_pin, n_pixels, brightness=.1, auto_write=True)
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
 
 
 def remap_range(value, leftMin, leftMax, rightMin, rightMax):
@@ -82,7 +68,7 @@ while True:
         if i >= height:
             strip[i] = [0, 0, 0]
         else:
-            strip[i] = wheel(remap_range(i, 0, (n_pixels - 1), 30, 150))
+            strip[i] = colorwheel(remap_range(i, 0, (n_pixels - 1), 30, 150))
 
     # Save sample for dynamic leveling
     vol[vol_count] = n

--- a/Textile_Potentiometer_Hoodie/code.py
+++ b/Textile_Potentiometer_Hoodie/code.py
@@ -1,5 +1,6 @@
 import analogio
 import board
+from rainbowio import colorwheel
 import neopixel
 
 # Initialize input/output pins
@@ -12,21 +13,6 @@ strip = neopixel.NeoPixel(pix_pin, num_pix, brightness=.15, auto_write=False)
 
 color_value = 0
 sensor_value = 0
-
-
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return 0, 0, 0
-    if pos < 85:
-        return int(pos * 3), int(255 - (pos * 3)), 0
-    elif pos < 170:
-        pos -= 85
-        return int(255 - pos * 3), 0, int(pos * 3)
-
-    pos -= 170
-    return 0, int(pos * 3), int(255 - pos * 3)
 
 
 def remap_range(value, left_min, left_max, right_min, right_max):
@@ -49,5 +35,5 @@ while True:
     color_value = remap_range(sensor.value, 0, 65535, 0, 255)
 
     for i in range(len(strip)):
-        strip[i] = wheel(color_value)
+        strip[i] = colorwheel(color_value)
     strip.write()

--- a/TrellisM4_Simple_MIDI_UART/code.py
+++ b/TrellisM4_Simple_MIDI_UART/code.py
@@ -1,7 +1,7 @@
 # Simple example of sending MIDI via UART to classic DIN-5 (not USB) synth
 
 import adafruit_trellism4
-
+from rainbowio import colorwheel
 import board
 import busio
 midiuart = busio.UART(board.SDA, board.SCL, baudrate=31250)
@@ -9,22 +9,11 @@ print("MIDI UART EXAMPLE")
 
 trellis = adafruit_trellism4.TrellisM4Express()
 
-def wheel(pos):
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return int(255 - pos * 3), int(pos * 3), 0
-    if pos < 170:
-        pos -= 85
-        return 0, int(255 - pos * 3), int(pos * 3)
-    pos -= 170
-    return int(pos * 3), 0, int(255 - (pos * 3))
-
 
 for x in range(trellis.pixels.width):
     for y in range(trellis.pixels.height):
         pixel_index = (((y * 8) + x) * 256 // 2)
-        trellis.pixels[x, y] = wheel(pixel_index & 255)
+        trellis.pixels[x, y] = colorwheel(pixel_index & 255)
 
 current_press = set()
 

--- a/Ukulele/code.py
+++ b/Ukulele/code.py
@@ -22,6 +22,7 @@ import board
 import neopixel
 from ulab.scipy.signal import spectrogram
 from ulab import numpy as np
+from rainbowio import colorwheel
 import adafruit_lsm6ds
 from adafruit_led_animation.helper import PixelMap
 from adafruit_led_animation.sequence import AnimationSequence
@@ -32,7 +33,6 @@ from adafruit_led_animation.animation.rainbowchase import RainbowChase
 from adafruit_led_animation.animation.rainbowcomet import RainbowComet
 from adafruit_led_animation.animation.chase import Chase
 from adafruit_led_animation.animation.comet import Comet
-from adafruit_led_animation.color import colorwheel
 from adafruit_led_animation.color import (
     BLACK,
     RED,

--- a/raver_bandolier/code.py
+++ b/raver_bandolier/code.py
@@ -1,5 +1,5 @@
 import time
-
+from rainbowio import colorwheel
 import board
 import neopixel
 
@@ -19,26 +19,11 @@ offset = 0
 prevtime = 0
 
 
-def wheel(pos):
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if (pos < 0) or (pos > 255):
-        return (0, 0, 0)
-    if pos < 85:
-        return (int(pos * 3), int(255 - (pos * 3)), 0)
-    elif pos < 170:
-        pos -= 85
-        return (int(255 - pos * 3), 0, int(pos * 3))
-
-    pos -= 170
-    return (0, int(pos * 3), int(255 - pos * 3))
-
-
 def rainbow_cycle(wait):
-    for j in range(255 * 6):  # 6 cycles of all colors on wheel
+    for j in range(255 * 6):  # 6 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
@@ -47,25 +32,25 @@ def rainbow(wait):
     for j in range(255):
         for index in range(len(pixels)):
             idx = int(index + j)
-            pixels[index] = wheel(idx & 255)
+            pixels[index] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
 
 def rainbow_cycle_slow(wait):
-    for j in range(255 * 3):  # 3 cycles of all colors on wheel
+    for j in range(255 * 3):  # 3 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
         pixels.write()
         time.sleep(wait)
 
 
 def rainbow_hold(wait):
-    for j in range(255 * 1):  # 3 cycles of all colors on wheel
+    for j in range(255 * 1):  # 3 cycles of all colors on colorwheel
         for r in range(len(pixels)):
             idx = int((r * 255 / len(pixels)) + j)
-            pixels[r] = wheel(idx & 255)
+            pixels[r] = colorwheel(idx & 255)
     pixels.write()
     time.sleep(wait)
 

--- a/ulab_Crunch_Numbers_Fast/ledwave/code.py
+++ b/ulab_Crunch_Numbers_Fast/ledwave/code.py
@@ -2,7 +2,7 @@ import random
 
 import board
 import neopixel
-from rainbowio import colorwheel as wheel
+from rainbowio import colorwheel
 from ulab import numpy as np
 
 # Customize your neopixel configuration here...
@@ -25,7 +25,7 @@ def step(u, um, f, n, dx, dt, c):
 def main():
     # This precomputes the color palette for maximum speed
     # You could change it to compute the color palette of your choice
-    w = [wheel(i) for i in range(256)]
+    w = [colorwheel(i) for i in range(256)]
 
     # This sets up the initial wave as a smooth gradient
     u = np.zeros(num_pixels)
@@ -62,7 +62,7 @@ def main():
         # of control
         u = u * .99
 
-        # incrementing th causes the wheel to slowly cycle even if nothing else is happening
+        # incrementing th causes the colorwheel to slowly cycle even if nothing else is happening
         th = (th + .25) % 256
         pixels.show()
 


### PR DESCRIPTION
Moves all `colorwheel` imports from `_pixelbuf` and `adafruit_pypixelbuf` to `rainbowio`. 

Converts _nearly_ all references to `def wheel()` to use `rainbowio`. There were three `wheel()` functions that are RGBW compatible, and I did not want to remove that functionality from the code as it appears to be referenced in comments. I would like to make `rainbowio` support RGBW, but that is a future thing, so I renamed those `wheel()` functions to `colorwheel()` to make a future update more seamless.