### PR TITLE
Use default I2C address for NeoSlider CircuitPython example

### DIFF
--- a/Adafruit_NeoSlider/CircuitPython_Rainbow_Slider/code.py
+++ b/Adafruit_NeoSlider/CircuitPython_Rainbow_Slider/code.py
@@ -10,7 +10,7 @@ from adafruit_seesaw.analoginput import AnalogInput
 from adafruit_seesaw import neopixel
 
 # NeoSlider Setup
-neoslider = Seesaw(board.I2C(), 0x31)
+neoslider = Seesaw(board.I2C(), 0x30)
 potentiometer = AnalogInput(neoslider, 18)
 pixels = neopixel.NeoPixel(neoslider, 14, 4)
 


### PR DESCRIPTION
The default out-of-the-bag I2C address for a NeoSlider is `0x30`, but the CircuitPython example is using `0x31.` Changed to `0x30`.

(Noticed this while testing NeoSlider for a customer problem.)