### PR TITLE
Add blank screen usable when idle

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -35,6 +35,10 @@ class App:
         """ Activate application settings; update OLED labels and LED
             colors. """
         group[13].text = self.name   # Application name
+        if self.name:
+            rect.fill = 0xFFFFFF
+        else: # empty app name indicates blank screen for which we dimm header
+            rect.fill = 0x000000
         for i in range(12):
             if i < len(self.macros): # Key in use, set label + LED color
                 macropad.pixels[i] = self.macros[i][0]
@@ -66,7 +70,8 @@ for key_index in range(12):
                                                 macropad.display.height - 1 -
                                                 (3 - y) * 12),
                              anchor_point=(x / 2, 1.0)))
-group.append(Rect(0, 0, macropad.display.width, 12, fill=0xFFFFFF))
+rect = Rect(0, 0, macropad.display.width, 12, fill=0xFFFFFF)
+group.append(rect)
 group.append(label.Label(terminalio.FONT, text='', color=0x000000,
                          anchored_position=(macropad.display.width//2, -2),
                          anchor_point=(0.5, 0.0)))

--- a/Macropad_Hotkeys/macros/zzz_blank.py
+++ b/Macropad_Hotkeys/macros/zzz_blank.py
@@ -1,0 +1,28 @@
+# MACROPAD Hotkeys: blank screen for idle
+# Contributed by GitHub @vitoni
+
+
+app = {                      # REQUIRED dict, must be named 'app'
+    'name' : '',             # Application name
+    'macros' : [             # List of button macros...
+        # COLOR    LABEL    KEY SEQUENCE
+        # 1st row ----------
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        # 2nd row ----------
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        # 3rd row ----------
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        # 4th row ----------
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        (0x000000, '',          []),
+        # Encoder button ---
+        (0x000000, '',          [])
+    ]
+}


### PR DESCRIPTION
The MacroPad stays active including screen and lights even when the computer it is attached to, goes to sleep. 
This change provides a blank screen, sets all RGB lights to black and disables the bright background of the title bar when the title is empty (as on the blank screen).