### PR TITLE
update UART-Between-Boards guide to work around NRF52 bug before CP8

### DIFF
--- a/UART-Between-Boards/code.py
+++ b/UART-Between-Boards/code.py
@@ -65,7 +65,7 @@ while True:
             pass
 
     byte_read = uart.read(1)  # Read one byte over UART lines
-    if byte_read is None:
+    if not byte_read:
         # Nothing read.
         continue
 


### PR DESCRIPTION
On Circuitpython before 8, UART.read() on NRF52 return `b''` instead of `None` if no byte was read.