### PR TITLE
Fix ArduinoISP.ino word-based address for reading/writing EEPROM

### DIFF
--- a/ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -488,8 +488,10 @@ byte write_eeprom(int length) {
   // here is a word address, so we use here*2
   // this writes byte-by-byte,
   // page writing may be faster (4 bytes at a time)
+  int start = _addr*2;
   for (int x = 0; x < length; x++) {
-    spi_transaction(0xC0, 0x00, _addr*2+x, buff[x]);
+    int addr = start + x;
+    spi_transaction(0xC0, (addr >> 8) & 0xFF, addr & 0xFF, buff[x]);
     delay(45);
   } 
   return STK_OK;
@@ -497,8 +499,9 @@ byte write_eeprom(int length) {
 
 void program_page() {
   byte result = STK_FAILED;
-  int length = 256 * getch() + getch();
-  if (length > 256) {
+  unsigned int length = 256 * getch();
+  length += getch();
+  if (length > param.eepromsize) {
       Serial.write(STK_FAILED);
       error++;
       return;


### PR DESCRIPTION
**Scope**
Allow reading and writing EEPROM with address larger than 256 byte. The provided test would fail without this patch. Fix #2186 

**Test**
1. Test setup: a cloned Arduino Uno (CH340 Serial converter) and ATMega328p
2. The following are the test procedure

```console
$ cat entest.epp 
:020000040000FA
:2000000054686520717569636B2062726F776E20666F78206A756D7073206F76657220740E
:200020006865206C617A7920646F670A54686520717569636B2062726F776E20666F78207C
:200040006A756D7073206F76657220746865206C617A7920646F670A5468652071756963FD
:200060006B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920D4
:20008000646F670A54686520717569636B2062726F776E20666F78206A756D7073206F76B5
:2000A000657220746865206C617A7920646F670A54686520717569636B2062726F776E20FE
:2000C000666F78206A756D7073206F76657220746865206C617A7920646F670A54686520C2
:2000E000717569636B2062726F776E20666F78206A756D7073206F76657220746865206C16
:20010000617A7920646F670A54686520717569636B2062726F776E20666F78206A756D7038
:2001200073206F76657220746865206C617A7920646F670A54686520717569636B20627279
:200140006F776E20666F78206A756D7073206F76657220746865206C617A7920646F670A0E
:2001600054686520717569636B2062726F776E20666F78206A756D7073206F7665722074AD
:200180006865206C617A7920646F670A54686520717569636B2062726F776E20666F78201B
:2001A0006A756D7073206F76657220746865206C617A7920646F670A54686520717569639C
:2001C0006B2062726F776E20666F78206A756D7073206F76657220746865206C617A792073
:2001E000646F670A54686520717569636B2062726F776E20666F78206A756D7073206F7654
:00000001FF

$ avrdude -c avrisp -p m328p -P /dev/ttyUSB0 -b 19200 -U eeprom:w:entest.epp:i

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.03s

avrdude: Device signature = 0x1e950f (probably m328p)
avrdude: reading input file "entest.epp"
avrdude: writing eeprom (512 bytes):

Writing | ################################################## | 100% 25.89s

avrdude: 512 bytes of eeprom written
avrdude: verifying eeprom memory against entest.epp:
avrdude: load data eeprom data from input file entest.epp:
avrdude: input file entest.epp contains 512 bytes
avrdude: reading on-chip eeprom data:

Reading | ################################################## | 100% 2.76s

avrdude: verifying ...
avrdude: 512 bytes of eeprom verified

avrdude: safemode: Fuses OK (E:FD, H:DF, L:E2)

avrdude done.  Thank you.

$ echo dump eeprom 0 300 | avrdude -c stk500v1 -p m328p -P /dev/ttyUSB0 -b 19200 -t

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.03s

avrdude: Device signature = 0x1e950f (probably m328p)
avrdude> dump eeprom 0 300
>>> dump eeprom 0 300 
0000  54 68 65 20 71 75 69 63  6b 20 62 72 6f 77 6e 20  |The quick brown |
0010  66 6f 78 20 6a 75 6d 70  73 20 6f 76 65 72 20 74  |fox jumps over t|
0020  68 65 20 6c 61 7a 79 20  64 6f 67 0a 54 68 65 20  |he lazy dog The |
0030  71 75 69 63 6b 20 62 72  6f 77 6e 20 66 6f 78 20  |quick brown fox |
0040  6a 75 6d 70 73 20 6f 76  65 72 20 74 68 65 20 6c  |jumps over the l|
0050  61 7a 79 20 64 6f 67 0a  54 68 65 20 71 75 69 63  |azy dog The quic|
0060  6b 20 62 72 6f 77 6e 20  66 6f 78 20 6a 75 6d 70  |k brown fox jump|
0070  73 20 6f 76 65 72 20 74  68 65 20 6c 61 7a 79 20  |s over the lazy |
0080  64 6f 67 0a 54 68 65 20  71 75 69 63 6b 20 62 72  |dog The quick br|
0090  6f 77 6e 20 66 6f 78 20  6a 75 6d 70 73 20 6f 76  |own fox jumps ov|
00a0  65 72 20 74 68 65 20 6c  61 7a 79 20 64 6f 67 0a  |er the lazy dog |
00b0  54 68 65 20 71 75 69 63  6b 20 62 72 6f 77 6e 20  |The quick brown |
00c0  66 6f 78 20 6a 75 6d 70  73 20 6f 76 65 72 20 74  |fox jumps over t|
00d0  68 65 20 6c 61 7a 79 20  64 6f 67 0a 54 68 65 20  |he lazy dog The |
00e0  71 75 69 63 6b 20 62 72  6f 77 6e 20 66 6f 78 20  |quick brown fox |
00f0  6a 75 6d 70 73 20 6f 76  65 72 20 74 68 65 20 6c  |jumps over the l|
0100  61 7a 79 20 64 6f 67 0a  54 68 65 20 71 75 69 63  |azy dog The quic|
0110  6b 20 62 72 6f 77 6e 20  66 6f 78 20 6a 75 6d 70  |k brown fox jump|
0120  73 20 6f 76 65 72 20 74  68 65 20 6c              |s over the l    |

avrdude> 
avrdude done.  Thank you.

$ avrdude -c avrisp -p m328p -P /dev/ttyUSB0 -b 19200 -U eeprom:r:-:i

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.03s

avrdude: Device signature = 0x1e950f (probably m328p)
avrdude: reading eeprom memory:

Reading | ################################################## | 100% 5.51s

avrdude: writing output file "<stdout>"
:2000000054686520717569636B2062726F776E20666F78206A756D7073206F76657220740E
:200020006865206C617A7920646F670A54686520717569636B2062726F776E20666F78207C
:200040006A756D7073206F76657220746865206C617A7920646F670A5468652071756963FD
:200060006B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920D4
:20008000646F670A54686520717569636B2062726F776E20666F78206A756D7073206F76B5
:2000A000657220746865206C617A7920646F670A54686520717569636B2062726F776E20FE
:2000C000666F78206A756D7073206F76657220746865206C617A7920646F670A54686520C2
:2000E000717569636B2062726F776E20666F78206A756D7073206F76657220746865206C16
:20010000617A7920646F670A54686520717569636B2062726F776E20666F78206A756D7038
:2001200073206F76657220746865206C617A7920646F670A54686520717569636B20627279
:200140006F776E20666F78206A756D7073206F76657220746865206C617A7920646F670A0E
:2001600054686520717569636B2062726F776E20666F78206A756D7073206F7665722074AD
:200180006865206C617A7920646F670A54686520717569636B2062726F776E20666F78201B
:2001A0006A756D7073206F76657220746865206C617A7920646F670A54686520717569639C
:2001C0006B2062726F776E20666F78206A756D7073206F76657220746865206C617A792073
:2001E000646F670A54686520717569636B2062726F776E20666F78206A756D7073206F7654
:20020000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
:20022000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDE
:20024000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBE
:20026000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9E
:20028000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7E
:2002A000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5E
:2002C000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3E
:2002E000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1E
:20030000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD
:20032000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDD
:20034000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBD
:20036000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9D
:20038000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7D
:2003A000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D
:2003C000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3D
:2003E000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1D
:00000001FF

avrdude: safemode: Fuses OK (E:FD, H:DF, L:E2)

avrdude done.  Thank you.

```
