### PR TITLE
Fix PyPlanter; update other catches of requests exceptions

### DIFF
--- a/Adafruit_IO_Air_Quality/code.py
+++ b/Adafruit_IO_Air_Quality/code.py
@@ -168,7 +168,7 @@ while True:
         # Hourly reset
         if cur_time.tm_min == 0:
             prv_mins = 0
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to fetch time, retrying\n", e)
         wifi.reset()
         wifi.connect()
@@ -200,7 +200,7 @@ while True:
             io.send_data(feed_temperature["key"], str(temperature))
             io.send_data(feed_humidity["key"], str(humidity))
             print("Published!")
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Failed to send data to IO, retrying\n", e)
             wifi.reset()
             wifi.connect()

--- a/Adafruit_IO_Power_Relay/code.py
+++ b/Adafruit_IO_Power_Relay/code.py
@@ -129,7 +129,7 @@ client.subscribe(feed_relay)
 while True:
     try: # Poll for new messages on feed_relay
         client.loop()
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         client.reconnect()

--- a/Adafruit_IO_Power_Relay/code_light_sensor/code.py
+++ b/Adafruit_IO_Power_Relay/code_light_sensor/code.py
@@ -169,7 +169,7 @@ while True:
                     print("Published!")
                 prv_sensor_value = sensor_value
             start_time = now
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         client.reconnect()

--- a/Adafruit_IO_Schedule_Trigger/code.py
+++ b/Adafruit_IO_Schedule_Trigger/code.py
@@ -141,7 +141,7 @@ io.get("relay")
 while True:
     try:
         io.loop()
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         io.reconnect()

--- a/Bitcoin_Matrix/code.py
+++ b/Bitcoin_Matrix/code.py
@@ -51,7 +51,7 @@ while True:
     try:
         value = matrixportal.fetch()
         print("Response is", value)
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(3 * 60)  # wait 3 minutes

--- a/Feather_ESP32-S2_TFT_Azure/code.py
+++ b/Feather_ESP32-S2_TFT_Azure/code.py
@@ -216,8 +216,8 @@ while True:
         device.loop()
 	#  if something disrupts the loop, reconnect
     # pylint: disable=broad-except
-    except (ValueError, RuntimeError, OSError, Exception) as e:
-        print("Connection error, reconnecting\n", str(e))
+    except (ValueError, RuntimeError, OSError, ConnectionError) as e:
+        print("Network error, reconnecting\n", str(e))
         supervisor.reload()
         continue
 	#  delay

--- a/MagTag_AdafruitQuotes/code.py
+++ b/MagTag_AdafruitQuotes/code.py
@@ -36,6 +36,6 @@ while True:
         try:
             value = magtag.fetch()
             print("Response is", value)
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Some error occured, retrying! -", e)
         timestamp = time.monotonic()

--- a/MagTag_Cheerlights/code.py
+++ b/MagTag_Cheerlights/code.py
@@ -43,6 +43,6 @@ while True:
             magtag.peripherals.neopixels.fill(color)
             external_pixels.fill(color)
             timestamp = time.monotonic()
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Some error occured, retrying! -", e)
     time.sleep(1)

--- a/MagTag_Cheerlights_LED_Animations/code.py
+++ b/MagTag_Cheerlights_LED_Animations/code.py
@@ -137,7 +137,7 @@ while True:
                 )
 
             timestamp = time.monotonic()
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             # Catch any random errors so the code will continue running.
             print("Some error occured, retrying! -", e)
     try:

--- a/MagTag_CountdownCelebration/code.py
+++ b/MagTag_CountdownCelebration/code.py
@@ -60,7 +60,7 @@ while True:
             seconds = int(datetime_str[17:19])
             rtc.RTC().datetime = time.struct_time((year, month, mday, hours, minutes, seconds, 0, 0, False))
             lasttimefetch_stamp = time.monotonic()
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Some error occured, retrying! -", e)
             continue
 

--- a/MagTag_CovidTracking/code.py
+++ b/MagTag_CovidTracking/code.py
@@ -95,7 +95,7 @@ try:
 
     # OK we're done!
     magtag.peripherals.neopixels.fill(0x000F00) # greten
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occured, trying again later -", e)
 
 time.sleep(2) # let screen finish updating

