### PR TITLE
handle no Display.auto_brightness

### DIFF
--- a/Hallowing_Jump_Sound/jump-sound/code.py
+++ b/Hallowing_Jump_Sound/jump-sound/code.py
@@ -61,7 +61,10 @@ except AttributeError:
 
 AUDIO = audioio.AudioOut(board.SPEAKER)  # Speaker
 
-board.DISPLAY.auto_brightness = False
+try:
+    board.DISPLAY.auto_brightness = False
+except AttributeError:
+    pass
 TOUCH1 = touchio.TouchIn(board.TOUCH1)  # Capacitive touch pads
 TOUCH2 = touchio.TouchIn(board.TOUCH2)
 TOUCH3 = touchio.TouchIn(board.TOUCH3)

--- a/Hallowing_Jump_Sound/stomp-and-roar/code.py
+++ b/Hallowing_Jump_Sound/stomp-and-roar/code.py
@@ -48,7 +48,10 @@ except AttributeError:
 
 AUDIO = audioio.AudioOut(board.SPEAKER)  # Speaker
 
-board.DISPLAY.auto_brightness = False
+try:
+    board.DISPLAY.auto_brightness = False
+except AttributeError:
+    pass
 
 # Set up accelerometer on I2C bus, 4G range:
 I2C = board.I2C()

--- a/PyPortal_MQTT_Control/code.py
+++ b/PyPortal_MQTT_Control/code.py
@@ -63,7 +63,10 @@ def set_backlight(val):
                 off, and ``1`` is 100% brightness.
     """
     val = max(0, min(1.0, val))
-    board.DISPLAY.auto_brightness = False
+    try:
+        board.DISPLAY.auto_brightness = False
+    except AttributeError:
+        pass
     board.DISPLAY.brightness = val
 
 

--- a/PyPortal_Smart_Thermometer/code.py
+++ b/PyPortal_Smart_Thermometer/code.py
@@ -76,7 +76,10 @@ def set_backlight(val):
                 off, and ``1`` is 100% brightness.
     """
     val = max(0, min(1.0, val))
-    board.DISPLAY.auto_brightness = False
+    try:
+        board.DISPLAY.auto_brightness = False
+    except AttributeError:
+        pass
     board.DISPLAY.brightness = val
 
 while True:

--- a/PyPortal_User_Interface/code.py
+++ b/PyPortal_User_Interface/code.py
@@ -51,7 +51,10 @@ switch_state = 0
 # Value between 0 and 1 where 0 is OFF, 0.5 is 50% and 1 is 100% brightness.
 def set_backlight(val):
     val = max(0, min(1.0, val))
-    board.DISPLAY.auto_brightness = False
+    try:
+        board.DISPLAY.auto_brightness = False
+    except AttributeError:
+        pass
     board.DISPLAY.brightness = val
 
 


### PR DESCRIPTION
CircuitPython 8 builds have dropped support for `Display.auto_brightness` (https://github.com/adafruit/circuitpython/pull/6734). These changes handle the attribute no longer being available in 8.x.x, while still working on 7.x.x.

We can't just simply remove the `board.DISPLAY.auto_brightness = False` lines, because then `board.DISPLAY.brightness = something` would not work, because `.brightness` changes are ignored when `.auto_brightness `is `True`.