### PR TITLE
change numpad example to emulate keyboard numpad

### DIFF
--- a/Macropad_Hotkeys/macros/numpad.py
+++ b/Macropad_Hotkeys/macros/numpad.py
@@ -11,21 +11,21 @@ app = {                # REQUIRED dict, must be named 'app'
     'macros' : [       # List of button macros...
         # COLOR    LABEL    KEY SEQUENCE
         # 1st row ----------
-        (0x202000, '7', ['7']),
-        (0x202000, '8', ['8']),
-        (0x202000, '9', ['9']),
+        (0x200020, '7', [Keycode.KEYPAD_SEVEN]),
+        (0x200020, '8', [Keycode.KEYPAD_EIGHT]),
+        (0x200020, '9', [Keycode.KEYPAD_NINE]),
         # 2nd row ----------
-        (0x202000, '4', ['4']),
-        (0x202000, '5', ['5']),
-        (0x202000, '6', ['6']),
+        (0x200020, '4', [Keycode.KEYPAD_FOUR]),
+        (0x200020, '5', [Keycode.KEYPAD_FIVE]),
+        (0x200020, '6', [Keycode.KEYPAD_SIX]),
         # 3rd row ----------
-        (0x202000, '1', ['1']),
-        (0x202000, '2', ['2']),
-        (0x202000, '3', ['3']),
+        (0x200020, '1', [Keycode.KEYPAD_ONE]),
+        (0x200020, '2', [Keycode.KEYPAD_TWO]),
+        (0x200020, '3', [Keycode.KEYPAD_THREE]),
         # 4th row ----------
-        (0x101010, '*', ['*']),
-        (0x800000, '0', ['0']),
-        (0x101010, '#', ['#']),
+        (0x200010, '0', [Keycode.KEYPAD_ZERO]),
+        (0x200010, '', [Keycode.KEYPAD_ZERO]),
+        (0x000020, '.', [Keycode.KEYPAD_PERIOD]),
         # Encoder button ---
         (0x000000, '', [Keycode.BACKSPACE])
     ]


### PR DESCRIPTION
The current numpad example emulates a phone keypad. This PR changes it to emulate the numpad section of a keyboard instead, including using the proper keycodes for a numpad and changing the layout to have a double-width `0` key and a period (instead of an asterisk and pound sign).

This allows the macropad to be useful for software that requires a numpad, like with Blender or certain older games.

(it also changes the colors because I'm not a big fan of yellow 😅 )