--- a/MagTag_Covid_Vaccination/code.py
+++ b/MagTag_Covid_Vaccination/code.py
@@ -112,7 +112,7 @@ try:
 
     SECONDS_TO_SLEEP = 24 * 60 * 60  # Sleep for one day
 
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occured, retrying in one hour! -", e)
     seconds_to_sleep = 60 * 60  # Sleep for one hour
 

--- a/MagTag_Killed_By_Google/code.py
+++ b/MagTag_Killed_By_Google/code.py
@@ -95,5 +95,5 @@ while True:
         PAUSE = alarm.time.TimeAlarm(monotonic_time=time.monotonic() + 60 * 60)
         alarm.exit_and_deep_sleep_until_alarms(PAUSE)
 
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)

--- a/MagTag_NYC_Positivity/code.py
+++ b/MagTag_NYC_Positivity/code.py
@@ -43,7 +43,7 @@ while True:
             qn_idx = header.index("Queens")
             si_idx = header.index("Staten Island")
             nyc_idx = header.index("Citywide")
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Some error occured, retrying! -", e)
             continue
 

--- a/MagTag_Progress_Displays/weblate_translated_percent/code.py
+++ b/MagTag_Progress_Displays/weblate_translated_percent/code.py
@@ -85,6 +85,6 @@ try:
     progress_bar.progress = value[1] / 100.0
     magtag.refresh()
     magtag.exit_and_deep_sleep(24 * 60 * 60)  # one day
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occurred, retrying! -", e)
     magtag.exit_and_deep_sleep(60)  # one minute

--- a/MagTag_Progress_Displays/year_progress_percent/code.py
+++ b/MagTag_Progress_Displays/year_progress_percent/code.py
@@ -67,6 +67,6 @@ try:
     print(now)
     magtag.exit_and_deep_sleep(24 * 60 * 60)  # one day
 
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occurred, retrying after 1 minute! -", e)
     magtag.exit_and_deep_sleep(60)  # one  minute

--- a/MagTag_Quote_Board/code.py
+++ b/MagTag_Quote_Board/code.py
@@ -48,7 +48,7 @@ try:
     magtag.network.connect()
     value = magtag.fetch()
     print("Response is", value)
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     magtag.set_text(e)
     print("Some error occured, retrying later -", e)
 # wait 2 seconds for display to complete

--- a/MagTag_Showerthoughts/code.py
+++ b/MagTag_Showerthoughts/code.py
@@ -50,7 +50,7 @@ try:
     magtag.network.connect()
     value = magtag.fetch()
     print("Response is", value)
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     magtag.set_text(e)
     print("Some error occured, retrying! -", e)
 

