### PR TITLE
Fix order of days of the week

### DIFF
--- a/Daily_Cheer_Automaton/CircuitPython/code.py
+++ b/Daily_Cheer_Automaton/CircuitPython/code.py
@@ -118,7 +118,7 @@ i2c = io.I2C(board.SCL, board.SDA)  # Change to the appropriate I2C clock & data
 rtc = adafruit_pcf8523.PCF8523(i2c)
 
 # Lookup table for names of days (nicer printing).
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 
 # selected time

--- a/Disconnected_CO2_Data_Logger/code.py
+++ b/Disconnected_CO2_Data_Logger/code.py
@@ -20,7 +20,7 @@ rtc = adafruit_pcf8523.PCF8523(i2c)
 #  start measuring co2 with SCD40
 scd4x.start_periodic_measurement()
 #  list of days to print to the text file on boot
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 # SPI SD_CS pin
 SD_CS = board.D10

--- a/Pulse_Oximeter_Logger/code.py
+++ b/Pulse_Oximeter_Logger/code.py
@@ -43,7 +43,7 @@ log_interval = 2  # you can adjust this to log at a different rate
 I2C = busio.I2C(board.SCL, board.SDA)
 rtc = adafruit_pcf8523.PCF8523(I2C)
 
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 set_time = False
 if set_time:  # change to True if you want to write the time!


### PR DESCRIPTION
Fixes an issue where the order of days is incorrect in some of the guides, I think due to the change made to `adafruit_regester.i2c_bcd_datetime.BCDDateTimeRegister.__get__()`, which fixed the order of week days to be CPython compatible.  This mirrors the change made in https://github.com/adafruit/Adafruit_CircuitPython_DS1307/pull/27 and other similar libraries.

None of these guides need to be updated for content.

Did not test.