### PR TITLE
Override ArduinoHttpClient library

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -48,6 +48,8 @@ jobs:
         git clone --quiet https://github.com/adafruit/Talkie /home/runner/Arduino/libraries/Talkie
         git clone --quiet https://github.com/Infineon/arduino-optiga-trust-m /home/runner/Arduino/libraries/arduinoOptigaTrustM
         git clone --quiet https://github.com/adafruit/HID /home/runner/Arduino/libraries/HID_Project
+        rm -rf /home/runner/Arduino/libraries/ArduinoHttpClient
+        git clone --quiet https://github.com/arduino-libraries/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
 
     - name: test platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}


### PR DESCRIPTION
Addresses an issue where current release of ArduinoHttpClient fails Arduino CI due to syntax. Appears to be fixed in library’s main branch but not yet an updated release…when that occurs, this edit can be removed.