### PR TITLE
Fix the button code in the NeoPixie_Dust_Bag

### DIFF
--- a/NeoPixie_Dust_Bag/code.py
+++ b/NeoPixie_Dust_Bag/code.py
@@ -22,13 +22,13 @@ delay_mult = 8  # Randomization multiplier, delay speed of the effect
 pixels = neopixel.NeoPixel(
     neo_pin, pixel_count, brightness=.4, auto_write=False)
 
-oldstate = True  # counting touch sensor button pushes
+oldstate = False  # counting touch sensor button pushes
 showcolor = 0  # color mode for cycling
 
-# initialize capacitive touch input
+# initialize external capacitive touch pad (active high)
 button = digitalio.DigitalInOut(touch_pin)
 button.direction = digitalio.Direction.INPUT
-button.pull = digitalio.Pull.UP
+button.pull = digitalio.Pull.DOWN
 
 while True:
 
@@ -83,19 +83,17 @@ while True:
     # get the current button state
     newstate = button.value
 
-    # Check if state changed from high to low (button press).
+    # Check if state changed from low to high (button/touchpad press).
     if newstate and not oldstate:
-        # Short delay to debounce button.
-        time.sleep(0.020)
-
-        # Check if button is still low after debounce.
-        newstate = button.value
-
-    if not newstate:
+        # cycle to next color
         showcolor += 1
 
-    if showcolor > 4:
-        showcolor = 0
+        # limit the cycle to the 5 colors
+        if showcolor > 4:
+            showcolor = 0
+
+        # give feedback to the REPL to debug the touch pad
+        # print("Color:", showcolor)
 
     # Set the last button state to the old state.
     oldstate = newstate

--- a/NeoPixie_Dust_Bag/code.py
+++ b/NeoPixie_Dust_Bag/code.py
@@ -28,7 +28,7 @@ showcolor = 0  # color mode for cycling
 # initialize external capacitive touch pad (active high)
 button = digitalio.DigitalInOut(touch_pin)
 button.direction = digitalio.Direction.INPUT
-button.pull = digitalio.Pull.DOWN
+button.pull = digitalio.Pull.UP
 
 while True:
 


### PR DESCRIPTION
Fixed the button detection to only act on rising edges.
Removed the debounce code (the loop already has a time.sleep in the animation anyway).

The guide uses a Standalone Momentary Capacitive Touch Sensor Breakout ([product 1374](https://www.adafruit.com/product/1374)). Which is active high. So the input pin is pulled down. And not using `touchio` (not without changes to the guide).