### PR TITLE
Fix digital input example to use NeoPixel.

### DIFF
--- a/Adafruit_QT_Py_ESP32-S2/digital_input/code.py
+++ b/Adafruit_QT_Py_ESP32-S2/digital_input/code.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+CircuitPython Digital Input example - Blinking a built-in NeoPixel LED using a button switch.
+"""
+import board
+import digitalio
+import neopixel
+
+pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+button = digitalio.DigitalInOut(board.BUTTON)
+button.switch_to_input(pull=digitalio.Pull.UP)
+
+while True:
+    if not button.value:
+        pixel.fill((255, 0, 0))
+    else:
+        pixel.fill((0, 0, 0))


### PR DESCRIPTION
Removed a file that shouldn't have been removed. QT Py does not have a built-in red LED.