### PR TITLE
Ignored hidden filenames created by macOS.

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -81,7 +81,7 @@ apps = []
 files = os.listdir(MACRO_FOLDER)
 files.sort()
 for filename in files:
-    if filename.endswith('.py'):
+    if filename.endswith('.py') and not filename.startswith('._'):
         try:
             module = __import__(MACRO_FOLDER + '/' + filename[:-3])
             apps.append(App(module.app))


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  

This change limited the scope of MacroPad Hotkeys to not look at the hidden filenames created by macOS (e.g. macOS will create a file named `._mac-safari.py` for a file named `mac-safari.py`

- **Describe any known limitations with your change.** 
I only tested this on macOS but this should not do any harm on any other platforms.

- **Please run any tests or examples that can exercise your modified code.** 

This works well on my mac. Without this change the serial console will display error messages about malformed macro format for these `._` files.