### PR TITLE
RGB_LED_Strips: Change sleep from 10 seconds to 10 milliseconds

### DIFF
--- a/RGB_LED_Strips/code.py
+++ b/RGB_LED_Strips/code.py
@@ -30,29 +30,29 @@ def duty_cycle(percent):
 # Fade from nothing up to full red.
 for i in range(100):
     red.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)
 
 # Now fade from violet (red + blue) down to red.
 for i in range(100, -1, -1):
     blue.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)
 
 # Fade from red to yellow (red + green).
 for i in range(100):
     green.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)
 
 # Fade from yellow to green.
 for i in range(100, -1, -1):
     red.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)
 
 # Fade from green to teal (blue + green).
 for i in range(100):
     blue.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)
 
 # Fade from teal to blue.
 for i in range(100, -1, -1):
     green.duty_cycle = duty_cycle(i)
-    time.sleep(FADE_SLEEP)
+    time.sleep(FADE_SLEEP / 1000)


### PR DESCRIPTION
The comment says that `FADE_SLEEP` is the time in milliseconds, but it's passed directly to `time.sleep`, which takes the time in seconds.

With a delay of 10 seconds it doesn't look like anything's happening – it'll take 15 minutes the first colour to fully fade in, This surely isn't what was intended.
