### PR TITLE
adding examples for qt py s3

### DIFF
--- a/Adafruit_QT_Py_ESP32-S3/analog_in/code.py
+++ b/Adafruit_QT_Py_ESP32-S3/analog_in/code.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Liz Clark for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""CircuitPython Analog In Voltage Example for ESP32-S3"""
+import time
+import board
+import analogio
+
+analog_pin = analogio.AnalogIn(board.A0)
+
+
+def get_voltage(pin):
+    return (pin.value * 3.53) / 61285
+
+
+while True:
+    print(get_voltage(analog_pin))
+    time.sleep(0.1)

--- a/Adafruit_QT_Py_ESP32-S3/cap_touch_one_pin/code.py
+++ b/Adafruit_QT_Py_ESP32-S3/cap_touch_one_pin/code.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Liz Clark for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+CircuitPython Capacitive Touch Pin Example for ESP32-S3.
+Print to the serial console when one pin is touched.
+"""
+import time
+import board
+import touchio
+
+touch = touchio.TouchIn(board.A2)
+
+while True:
+    if touch.value:
+        print("Pin touched!")
+    time.sleep(0.1)

--- a/Adafruit_QT_Py_ESP32-S3/cap_touch_two_pins/code.py
+++ b/Adafruit_QT_Py_ESP32-S3/cap_touch_two_pins/code.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Liz Clark for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+CircuitPython Capacitive Two Touch Pin Example for ESP32-S3
+Print to the serial console when a pin is touched.
+"""
+import time
+import board
+import touchio
+
+touch_one = touchio.TouchIn(board.A2)
+touch_two = touchio.TouchIn(board.TX)
+
+while True:
+    if touch_one.value:
+        print("Pin one touched!")
+    if touch_two.value:
+        print("Pin two touched!")
+    time.sleep(0.1)

--- a/Adafruit_QT_Py_ESP32-S3/digital_input/code.py
+++ b/Adafruit_QT_Py_ESP32-S3/digital_input/code.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+CircuitPython Digital Input example - Blinking a built-in NeoPixel LED using a button switch.
+"""
+import board
+import digitalio
+import neopixel
+
+pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+button = digitalio.DigitalInOut(board.BUTTON)
+button.switch_to_input(pull=digitalio.Pull.UP)
+
+while True:
+    if not button.value:
+        pixel.fill((255, 0, 0))
+    else:
+        pixel.fill((0, 0, 0))

--- a/Adafruit_QT_Py_ESP32-S3/storage/boot.py
+++ b/Adafruit_QT_Py_ESP32-S3/storage/boot.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+CircuitPython Essentials Storage CP Filesystem boot.py file
+"""
+import time
+import board
+import digitalio
+import storage
+import neopixel
+
+pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
+
+button = digitalio.DigitalInOut(board.BUTTON)
+button.switch_to_input(pull=digitalio.Pull.UP)
+
+# Turn the NeoPixel blue for one second to indicate when to press the boot button.
+pixel.fill((255, 255, 255))
+time.sleep(1)
+
+# If the button is connected to ground, the filesystem is writable by CircuitPython
+storage.remount("/", readonly=button.value)


### PR DESCRIPTION
adding code examples for the qt py esp32-s3 guide