--- a/MagTag_SpaceX/code.py
+++ b/MagTag_SpaceX/code.py
@@ -84,7 +84,7 @@ magtag.add_text(
 magtag.add_text(
     text_font=terminalio.FONT,
     text_position=(10, 94),
-    line_spacing=0.8, 
+    line_spacing=0.8,
     text_wrap=47,     # wrap text at this count
     text_transform=details_transform
 )
@@ -95,7 +95,7 @@ try:
     # This statement gets the JSON data and displays it automagically
     value = magtag.fetch()
     print("Response is", value)
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occured, retrying! -", e)
 
 # wait 2 seconds for display to complete

--- a/MagTag_Twitter/code.py
+++ b/MagTag_Twitter/code.py
@@ -68,7 +68,7 @@ magtag.preload_font()
 try:
     value = magtag.fetch()
     print("Response is", value)
-except (ValueError, RuntimeError) as e:
+except (ValueError, RuntimeError, ConnectionError, OSError) as e:
     print("Some error occured, retrying! -", e)
 
 time.sleep(2)

--- a/PyPortal_AWS_IOT_Planter/code.py
+++ b/PyPortal_AWS_IOT_Planter/code.py
@@ -172,6 +172,6 @@ while True:
             # Reset timer
             initial = now
         aws_iot.loop()
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying", e)
         wifi.reset()

--- a/PyPortal_AdafruitIO_Logger/code.py
+++ b/PyPortal_AdafruitIO_Logger/code.py
@@ -88,7 +88,7 @@ while True:
         io.send_data(light_feed['key'], light_value)
         io.send_data(temperature_feed['key'], temperature, precision=2)
         print('Sent to Adafruit IO!')
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         continue

--- a/PyPortal_Azure_Plant_Monitor/code.py
+++ b/PyPortal_Azure_Plant_Monitor/code.py
@@ -97,7 +97,7 @@ while True:
 
         gfx.display_azure_status("Data sent!")
         print("Data sent!")
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         wifi.connect()

--- a/PyPortal_Bitcoin/bitcoin/code.py
+++ b/PyPortal_Bitcoin/bitcoin/code.py
@@ -42,7 +42,7 @@ while True:
     try:
         value = pyportal.fetch()
         print("Response is", value)
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(3*60)  # wait 3 minutes

--- a/PyPortal_Bitcoin/bitcoin_2/code.py
+++ b/PyPortal_Bitcoin/bitcoin_2/code.py
@@ -46,7 +46,7 @@ while True:
     try:
         value = pyportal.fetch()
         print("Response is", value)
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(3*60)  # wait 3 minutes

--- a/PyPortal_GCP_IOT_Planter/code.py
+++ b/PyPortal_GCP_IOT_Planter/code.py
@@ -189,7 +189,7 @@ while True:
             # Reset timer
             initial = now
         google_mqtt.loop()
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, OSError, ConnectionError) as e:
         print("Failed to get data, retrying", e)
         wifi.reset()
         google_mqtt.reconnect()

--- a/PyPortal_GithubStars/code.py
+++ b/PyPortal_GithubStars/code.py
@@ -51,7 +51,7 @@ while True:
             print("New star!")
             pyportal.play_file(cwd+"/coin.wav")
         last_value = value
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(60)  # wait a minute before getting again

--- a/PyPortal_IOT_Scale/code.py
+++ b/PyPortal_IOT_Scale/code.py
@@ -104,7 +104,7 @@ while True:
             text_label.text = 'sending...'
             # send data to Adafruit IO (rounded to one decimal place)
             io.send_data(weight_feed['key'], round(reading.weight, 1))
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("failed to send data..retrying...")
             wifi.reset()
             continue

--- a/PyPortal_LeagueLevel/code.py
+++ b/PyPortal_LeagueLevel/code.py
@@ -52,7 +52,7 @@ while True:
             print("New level!")
             pyportal.play_file(cwd+"/triode_low_fade.wav")
         last_value = value
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occurred, retrying! -", e)
     #check again in two minutes
     time.sleep(60*2)

--- a/PyPortal_Quarantine_Clock/code.py
+++ b/PyPortal_Quarantine_Clock/code.py
@@ -90,7 +90,7 @@ while True:
             refresh_time = time.monotonic()
             # set the_time
             the_time = time.localtime()
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Failed to get data, retrying\n", e)
             esp.reset()
             continue

--- a/PyPortal_Quarantine_Clock/month_clock/code.py
+++ b/PyPortal_Quarantine_Clock/month_clock/code.py
@@ -119,7 +119,7 @@ while True:
             refresh_time = time.monotonic()
             # set the_time
             the_time = time.localtime()
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             print("Failed to get data, retrying\n", e)
             esp.reset()
             continue

--- a/PyPortal_Quotes/code.py
+++ b/PyPortal_Quotes/code.py
@@ -34,6 +34,6 @@ while True:
     try:
         value = pyportal.fetch()
         print("Response is", value)
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
     time.sleep(60)

--- a/PyPortal_Reddit/code.py
+++ b/PyPortal_Reddit/code.py
@@ -42,7 +42,7 @@ while True:
             print("New subscriber!")
             pyportal.play_file(cwd+"/coin.wav")
         last_value = value
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(60)

--- a/PyPortal_Remote/code.py
+++ b/PyPortal_Remote/code.py
@@ -88,7 +88,7 @@ def getchannels():
             channel_dict[name] = chan_id
         response.close()
         return channel_dict
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data\n", e)
         wifi.reset()
         return None
