### PR TITLE
Magtag project fixes

### DIFF
--- a/MagTag_Sports_Schedule/code.py
+++ b/MagTag_Sports_Schedule/code.py
@@ -25,12 +25,12 @@ TIME_ZONE_NAME = "PST"
 SPORTS = [
     {
         "name": "NCAA Men's Basketball",
-        #pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         "url": "http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard",
     },
     {
         "name": "NCAA Wmn's Basketball",
-        #pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         "url": "http://site.api.espn.com/apis/site/v2/sports/basketball/womens-college-basketball/scoreboard",
     },
     {
@@ -185,7 +185,7 @@ def update_labels():
 
 def fetch_sports_data(reset_game_number=True):
     # Fetches and parses data for all games for the current sport
-    #pylint: disable=global-statement
+    # pylint: disable=global-statement
     global sports_data, current_game, current_sport
     magtag.url = SPORTS[current_sport]["url"]
     sports_data.clear()
@@ -229,12 +229,12 @@ magtag.add_text(text_font="/fonts/Arial-12.bdf", text_position=(10, 40), is_data
 
 # Broadcast Information
 magtag.add_text(
-    text_font="/fonts/Arial-Italic-12.bdf", text_position=(10, 100), is_data=False
+    text_font="/fonts/Arial-Italic-12.bdf", text_position=(10, 98), is_data=False
 )
 
 # Game Status
 magtag.add_text(
-    text_font="/fonts/Arial-Italic-12.bdf", text_position=(10, 120), is_data=False
+    text_font="/fonts/Arial-Italic-12.bdf", text_position=(10, 116), is_data=False
 )
 
 # Game Number

--- a/MagTag_Tides/code.py
+++ b/MagTag_Tides/code.py
@@ -240,6 +240,7 @@ def show_hilo():
         ampm = "A" if h < 12 else "P"
         h = h if h < 13 else h - 12
         hilo_times[i].text = "{:>2}:{:02} {}".format(h, m, ampm)
+        hilo_times[i].hidden = False
 
 
 def time_to_sleep():
@@ -255,6 +256,7 @@ def time_to_sleep():
         remaining += 24 * 60 * 60  # wrap around to the next day
     # return it
     return remaining
+
 
 # ===========
 #  M A I N

--- a/MagTag_Tides/code.py
+++ b/MagTag_Tides/code.py
@@ -231,6 +231,7 @@ def show_hilo():
     for i, data in enumerate(hilo_data):
         # make it visible
         hilo_icons[i].hidden = False
+        hilo_times[i].hidden = False
         # icon
         hilo_icons[i][0] = 0 if data["type"] == "H" else 1
         # time
@@ -240,7 +241,6 @@ def show_hilo():
         ampm = "A" if h < 12 else "P"
         h = h if h < 13 else h - 12
         hilo_times[i].text = "{:>2}:{:02} {}".format(h, m, ampm)
-        hilo_times[i].hidden = False
 
 
 def time_to_sleep():


### PR DESCRIPTION
Resolves: #1945 

@caternuson These are the fixes that we discussed on Discord.

Tide texts were not getting `hidden = False` previously. I think one or more of the libraries got updated at some point and it made this behavior different than it was originally. I ran the Tides project a few months back and the text was visible at that time.

This PR also scoots the bottom line of text a little bit higher in the sports schedule project. Previously the bottom 1 or 2 pixels was partially off the screen.

Also ran black formatting which added a few spaces that were otherwise unrelated to these fixes.

Both changes tested successfully on MagTag with 7.1.0 Beta 1.

Tides Before:
![magtag_tides_before](https://user-images.githubusercontent.com/2406189/145643938-b39137cf-443b-4686-9679-88f09830ba4e.png)

Tides with this change:
![magtag_tides_after](https://user-images.githubusercontent.com/2406189/145643953-e17d4756-86f2-440b-8968-609b6f88ccc5.png)


Sports Schedule Before:
![magtag_sports_before](https://user-images.githubusercontent.com/2406189/145643974-113ce1b5-8c4e-4b3b-8ce5-84971117c5cf.png)

Sports Schedule with this change:
![magtag_sports_after](https://user-images.githubusercontent.com/2406189/145643993-0997ec49-ac33-404a-a75c-1ea715be00b9.png)
