### PR TITLE
Update local color mid-grey to RGB565

### DIFF
--- a/FunHouse_Arduino_Demos/selftest/selftest.ino
+++ b/FunHouse_Arduino_Demos/selftest/selftest.ino
@@ -10,6 +10,7 @@
 
 #define NUM_DOTSTAR 5
 #define BG_COLOR ST77XX_BLACK
+#define ST77XX_GREY 0x8410   // Colors are in RGB565 format
 
 // display!
 Adafruit_ST7789 tft = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_RESET);
@@ -125,7 +126,7 @@ void loop() {
   tft.setTextColor(ST77XX_YELLOW);
   tft.print("Buttons: ");
   if (! digitalRead(BUTTON_DOWN)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("DOWN pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -133,7 +134,7 @@ void loop() {
   tft.print("DOWN ");
 
   if (! digitalRead(BUTTON_SELECT)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("SELECT pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -141,7 +142,7 @@ void loop() {
   tft.print("SEL ");
   
   if (! digitalRead(BUTTON_UP)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("UP pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -156,7 +157,7 @@ void loop() {
   tft.print("Captouch 6: ");
   touchread = touchRead(6);
   if (touchread < 10000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }
@@ -169,7 +170,7 @@ void loop() {
   tft.print("Captouch 7: ");
   touchread = touchRead(7);
   if (touchread < 20000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }
@@ -183,7 +184,7 @@ void loop() {
   tft.print("Captouch 8: ");
   touchread = touchRead(8);
   if (touchread < 20000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }

--- a/FunHouse_Arduino_Demos/selftest/selftest.ino
+++ b/FunHouse_Arduino_Demos/selftest/selftest.ino
@@ -249,10 +249,10 @@ void loop() {
   /************************** Beep! */
   if (digitalRead(BUTTON_SELECT)) {  
      Serial.println("** Beep! ***");
-     tone(SPEAKER, 988, 100);  // tone1 - B5
-     tone(SPEAKER, 1319, 200); // tone2 - E6
+     fhtone(SPEAKER, 988.0, 100.0);  // tone1 - B5
+     fhtone(SPEAKER, 1319.0, 200.0); // tone2 - E6
      delay(100);
-     //tone(SPEAKER, 2000, 100);
+     //fhtone(SPEAKER, 2000.0, 100.0);
   }
   
   /************************** LEDs */
@@ -270,7 +270,7 @@ void loop() {
 }
 
 
-void tone(uint8_t pin, float frequency, float duration) {
+void fhtone(uint8_t pin, float frequency, float duration) {
   ledcSetup(1, frequency, 8);
   ledcAttachPin(pin, 1);
   ledcWrite(1, 128);

--- a/FunHouse_Arduino_Demos/shipping_demo/shipping_demo.ino
+++ b/FunHouse_Arduino_Demos/shipping_demo/shipping_demo.ino
@@ -10,6 +10,7 @@
 
 #define NUM_DOTSTAR 5
 #define BG_COLOR ST77XX_BLACK
+#define ST77XX_GREY 0x8410   // define mid-grey in RGB565
 
 // display!
 Adafruit_ST7789 tft = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_RESET);
@@ -124,7 +125,7 @@ void loop() {
   tft.setTextColor(ST77XX_YELLOW);
   tft.print("Buttons: ");
   if (! digitalRead(BUTTON_DOWN)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("DOWN pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -132,7 +133,7 @@ void loop() {
   tft.print("DOWN ");
 
   if (! digitalRead(BUTTON_SELECT)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("SELECT pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -140,7 +141,7 @@ void loop() {
   tft.print("SEL ");
   
   if (! digitalRead(BUTTON_UP)) {  
-    tft.setTextColor(0x808080);
+    tft.setTextColor(ST77XX_GREY);
   } else {
     Serial.println("UP pressed");
     tft.setTextColor(ST77XX_WHITE);
@@ -155,7 +156,7 @@ void loop() {
   tft.print("Captouch 6: ");
   touchread = touchRead(6);
   if (touchread < 10000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }
@@ -168,7 +169,7 @@ void loop() {
   tft.print("Captouch 7: ");
   touchread = touchRead(7);
   if (touchread < 20000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }
@@ -182,7 +183,7 @@ void loop() {
   tft.print("Captouch 8: ");
   touchread = touchRead(8);
   if (touchread < 20000 ) {  
-    tft.setTextColor(0x808080, BG_COLOR);
+    tft.setTextColor(ST77XX_GREY, BG_COLOR);
   } else {
     tft.setTextColor(ST77XX_WHITE, BG_COLOR);
   }
@@ -247,10 +248,10 @@ void loop() {
   /************************** Beep! */
   if (digitalRead(BUTTON_SELECT)) {  
      Serial.println("** Beep! ***");
-     tone(SPEAKER, 988, 100);  // tone1 - B5
-     tone(SPEAKER, 1319, 200); // tone2 - E6
+     fhtone(SPEAKER, 988.0, 100.0);  // tone1 - B5
+     fhtone(SPEAKER, 1319.0, 200.0); // tone2 - E6
      delay(100);
-     //tone(SPEAKER, 2000, 100);
+     //fhtone(SPEAKER, 2000.0, 100.0);
   }
   
   /************************** LEDs */
@@ -268,7 +269,7 @@ void loop() {
 }
 
 
-void tone(uint8_t pin, float frequecy, float duration) {
+void fhtone(uint8_t pin, float frequecy, float duration) {
   ledcSetup(1, frequecy * 80, 8);
   ledcAttachPin(pin, 1);
   ledcWrite(1, 128);

--- a/FunHouse_Arduino_Demos/shipping_demo/shipping_demo.ino
+++ b/FunHouse_Arduino_Demos/shipping_demo/shipping_demo.ino
@@ -9,8 +9,8 @@
 #include <Adafruit_AHTX0.h>
 
 #define NUM_DOTSTAR 5
-#define BG_COLOR ST77XX_BLACK
-#define ST77XX_GREY 0x8410   // define mid-grey in RGB565
+#define BG_COLOR ST77XX_BLACK  // Set background to black
+#define ST77XX_GREY 0x8410     // define mid-grey in RGB565
 
 // display!
 Adafruit_ST7789 tft = Adafruit_ST7789(TFT_CS, TFT_DC, TFT_RESET);


### PR DESCRIPTION
A hardcoded value of 0x808080 was in the code for a mid-level grey. This is an RGB888 value, but the ST77XX library uses RGB565 values. A mid-grey in RGB565 is 0x8410. A local define was done to define this as ST77XX_GREY and the new value placed in the calls previously using 0x808080. This solves a compiler integer overflow warning preventing CI from completing.
