### PR TITLE
Put Keypad guide examples in Learn repo

### DIFF
--- a/Keypad_Examples/comparing_events/code.py
+++ b/Keypad_Examples/comparing_events/code.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import board
+
+from keypad import Keys, Event
+
+keys = Keys((board.D8, board.D9, board.D10), value_when_pressed=False, pull=True)
+
+LEFT_EVENT = Event(0, True)  # Button 0 (D8) pressed
+RIGHT_EVENT = Event(1, True)  # Button 1 (D9) pressed
+STOP_EVENT = Event(2, True)  # Button 2 (D10) pressed
+
+DIRECTION = {
+    LEFT_EVENT: "LEFT",
+    RIGHT_EVENT: "RIGHT",
+}
+
+while True:
+    event = keys.events.get()
+    if event:
+        if event == STOP_EVENT:
+            print("stop")
+            break
+
+        # Look up the event. If not found, direction is None.
+        direction = DIRECTION.get(event)
+        if direction:
+            print(direction)

--- a/Keypad_Examples/keymatrix/code.py
+++ b/Keypad_Examples/keymatrix/code.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+km = keypad.KeyMatrix(
+    row_pins=(board.A0, board.A1, board.A2, board.A3),
+    column_pins=(board.D0, board.D1, board.D2),
+)
+
+while True:
+    event = km.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/keymatrix_columns_to_anodes/code.py
+++ b/Keypad_Examples/keymatrix_columns_to_anodes/code.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+km = keypad.KeyMatrix(
+    row_pins=(board.D0, board.D1, board.D2, board.D3),
+    column_pins=(board.D4, board.D5, board.D6),
+    columns_to_anodes=True,
+)
+
+while True:
+    event = km.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/longer_interval/code.py
+++ b/Keypad_Examples/longer_interval/code.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+km = keypad.KeyMatrix(
+    row_pins=(board.A0, board.A1, board.A2, board.A3),
+    column_pins=(board.D0, board.D1, board.D2),
+    # Allow 50 msecs to debounce.
+    interval=0.050,
+)
+
+while True:
+    event = km.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/macropad_hid/code.py
+++ b/Keypad_Examples/macropad_hid/code.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import board
+import keypad
+import neopixel
+
+KEY_PINS = (
+    board.KEY1,
+    board.KEY2,
+    board.KEY3,
+    board.KEY4,
+    board.KEY5,
+    board.KEY6,
+    board.KEY7,
+    board.KEY8,
+    board.KEY9,
+    board.KEY10,
+    board.KEY11,
+    board.KEY12,
+)
+
+keys = keypad.Keys(KEY_PINS, value_when_pressed=False, pull=True)
+
+neopixels = neopixel.NeoPixel(board.NEOPIXEL, 12, brightness=0.4)
+
+while True:
+    event = keys.events.get()
+    if event:
+        # A key transition occurred.
+        print(event)
+
+        if event.pressed:
+            # Turn the key blue when pressed
+            neopixels[event.key_number] = (0, 0, 255)
+
+        # This could just be `else:`,
+        # since event.pressed and event.released are opposites.
+        if event.released:
+            neopixels[event.key_number] = (0, 0, 0)

--- a/Keypad_Examples/max_events/code.py
+++ b/Keypad_Examples/max_events/code.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+k = keypad.Keys(
+    (board.D8, board.D9),
+    value_when_pressed=False,
+    pull=True,
+    # Increase event queue size to 128 events.
+    max_events=128,
+)
+
+while True:
+    event = k.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/one_button/code.py
+++ b/Keypad_Examples/one_button/code.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import board
+import keypad
+
+keys = keypad.Keys((board.D5,), value_when_pressed=False, pull=True)
+
+while True:
+    event = keys.events.get()
+    # event will be None if nothing has happened.
+    if event:
+        print(event)

--- a/Keypad_Examples/overflow/code.py
+++ b/Keypad_Examples/overflow/code.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+k = keypad.Keys(
+    (board.D8, board.D9),
+    value_when_pressed=False,
+    pull=True,
+)
+
+while True:
+    # Check if we lost some events.
+    if k.events.overflowed:
+        k.events.clear()  # Empty the event queue.
+        k.reset()  # Forget any existing presses. Start over.
+
+    event = k.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/reuse_event/code.py
+++ b/Keypad_Examples/reuse_event/code.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import board
+import keypad
+
+keys = keypad.Keys((board.D8,), value_when_pressed=False, pull=True)
+
+# Create an event we will reuse over and over.
+event = keypad.Event()
+
+while True:
+    if keys.events.get_into(event):
+        print(event)

--- a/Keypad_Examples/shift_register_keys/code.py
+++ b/Keypad_Examples/shift_register_keys/code.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+k = keypad.ShiftRegisterKeys(
+    clock=board.BUTTON_CLOCK,
+    data=board.BUTTON_OUT,
+    latch=board.BUTTON_LATCH,
+    key_count=8,
+    value_when_pressed=True,
+)
+
+while True:
+    event = k.events.get()
+    if event:
+        print(event)

--- a/Keypad_Examples/snes_controller/code.py
+++ b/Keypad_Examples/snes_controller/code.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import keypad
+import board
+
+SNES_KEY_NAMES = (
+    "B",
+    "Y",
+    "SELECT",
+    "START",
+    "UP",
+    "DOWN",
+    "LEFT",
+    "RIGHT",
+    "A",
+    "X",
+    "L",
+    "R",
+)
+
+shift_k = keypad.ShiftRegisterKeys(
+    clock=board.D5,
+    latch=board.D6,
+    value_to_latch=False,
+    data=board.D7,
+    key_count=12,
+    value_when_pressed=False,
+)
+
+while True:
+    event = shift_k.events.get()
+    if event:
+        print(
+            SNES_KEY_NAMES[event.key_number],
+            "pressed" if event.pressed else "released",
+        )


### PR DESCRIPTION
The examples in the https://learn.adafruit.com/key-pad-matrix-scanning-in-circuitpython Guide were all local to the guide.

- Moved them to the Learn repo
- Expanded fragments into full programs

I will fix up the Guide after this is merged.