### PR TITLE
change default layout to use cpy compatible format for rp2040

### DIFF
--- a/Mini_GIF_Players/Mini_GIF_Players.ino
+++ b/Mini_GIF_Players/Mini_GIF_Players.ino
@@ -25,14 +25,20 @@
   Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+  // RP2040 use same flash device that store code for file system. Therefore we
+  // only need to specify start address and size (no need SPI or SS)
+  // By default (start=0, size=0), values that match file system setting in
+  // 'Tools->Flash Size' menu selection will be used.
+  // Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+  // To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+  // size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE) or
+  // subclass Adafruit_FlashTransport_RP2040_CPY. Un-comment either of the
+  // following line:
+  //  Adafruit_FlashTransport_RP2040
+  //    flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+  //                   Adafruit_FlashTransport_RP2040::CPY_SIZE);
+  Adafruit_FlashTransport_RP2040_CPY flashTransport;
 
 #else
   // On-board external flash (QSPI or SPI) macros should already


### PR DESCRIPTION
SPIFlash v4 has updated to better support dynamic flash layout from Arduino IDE. The fixed CPY compatible is supported by new subclass `Adafruit_FlashTransport_RP2040_CPY`

related issue: https://forums.adafruit.com/viewtopic.php?p=946379#p946379

![Screenshot 2022-10-31 23:04:42](https://user-images.githubusercontent.com/249515/199054277-3bf29f46-4cd9-478e-84ab-8060059bd094.png)

