### PR TITLE
Adding code for midi friends learn guide

### DIFF
--- a/QT_Py_RP2040_USB_to_Serial_MIDI_Friends/code.py
+++ b/QT_Py_RP2040_USB_to_Serial_MIDI_Friends/code.py
@@ -1,0 +1,36 @@
+import board
+import busio
+import usb_midi
+import adafruit_midi
+# pylint: disable=unused-import
+from adafruit_midi.control_change import ControlChange
+from adafruit_midi.pitch_bend import PitchBend
+from adafruit_midi.note_off import NoteOff
+from adafruit_midi.note_on import NoteOn
+from adafruit_midi.program_change import ProgramChange
+
+#  uart setup
+uart = busio.UART(board.TX, board.RX, baudrate=31250)
+#  midi channel setup
+midi_in_channel = 1
+midi_out_channel = 1
+#  midi setup
+#  UART is setup as the input
+#  USB is setup as the output
+midi = adafruit_midi.MIDI(
+    midi_in=usb_midi.ports[0],
+    midi_out=uart,
+    in_channel=(midi_in_channel - 1),
+    out_channel=(midi_out_channel - 1),
+    debug=False,
+)
+
+while True:
+    #  receive MIDI message over USB
+    msg = midi.receive()
+    #  if a message is received...
+    if msg is not None:
+        #  send that message over UART
+        midi.send(msg)
+        #  print message to REPL for debugging
+        print(msg)

--- a/QT_Py_RP2040_USB_to_Serial_MIDI_Friends/code.py
+++ b/QT_Py_RP2040_USB_to_Serial_MIDI_Friends/code.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Liz Clark for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
 import board
 import busio
 import usb_midi


### PR DESCRIPTION
Adding code for the USB to Serial midi friends learn guide. Using a pylint ignore for unused-import because the midi libraries are used to recognize the incoming midi messages over USB to send over UART