### PR TITLE
HID Keyboard: handle delayed and terminated connections

### DIFF
--- a/CircuitPython_Essentials/CircuitPython_HID_Keyboard/code.py
+++ b/CircuitPython_Essentials/CircuitPython_HID_Keyboard/code.py
@@ -39,10 +39,11 @@ while True:
         try:
             # The keyboard object!
             keyboard = Keyboard(usb_hid.devices)
-            keyboard_layout = KeyboardLayoutUS(keyboard)  # We're in the US :)
             break  # successfully connected, leave the connection loop
         except:
             time.sleep(1.0)
+
+    keyboard_layout = KeyboardLayoutUS(keyboard)  # We're in the US :)
 
     try:  # catch exceptions due to terminated connection, e.g. when the PC is shut down
         print("Waiting for key pin...")


### PR DESCRIPTION
The example code is used on many projects, but actually it fails on many occasions, e.g. when shutting down and re-starting a PC.

The modifications handle connection problems. They will try until a successful connection is made and when it is dropped, they will re-try.

Unfortunately I don't know which exception types are thrown exactly. So at the moment I have just added `except:`
I could not test exactly this code, as my hardware is different.

Also, it might be a good idea to add example code for `boot.py`:
```
maintenance_mode = ...  # set when e.g. some key is pressed
usb_hid.enable((usb_hid.Device.KEYBOARD,), boot_device=1 if not maintenance_mode else 0)
```

