### PR TITLE
use actions-gh-release

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -60,6 +60,7 @@ jobs:
       with:
         files: build/${{ matrix.arduino-platform }}.zip
         fail_on_unmatched_files: false
+        body: "Select the zip file corresponding to your board from the list below."
 
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -51,7 +51,12 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         if [ -d build ]; then
-            cd build && zip -9 -o ${{ matrix.arduino-platform }}.zip *.hex *.bin *.uf2
+            (
+            echo "Built from Adafruit Learning System Guides `git describe --tags` for ${{ matrix.arduino-platform }}"
+            echo "Source code: https://github.com/adafruit/"
+            echo "Adafruit Learning System: https://learn.adafruit.com/"
+            ) > build/README.txt
+            cd build && zip -9 -o ${{ matrix.arduino-platform }}.zip *.hex *.bin *.uf2 *.txt
         fi
 
     - name: Create release

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -47,6 +47,20 @@ jobs:
             build/*.bin
             build/*.uf2
 
+    - name: Zip release files
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        if [ -d build ]; then
+            cd build && zip -9 -o ${{ matrix.arduino-platform }}.zip *.hex *.bin *.uf2
+        fi
+
+    - name: Create release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: build/${{ matrix.arduino-platform }}.zip
+        fail_on_unmatched_files: false
+
   pylint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
.. to create a release from a tag, and upload the desired artifacts to it. This is the next step towards producing automatic, *nightly* releases with useful artifacts.

Here's a release created with this CI: https://github.com/jepler/Adafruit_Learning_System_Guides/releases/tag/v0.0%2B1633967579

![image](https://user-images.githubusercontent.com/1517291/136820892-9a9e43ea-0636-4ae0-86a0-ad5048d81b52.png)

![image](https://user-images.githubusercontent.com/1517291/136820928-284280c1-a127-4d8f-a7b6-d082868fcbee.png)

To cause releases to be made nightly, we can add a "cron" job either in this repo or (as is done for learn) in the adabot repo. My understanding is that this job would simply create & push a new tag.

Other rough edges:
 * The build isn't identified in any way inside the zip files
 * the release notes attached to the release are not meaningful