### PR TITLE
Reformatted to reduce each line length.

### DIFF
--- a/Welcome_to_CircuitPython/code.py
+++ b/Welcome_to_CircuitPython/code.py
@@ -6,13 +6,13 @@
 Blink example for boards with ONLY a NeoPixel LED (e.g. without a built-in red LED).
 Includes QT Py and various Trinkeys.
 
-Requires two libraries from the Adafruit CircuitPython Library Bundle. 
-Download the bundle from circuitpython.org/libraries and copy the 
+Requires two libraries from the Adafruit CircuitPython Library Bundle.
+Download the bundle from circuitpython.org/libraries and copy the
 following files to your CIRCUITPY/lib folder:
 * neopixel.mpy
 * adafruit_pypixelbuf.mpy
 
-Once the libraries are copied, save this file as code.py to your CIRCUITPY 
+Once the libraries are copied, save this file as code.py to your CIRCUITPY
 drive to run it.
 """
 import time

--- a/Welcome_to_CircuitPython/code.py
+++ b/Welcome_to_CircuitPython/code.py
@@ -6,12 +6,14 @@
 Blink example for boards with ONLY a NeoPixel LED (e.g. without a built-in red LED).
 Includes QT Py and various Trinkeys.
 
-Requires two libraries from the Adafruit CircuitPython Library Bundle. Download the bundle
-from circuitpython.org/libraries and copy the following files to your CIRCUITPY/lib folder:
+Requires two libraries from the Adafruit CircuitPython Library Bundle. 
+Download the bundle from circuitpython.org/libraries and copy the 
+following files to your CIRCUITPY/lib folder:
 * neopixel.mpy
 * adafruit_pypixelbuf.mpy
 
-Once the libraries are copied, save this file as code.py to your CIRCUITPY drive to run it.
+Once the libraries are copied, save this file as code.py to your CIRCUITPY 
+drive to run it.
 """
 import time
 import board


### PR DESCRIPTION
Max supported line length in Mu (the recommended editor) is 88 charecters. Several lines in the comments section were longer than this. Changed so it may be copy-pasted as directed in tutorial.
