### PR TITLE
Adding code for PyLeap CLUE badge

### DIFF
--- a/PyLeap_CLUE_Conference_Badge/code.py
+++ b/PyLeap_CLUE_Conference_Badge/code.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-FileCopyrightText: 2022 Liz Clark for Adafruit Industries (Adapted for CLUE)
-
+#
 # SPDX-License-Identifier: MIT
 
 import board


### PR DESCRIPTION
Adding code for the PyLeap CLUE conference badge. Display is flipped for use with a lanyard.