### PR TITLE
Don't use "bitmap" property of TileGrid objects

### DIFF
--- a/ulab_Crunch_Numbers_Fast/waterfall/code.py
+++ b/ulab_Crunch_Numbers_Fast/waterfall/code.py
@@ -36,15 +36,15 @@ for i, pi in enumerate((0xff0000, 0xff0a00, 0xff1400, 0xff1e00,
 class RollingGraph(displayio.TileGrid):
     def __init__(self, scale=2):
         # Create a bitmap with heatmap colors
-        self.bitmap = displayio.Bitmap(display.width//scale,
+        self._bitmap = displayio.Bitmap(display.width//scale,
                                        display.height//scale, len(palette))
-        super().__init__(self.bitmap, pixel_shader=palette)
+        super().__init__(self._bitmap, pixel_shader=palette)
 
         self.scroll_offset = 0
 
     def show(self, data):
         y = self.scroll_offset
-        bitmap = self.bitmap
+        bitmap = self._bitmap
 
         board.DISPLAY.auto_refresh = False
         offset = max(0, (bitmap.width-len(data))//2)


### PR DESCRIPTION
In 8.0, the TIleGrid adds its own "bitmap" property. This interfered, causing the exception reported in guide feedback:
```
Traceback (most recent call last):
File "code.py", line 59, in
File "code.py", line 40, in __init__
NotImplementedError: Call super().__init__() before accessing native object.
```
