### PR TITLE
fix httpserver imports. print errors if they occur

### DIFF
--- a/PicoW_CircuitPython_HTTP_Server/code.py
+++ b/PicoW_CircuitPython_HTTP_Server/code.py
@@ -16,7 +16,8 @@ from adafruit_display_text import label
 import adafruit_displayio_ssd1306
 import adafruit_imageload
 from digitalio import DigitalInOut, Direction
-from adafruit_httpserver import HTTPServer, HTTPResponse
+from adafruit_httpserver.server import HTTPServer
+from adafruit_httpserver.response import HTTPResponse
 from adafruit_onewire.bus import OneWireBus
 from adafruit_ds18x20 import DS18X20
 
@@ -249,5 +250,6 @@ while True:
         #  poll the server for incoming/outgoing requests
         server.poll()
     # pylint: disable=broad-except
-    except Exception:
+    except Exception as e:
+        print(e)
         continue


### PR DESCRIPTION
This PR: https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer/pull/25 changed the way imports for this library need to be coded. This PR changes to the new import syntax for the only current Learn project that uses the library. 

I've also added a print statement to print errors if they are caught so that they won't be silently consumed. This can make it easier to troubleshoot if something has gone wrong. 