### PR TITLE
limit images workflow to adafruit fork

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   update-images:
+    if: github.repository_owner == 'adafruit'
     runs-on: ubuntu-latest
     steps:
     - name: Dump GitHub context


### PR DESCRIPTION
This change restricts the folder images workflow to only run in the adafruit fork of this repo so that they won't be generated / committed for other forks.