### PR TITLE
Fix for Feather Knob Sketcher

### DIFF
--- a/CircuitPython_Knob_Sketcher/feather_sketcher/code.py
+++ b/CircuitPython_Knob_Sketcher/feather_sketcher/code.py
@@ -99,9 +99,9 @@ def read_knobs(reads, delay):
     xx = int(map_range(avg_x, 0, 65535, 0, SKETCH_WIDTH - 1))
     yy = int(map_range(avg_y, 0, 65535, 0, SKETCH_HEIGHT - 1))
     if REVERSE_X:
-        xx = SKETCH_WIDTH - xx
+        xx = SKETCH_WIDTH - xx - 1
     if REVERSE_Y:
-        yy = SKETCH_HEIGHT - yy
+        yy = SKETCH_HEIGHT - yy - 1
     return xx, yy
 
 #-------


### PR DESCRIPTION
Oops. Fixes bug hitting "pixel out of bounds" error when at screen limits.