### PR TITLE
add midinote and midicc to hotkeys

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2021 Phillip Burgess for Adafruit Industries
-#
-# SPDX-License-Identifier: MIT
-
 """
 A macro/hotkey program for Adafruit MACROPAD. Macro setups are stored in the
 /macros folder (configurable below), load up just the ones you're likely to
@@ -181,6 +177,12 @@ while True:
                         macropad.stop_tone()
                 elif 'play' in item:
                     macropad.play_file(item['play'])
+                elif 'midinote' in item:
+                    macropad.midi.send(macropad.NoteOn(item['midinote'], 127))
+                    time.sleep(0.15)
+                    macropad.midi.send(macropad.NoteOff(item['midinote'], 0))
+                elif 'midicc' in item:
+                    macropad.midi.send(macropad.ControlChange(item['midicc'][0],item['midicc'][1]))
     else:
         # Release any still-pressed keys, consumer codes, mouse buttons
         # Keys and mouse buttons are individually released this way (rather

--- a/Macropad_Hotkeys/macros/midi.py
+++ b/Macropad_Hotkeys/macros/midi.py
@@ -1,16 +1,24 @@
-# MACROPAD Hotkeys example: Tones
+# MACROPAD Hotkeys example: MIDI
 
-# The syntax for Tones in macros is highly peculiar, in order to maintain
+# The syntax for MIDI is based off of Tones in macros, in order to maintain
 # backward compatibility with the original keycode-only macro files.
 # The third item for each macro is a list in brackets, and each value within
 # is normally an integer (Keycode), float (delay) or string (typed literally).
 # Consumer Control codes were added as list-within-list, and then mouse and
-# tone further complicate this by adding dicts-within-list. Each tone-related
-# item is the key 'tone' with either an integer frequency value, or 0 to stop
-# the tone mid-macro (tone is also stopped when key is released).
+# tone and midinote further complicate this by adding dicts-within-list. Each 
+# midinote related item is the key 'midinote' with an integer  value between
+# 0 and 127 as per the MIDI spec.  
+# Unlike the Tone macro the midinote is momentarily played and also stopped 
+# once for keypress.  This is useful for triggering functions within a DAW.
+# (but less useful for playing in instrument directly)
+#
+# The midicc syntax further complicates the syntax by taking a list within
+# brackets containing a CC number and a value between 0 and 127 as per the 
+# MIDI spec.
+
 # Helpful: https://en.wikipedia.org/wiki/Piano_key_frequencies
 
-# This example ONLY shows tones (and delays), but really they can be mixed
+# This example ONLY shows midinote and midicc, but really they can be mixed
 # with other elements (keys, codes, mouse) to provide auditory feedback.
 
 app = {               # REQUIRED dict, must be named 'app'

--- a/Macropad_Hotkeys/macros/midi.py
+++ b/Macropad_Hotkeys/macros/midi.py
@@ -5,15 +5,15 @@
 # The third item for each macro is a list in brackets, and each value within
 # is normally an integer (Keycode), float (delay) or string (typed literally).
 # Consumer Control codes were added as list-within-list, and then mouse and
-# tone and midinote further complicate this by adding dicts-within-list. Each 
+# tone and midinote further complicate this by adding dicts-within-list. Each
 # midinote related item is the key 'midinote' with an integer  value between
-# 0 and 127 as per the MIDI spec.  
-# Unlike the Tone macro the midinote is momentarily played and also stopped 
+# 0 and 127 as per the MIDI spec.
+# Unlike the Tone macro the midinote is momentarily played and also stopped
 # once for keypress.  This is useful for triggering functions within a DAW.
 # (but less useful for playing in instrument directly)
 #
 # The midicc syntax further complicates the syntax by taking a list within
-# brackets containing a CC number and a value between 0 and 127 as per the 
+# brackets containing a CC number and a value between 0 and 127 as per the
 # MIDI spec.
 
 # Helpful: https://en.wikipedia.org/wiki/Piano_key_frequencies

--- a/Macropad_Hotkeys/macros/midi.py
+++ b/Macropad_Hotkeys/macros/midi.py
@@ -1,0 +1,39 @@
+# MACROPAD Hotkeys example: Tones
+
+# The syntax for Tones in macros is highly peculiar, in order to maintain
+# backward compatibility with the original keycode-only macro files.
+# The third item for each macro is a list in brackets, and each value within
+# is normally an integer (Keycode), float (delay) or string (typed literally).
+# Consumer Control codes were added as list-within-list, and then mouse and
+# tone further complicate this by adding dicts-within-list. Each tone-related
+# item is the key 'tone' with either an integer frequency value, or 0 to stop
+# the tone mid-macro (tone is also stopped when key is released).
+# Helpful: https://en.wikipedia.org/wiki/Piano_key_frequencies
+
+# This example ONLY shows tones (and delays), but really they can be mixed
+# with other elements (keys, codes, mouse) to provide auditory feedback.
+
+app = {               # REQUIRED dict, must be named 'app'
+    'name' : 'MIDI', # Application name
+    'macros' : [      # List of button macros...
+        # COLOR    LABEL    KEY SEQUENCE
+        # 1st row ----------
+        (0x200005, 'C4', [{'midinote':48}]),
+        (0x200005, 'D4', [{'midinote':50}]),
+        (0x200005, 'E4', [{'midinote':52}]),
+        # 2nd row ----------
+        (0x000000, '', []),
+        (0x000000, '', []),
+        (0x000000, '', []),
+        # 3rd row ----------
+        (0x000000, '', []),
+        (0x000000, '', []),
+        (0x000000, '', []),
+        # 4th row ----------
+	(0x050000, 'Vol 40', [{'midicc':[7,40]}]),
+        (0x100000, 'Vol 90', [{'midicc':[7,90]}]),
+        (0x200000, 'Vol127', [{'midicc':[7,127]}]),
+        # Encoder button ---
+        (0x000000, '', [])
+    ]
+}


### PR DESCRIPTION
Added a 'midinote' and 'midicc' option for the macros
Created a midi.py example showing how to use.