### PR TITLE
Use a different concurrency group name

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -56,7 +56,7 @@ jobs:
 
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ github.event.repository.name }}.${{ github.sha }}
         path: |

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         python-version: "3.x"
     - name: Checkout Current Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: check SPDX licensing
       run: python ./SPDX.py
@@ -26,8 +26,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -98,7 +98,7 @@ jobs:
       run: |
         pip install --force-reinstall pylint==2.7.1
     - name: Checkout Current Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: lint
       run: ./pylint_check.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: folder-images
+  group: folder-images-concurrency # https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/2327
   cancel-in-progress: true
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
 
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.x
       uses: actions/setup-python@v4


### PR DESCRIPTION
.. the other one is haunted.  Closes #2327.

Also upgrades actions/checkout to one that doesn't warn
```
Warning: The `save-state` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```