### PR TITLE
use forced content type for pyportal discord

### DIFF
--- a/PyPortal_Discord/code.py
+++ b/PyPortal_Discord/code.py
@@ -7,6 +7,7 @@ If you can find something that spits out text, we can display it!
 import time
 import board
 from adafruit_pyportal import PyPortal
+from adafruit_portalbase.network import CONTENT_TEXT
 
 # Set up where we'll be fetching data from
 DATA_SOURCE = "https://img.shields.io/discord/327254708534116352.svg"
@@ -22,7 +23,7 @@ pyportal = PyPortal(url=DATA_SOURCE, regexp_path=DATA_LOCATION,
 
 while True:
     try:
-        value = pyportal.fetch()
+        value = pyportal.fetch(force_content_type=CONTENT_TEXT)
         print("Response is", value)
     except RuntimeError as e:
         print("Some error occured, retrying! -", e)


### PR DESCRIPTION
The issue that this resolves was raised here: https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/issues/57

This project fetches an SVG file and then parses it as text. 

At some point the PyPortal library got improved features for handling more content types and it started relying on content_type returned by the server. 

In the case of this project it broke because the server is using image/svg type, but we want to ignore image and parse it as text.

This uses the fix introduced with: https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/pull/120

I tested this fix successfully on a PyPortal with 7.1.0