### PR TITLE
Add NeXT to USB adapter with CircuitPython & RP2040

### DIFF
--- a/CircuitPython_NeXT_Keyboard_RP2040/code.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/code.py
@@ -101,12 +101,11 @@ def modifiers(report):
 
 sm = rp2pio.StateMachine(
     pio_program.assembled,
-    first_sideset_pin=board.D11,
-    first_in_pin=board.D12,
+    first_in_pin=board.MISO,
     pull_in_pin_up=1,
-    first_set_pin=board.D13,
+    first_set_pin=board.MOSI,
     set_pin_count=1,
-    first_out_pin=board.D13,
+    first_out_pin=board.MOSI,
     out_pin_count=1,
     frequency=16 * NEXT_SERIAL_BUS_FREQUENCY,
     in_shift_right=False,

--- a/CircuitPython_NeXT_Keyboard_RP2040/code.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/code.py
@@ -12,11 +12,6 @@ from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keyboard import Keycode
 from adafruit_pioasm import Program
 from adafruit_ticks import ticks_add, ticks_less, ticks_ms
-
-# Customize the power key's keycode. You can change it to `Keycode.POWER` if
-# you really want to accidentally power off your computer!
-POWER_KEY_SENDS = Keycode.F1
-
 from next_keycode import (
     cc_value,
     is_cc,
@@ -25,6 +20,10 @@ from next_keycode import (
     shifted_codes,
     shift_modifiers,
 )
+
+# Customize the power key's keycode. You can change it to `Keycode.POWER` if
+# you really want to accidentally power off your computer!
+POWER_KEY_SENDS = Keycode.F1
 
 # according to https://journal.spencerwnelson.com/entries/nextkb.html the
 # keyboard's timing source is a 455MHz crystal, and the serial data rate is

--- a/CircuitPython_NeXT_Keyboard_RP2040/code.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/code.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Jeff Epler for Adafruit Industries
+# SPDX-License-Identifier: MIT
 import array
 import time
 
@@ -70,8 +72,6 @@ def set_leds(i):
     return pack_message_str(f"0000000001110{i:02b}0000000")
 
 
-TEST1 = pack_message_str("010100")
-TEST2 = pack_message_str("001010")
 QUERY = pack_message_str("000001000", 1)
 RESET = pack_message_str("0111101111110000000000")
 
@@ -84,7 +84,7 @@ def is_make(report):
 
 
 def is_mod_report(report):
-    return not report & 1
+    return not bool(report & BIT_MOD)
 
 
 # keycode bits are backwards compared to other information sources

--- a/CircuitPython_NeXT_Keyboard_RP2040/code.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/code.py
@@ -1,0 +1,170 @@
+import array
+import time
+
+import board
+import rp2pio
+import usb_hid
+from adafruit_hid.consumer_control import ConsumerControl
+from adafruit_hid.consumer_control_code import ConsumerControlCode
+from adafruit_hid.keyboard import Keyboard
+from adafruit_pioasm import Program
+from adafruit_ticks import ticks_add, ticks_less, ticks_ms
+
+from next_keycode import cc_value, is_cc, next_modifiers, next_scancodes
+
+NEXT_SERIAL_BUS_FREQUENCY = (
+    18958  # 455kHz/24 https://journal.spencerwnelson.com/entries/nextkb.html
+)
+
+pio_program = Program(
+    """
+top:
+    pull block             ; wait for send request
+    out x, 1               ; trigger receive?
+    out y, 7               ; get count of bits to transmit (minus 1)
+
+    set pins, 1
+bitloop:              
+    out pins, 1        [7] ; send next bit
+    jmp y--, bitloop   [7] ; loop if bits left to send
+
+    set pins, 1            ; idle the bus after last bit
+    jmp !x, top            ; to top if no scancode expected
+
+    set y, 19              ; 20 bits to receive
+
+    wait 0, pin 0 [7]      ; wait for falling edge plus half bit time
+recvloop:
+    in pins, 1 [7]         ; sample in the middle of the bit
+    jmp y--, recvloop [7]  ; loop until all bits read
+
+    push                   ; send report to CircuitPython
+"""
+)
+
+def pack_message(bitcount, data, trigger_receive=False):
+    if bitcount > 24:
+        raise ValueError("too many bits in message")
+    trigger_receive = bool(trigger_receive)
+    message = (
+        (trigger_receive << 31) | ((bitcount - 1) << 24) | (data << (24 - bitcount))
+    )
+    return array.array("I", [message])
+
+
+def pack_message_str(bitstring, trigger_receive=False):
+    bitcount = len(bitstring)
+    data = int(bitstring, 2)
+    return pack_message(bitcount, data, trigger_receive=trigger_receive)
+
+
+def set_leds(i):
+    return pack_message_str(f"0000000001110{i:02b}0000000")
+
+
+TEST1 = pack_message_str("010100")
+TEST2 = pack_message_str("001010")
+QUERY = pack_message_str("000001000", 1)
+RESET = pack_message_str("0111101111110000000000")
+
+BIT_BREAK = 1 << 11
+BIT_MOD = 1
+
+
+def is_make(report):
+    return not bool(report & BIT_BREAK)
+
+
+def is_mod_report(report):
+    return not (report & 1)
+
+
+# keycode bits are backwards compared to other information sources
+# (bit 0 is first)
+def keycode(report):
+    b = f"{report >> 12:07b}"
+    b = "".join(reversed(b))
+    return int(b, 2)
+
+
+def modifiers(report):
+    return (report >> 1) & 0x7F
+
+
+sm = rp2pio.StateMachine(
+    pio_program.assembled,
+    first_sideset_pin=board.D11,
+    first_in_pin=board.D12,
+    pull_in_pin_up=1,
+    first_set_pin=board.D13,
+    set_pin_count=1,
+    first_out_pin=board.D13,
+    out_pin_count=1,
+    frequency=16 * NEXT_SERIAL_BUS_FREQUENCY,
+    in_shift_right=False,
+    wait_for_txstall=False,
+    out_shift_right=False,
+    **pio_program.pio_kwargs,
+)
+
+class KeyboardHandler:
+    def __init__(self):
+        self.old_modifiers = 0
+        self.cc = ConsumerControl(usb_hid.devices)
+        self.kbd = Keyboard(usb_hid.devices)
+
+    def set_key_state(self, key, state):
+        print("set_key_state", key, state)
+        if state:
+            self.kbd.press(key)
+        else:
+            self.kbd.release(key)
+
+    def handle_report(self, value):
+        if value == 1536:
+            return
+
+        if is_mod_report(value):
+            mods = modifiers(value)
+            changes = self.old_modifiers ^ mods
+            self.old_modifiers = mods
+            for i in range(7):
+                bit = 1 << i
+                if changes & bit:  # Modifier key pressed or released
+                    self.set_key_state(next_modifiers[i], mods & bit)
+        else:
+            code = next_scancodes.get(keycode(value))
+            make = is_make(value)
+            if code:
+                if is_cc(code):
+                    if make:
+                        self.cc.send(cc_value(code))
+                else:
+                    self.set_key_state(code, make)
+
+
+handler = KeyboardHandler()
+
+recv_buf = array.array("I", [0])
+
+sm.write(RESET)
+time.sleep(0.1)
+sm.write(set_leds(0))
+time.sleep(0.1)
+
+print("Keyboard ready!")
+
+while True:
+    sm.write(QUERY)
+    deadline = ticks_add(ticks_ms(), 100)
+    while ticks_less(ticks_ms(), deadline):
+        if sm.in_waiting:
+            sm.readinto(recv_buf)
+            value = recv_buf[0]
+            handler.handle_report(value)
+            break
+    else:
+        print("keyboard did not respond - resetting")
+        sm.restart()
+        sm.write(RESET)
+        time.sleep(0.1)

--- a/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
@@ -1,0 +1,103 @@
+from adafruit_hid.consumer_control_code import ConsumerControlCode as C
+from adafruit_hid.keycode import Keycode as K
+
+MASK_CC = 1 << 15
+
+
+def is_cc(value):
+    return value & MASK_CC
+
+
+def cc_value(value):
+    return value & ~MASK_CC
+
+
+next_modifiers = [
+    K.RIGHT_ALT,
+    K.ALT,
+    K.APPLICATION,  # right command
+    K.COMMAND,
+    K.RIGHT_SHIFT,
+    K.SHIFT,
+    K.CONTROL,
+]
+
+next_scancodes = {
+    3: K.BACKSLASH,
+    4: K.RIGHT_BRACKET,
+    5: K.LEFT_BRACKET,
+    6: K.I,
+    7: K.O,
+    8: K.P,
+    9: K.LEFT_ARROW,
+    11: K.KEYPAD_ZERO,
+    12: K.KEYPAD_PERIOD,
+    13: K.KEYPAD_ENTER,
+    15: K.DOWN_ARROW,
+    16: K.RIGHT_ARROW,
+    17: K.KEYPAD_ONE,
+    18: K.KEYPAD_FOUR,
+    19: K.KEYPAD_SIX,
+    20: K.KEYPAD_THREE,
+    21: K.KEYPAD_PLUS,
+    22: K.UP_ARROW,
+    23: K.KEYPAD_TWO,
+    24: K.KEYPAD_FIVE,
+    27: K.BACKSPACE,
+    28: K.EQUALS,
+    29: K.MINUS,
+    30: K.EIGHT,
+    31: K.NINE,
+    32: K.ZERO,
+    33: K.KEYPAD_SEVEN,
+    34: K.KEYPAD_EIGHT,
+    35: K.KEYPAD_NINE,
+    36: K.KEYPAD_MINUS,
+    37: K.KEYPAD_ASTERISK,
+    38: K.GRAVE_ACCENT,
+    39: K.KEYPAD_EQUALS,
+    40: K.KEYPAD_FORWARD_SLASH,
+    42: K.RETURN,
+    43: K.QUOTE,
+    44: K.SEMICOLON,
+    45: K.L,
+    46: K.COMMA,
+    47: K.PERIOD,
+    48: K.FORWARD_SLASH,
+    49: K.Z,
+    50: K.X,
+    51: K.C,
+    52: K.V,
+    53: K.B,
+    54: K.M,
+    55: K.N,
+    56: K.SPACE,
+    57: K.A,
+    58: K.S,
+    59: K.D,
+    60: K.F,
+    61: K.G,
+    62: K.K,
+    63: K.J,
+    64: K.H,
+    65: K.TAB,
+    66: K.Q,
+    67: K.W,
+    68: K.E,
+    69: K.R,
+    70: K.U,
+    71: K.Y,
+    72: K.T,
+    73: K.ESCAPE,
+    74: K.ONE,
+    75: K.TWO,
+    76: K.THREE,
+    77: K.FOUR,
+    78: K.SEVEN,
+    79: K.SIX,
+    80: K.FIVE,
+    26: C.VOLUME_INCREMENT | MASK_CC,
+    2: C.VOLUME_DECREMENT | MASK_CC,
+    25: C.BRIGHTNESS_INCREMENT | MASK_CC,
+    1: C.BRIGHTNESS_DECREMENT | MASK_CC,
+}

--- a/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
@@ -5,7 +5,7 @@ MASK_CC = 1 << 15
 
 
 def is_cc(value):
-    return value & MASK_CC
+    return isinstance(value, int) and (value & MASK_CC)
 
 
 def cc_value(value):
@@ -21,6 +21,8 @@ next_modifiers = [
     K.SHIFT,
     K.CONTROL,
 ]
+
+shift_modifiers = (1<<4) | (1<<5)
 
 next_scancodes = {
     3: K.BACKSLASH,
@@ -100,4 +102,9 @@ next_scancodes = {
     2: C.VOLUME_DECREMENT | MASK_CC,
     25: C.BRIGHTNESS_INCREMENT | MASK_CC,
     1: C.BRIGHTNESS_DECREMENT | MASK_CC,
+}
+
+shifted_codes = {
+    39: K.BACKSLASH, # already shifted
+    40: (K.BACKSLASH,), # will temporarily undo shift
 }

--- a/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
+++ b/CircuitPython_NeXT_Keyboard_RP2040/next_keycode.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Jeff Epler for Adafruit Industries
+# SPDX-License-Identifier: MIT
 from adafruit_hid.consumer_control_code import ConsumerControlCode as C
 from adafruit_hid.keycode import Keycode as K
 


### PR DESCRIPTION
In 2012, Lady Ada wrote a Learn project to convert a NeXT keyboard to USB with an Arduino Micro.

Now, ten years later, the keyboard is still as awesome as ever!  So awesome that for the anniversary we re-did the project with our favorite environment (CircuitPython) and an awesome microcontroller (RP2040)

In draft state for the moment, as I'm going to move the project from the Adafruit Feather RP2040 to the Adafruit QT Py RP2040 instead! It also doesn't handle sending vertical bar or backslash keys as those are in non-standard shifted locations.

This pull request text was typed on the NeXT keyboard!