### PR TITLE
print out traceback for errors in Macropad Hotkeys macro files

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -83,7 +83,9 @@ for filename in files:
             apps.append(App(module.app))
         except (SyntaxError, ImportError, AttributeError, KeyError, NameError,
                 IndexError, TypeError) as err:
-            pass
+            print("ERROR in", filename)
+            import traceback
+            traceback.print_exception(err, err, err.__traceback__)
 
 if not apps:
     group[13].text = 'NO MACRO FILES FOUND'


### PR DESCRIPTION
The Macropad Hotkeys script silently ignores errors in `macros/*.py`. This makes it more robust, but also makes debugging user-provided macro definitions more difficult.

@Neradoc suggested adding a traceback print (thanks!). The new behavior is that the errors will be printed to serial output, but the script will still run. 