### PR TITLE
Use ubuntu-latest and Python 3.x for CI runs

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -8,12 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         arduino-platform: ["cpb", "cpc", "cpx_ada", "esp32", "esp8266", "feather32u4", "feather_m0_express", "feather_m4_express", "feather_rp2040", "flora", "funhouse", "gemma", "gemma_m0", "hallowing_m0", "hallowing_m4_tinyusb", "magtag", "metro_m0", "metro_m0_tinyusb", "metro_m4", "metro_m4_tinyusb", "monster_m4sk", "monster_m4sk_tinyusb", "neokeytrinkey_m0", "neotrellis_m4", "nrf52832", "nrf52840", "protrinket_5v", "proxlighttrinkey_m0", "pybadge", "pygamer", "pyportal", "qt2040_trinkey", "qtpy_m0", "qtpy_esp32s2", "rotarytrinkey_m0", "slidetrinkey_m0", "trinket_m0", "uno", "trinket_5v", "ledglasses_nrf52840" ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: "3.x"
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:
@@ -72,10 +72,10 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.6
+    - name: Set up Python 3.x
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Dump GitHub context
       env:
@@ -22,10 +22,10 @@ jobs:
 
     - uses: actions/checkout@v2.2.0
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.x
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.x"
 
     - name: Checkout screenshot maker
       run: git clone --depth=1 https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker
@@ -49,4 +49,3 @@ jobs:
         git add *.png index.html
         git remote add origin https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         if git commit -m"update images"; then git push -f origin HEAD:folder-images; fi
-


### PR DESCRIPTION
`runs-on: ubuntu-18.04` is (temporarily) broken and is breaking CI builds.

Update to `ubuntu-latest`. Also update to Python `"3.x"` to avoid getting behind on Python dependencies.