### PR TITLE
Fix for consistent server connection failures

### DIFF
--- a/MagTag_Arduino_Demos/quotes/quotes.ino
+++ b/MagTag_Arduino_Demos/quotes/quotes.ino
@@ -88,6 +88,7 @@ void setup() {
   intneo.show();
   
   Serial.println("\nStarting connection to server...");
+  client.setInsecure();
   if (!client.connect(server, 443)) {
     Serial.println("Connection failed!");
     deepSleep();


### PR DESCRIPTION
The connection to the server consistently fails. Adding
`  client.setInsecure();'
before the request causes it to always succeed.

Above this code some certificate methods are commented out. They can't just be uncommented with the code as is.