@@ -104,7 +104,7 @@ def sendkey(key):
         if response:
             response.close()
             print("OK")
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data\n", e)
         wifi.reset()
         return
@@ -119,7 +119,7 @@ def sendletter(letter):
         if response:
             response.close()
             print("OK")
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data\n", e)
         wifi.reset()
         return
@@ -135,8 +135,8 @@ def openchannel(channel):
             response.close()
             print("OK")
         response = None
-    except (ValueError, RuntimeError):
-        print("Probably worked")
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
+        print("Probably worked, but got error\n", e)
         wifi.reset()
     response = None
 

--- a/PyPortal_Smart_Thermometer/code.py
+++ b/PyPortal_Smart_Thermometer/code.py
@@ -105,7 +105,7 @@ while True:
             gfx.display_io_status('Data sent!')
         except AdafruitIO_RequestError as e:
             raise AdafruitIO_RequestError('IO Error: ', e)
-    except (ValueError, RuntimeError) as e: # WiFi Connection Failure
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         continue

--- a/PyPortal_TwitterFollowers/code.py
+++ b/PyPortal_TwitterFollowers/code.py
@@ -45,7 +45,7 @@ while True:
             print("New follower!")
             pyportal.play_file(cwd+"/coin.wav")  # uncomment make a noise!
         last_value = value
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Some error occured, retrying! -", e)
 
     time.sleep(60)  # wait a minute before getting again

--- a/PyPortal_UV_Index/code.py
+++ b/PyPortal_UV_Index/code.py
@@ -82,7 +82,7 @@ while True:
     try:
         json_payload = pyportal.fetch()
         raw_data = json.loads(json_payload)
-    except (ValueError, RuntimeError) as ex:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as ex:
         print('Error: ', ex)
         if isinstance(ex, ValueError):
             print('JSON:', json_payload)

--- a/Smart_Alarm_Clock/code.py
+++ b/Smart_Alarm_Clock/code.py
@@ -439,7 +439,7 @@ while True:
         else:
             pass
         gc.collect()
-    except (ValueError, RuntimeError) as err:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as err:
         print("Failed to get data, retrying\n", err)
         wifi.reset()
         mqtt_client.reconnect()

--- a/pyportal_pet_planter/code.py
+++ b/pyportal_pet_planter/code.py
@@ -23,7 +23,8 @@ from simpleio import map_range
 #---| User Config |---------------
 
 # How often to poll the soil sensor, in seconds
-DELAY_SENSOR = 30
+# Polling every 30 seconds or more may cause connection timeouts
+DELAY_SENSOR = 15
 
 # How often to send data to adafruit.io, in minutes
 DELAY_PUBLISH = 5
@@ -179,7 +180,7 @@ label_status.text = "Connecting..."
 while not esp.is_connected:
     try:
         wifi.connect()
-    except RuntimeError as e:
+    except (RuntimeError, ConnectionError) as e:
         print("could not connect to AP, retrying: ",e)
         wifi.reset()
         continue
@@ -269,7 +270,7 @@ while True:
     # to keep the connection active
     try:
         io.loop()
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying...\n", e)
         wifi.reset()
         continue
@@ -314,7 +315,7 @@ while True:
 
             # reset timer
             initial = now
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, ConnectionError, OSError) as e:
             label_status.text = "ERROR!"
             print("Failed to get data, retrying...\n", e)
             wifi.reset()

--- a/pyportal_weather_station/code.py
+++ b/pyportal_weather_station/code.py
@@ -136,7 +136,7 @@ while True:
             print('Data sent!')
         except AdafruitIO_RequestError as e:
             raise AdafruitIO_RequestError('IO Error: ', e)
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, ConnectionError, OSError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
         continue


### PR DESCRIPTION
`pyportal_pet_planter` was not working; reduced sensor-reading timeout to avoid hitting keep-alive timeout.

In wifi projects, updated exceptions handled to handled new, more correct exceptions thrown: `OSError` (and subclasses), and `ConnectionError`. Before some recent changes in `adafruit_requests`, these were other exceptions like `RuntimeError` or `ValueError`.