### PR TITLE
update comment to reference pwmio instead of pulseio

### DIFF
--- a/MetroX_CircuitPython/fading_led/code.py
+++ b/MetroX_CircuitPython/fading_led/code.py
@@ -6,7 +6,7 @@
 'fading_led.py'.
 
 =================================================
-fades a LED using pulseio's PWM
+fades a LED using pwmio's PWM
 """
 
 import time


### PR DESCRIPTION
This code was updated previously to use `pwmio` instead of `pulseio` but the comment remained mentioning `pulseio`

This change updates the comment to reflect the current version of the code.