### PR TITLE
update ondiskbitmap usage for circuitpython 7+, remove fallback for 6

### DIFF
--- a/CircuitPython_displayio/displayio_ondiskbitmap/code.py
+++ b/CircuitPython_displayio/displayio_ondiskbitmap/code.py
@@ -7,36 +7,6 @@ import displayio
 
 display = board.DISPLAY
 
-# Current method valid for CircuitPython 6 & 7
-
-# Open the file
-with open("/purple.bmp", "rb") as bitmap_file:
-
-    # Setup the file as the bitmap data source
-    bitmap = displayio.OnDiskBitmap(bitmap_file)
-
-    # Create a TileGrid to hold the bitmap
-    tile_grid = displayio.TileGrid(
-        bitmap,
-        pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
-    )
-
-    # Create a Group to hold the TileGrid
-    group = displayio.Group()
-
-    # Add the TileGrid to the Group
-    group.append(tile_grid)
-
-    # Add the Group to the Display
-    display.show(group)
-
-    # Loop forever so you can enjoy your image
-    while True:
-        pass
-
-
-# Future method for CircuitPython 7 onwards
-
 # Setup the file as the bitmap data source
 bitmap = displayio.OnDiskBitmap("/purple.bmp")
 


### PR DESCRIPTION
This changes the ondiskbitmap code example embedded on this guide page: https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-a-bitmap to use the newer circuitpython version 7+ method for creating the OnDiskBitmap. 

The <=6 fallback version has been removed. 

I also updated the one reference to similar code on this page: https://learn.adafruit.com/circuitpython-display-support-using-displayio/ui-quickstart