### PR TITLE
add pygamer to esp32 passthru code

### DIFF
--- a/Adafruit_ESP32_Arduino_Demos/SerialESPPassthrough/SerialESPPassthrough.ino
+++ b/Adafruit_ESP32_Arduino_Demos/SerialESPPassthrough/SerialESPPassthrough.ino
@@ -33,7 +33,8 @@ unsigned long baud = 115200;
   defined(ADAFRUIT_ITSYBITSY_M0) || \
   defined(ADAFRUIT_ITSYBITSY_M4_EXPRESS) || \
   defined(ARDUINO_AVR_ITSYBITSY32U4_3V) || \
-  defined(ARDUINO_NRF52_ITSYBITSY)
+  defined(ARDUINO_NRF52_ITSYBITSY) || \
+  defined(ARDUINO_PYGAMER_M4_EXPRESS)
   // Configure the pins used for the ESP32 connection
   #define SerialESP32   Serial1
   #define SPIWIFI       SPI  // The SPI port


### PR DESCRIPTION
Just a one line change to allow PyGamer to be recognized when defining the pins needed to run the passthru.
I ran it with my PyGamer and AirLift feather wing, went from v1.2.2 -> v1.7.4

** Note, my PyGamer doesn't work with the ESP32 if I have an SD card inserted.  There is another thread open for this, but so far no progress.  Flashing the ESP32 wing was my latest attempt to fix this issue.