### PR TITLE
Portal eyes: TileGrid has its own height property now

### DIFF
--- a/Matrix_Portal_Eyes/code.py
+++ b/Matrix_Portal_Eyes/code.py
@@ -53,7 +53,6 @@ class Sprite(displayio.TileGrid):
         elif isinstance(transparent, int):
             palette.make_transparent(transparent)
         super(Sprite, self).__init__(bitmap, pixel_shader=palette)
-        self.height = bitmap.height
 
 
 # ONE-TIME INITIALIZATION --------------------------------------------------


### PR DESCRIPTION
Don't try to set the height property of Sprite, because [it now inherits it from displayio.TileGrid](https://github.com/adafruit/circuitpython/pull/5749).

Without that change we get the following error in CP 7.2.0 and later:
```py
Traceback (most recent call last):
  File "code.py", line 68, in <module>
  File "code.py", line 56, in __init__
AttributeError: 'Sprite' object has no attribute 'height'
```