### PR TITLE
updated TFT_CS / TFT_DC to Arduino pins

### DIFF
--- a/Mini_GIF_Players/Mini_GIF_Players.ino
+++ b/Mini_GIF_Players/Mini_GIF_Players.ino
@@ -9,8 +9,8 @@
 #include <Adafruit_ST7735.h> // Hardware-specific library for ST7735
 #include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
 
-#define TFT_CS         5
-#define TFT_DC         6
+#define TFT_CS         7
+#define TFT_DC         8
 #define TFT_RST        9
 
 #define DISPLAY_WIDTH 320


### PR DESCRIPTION

- TFT_DC and TFT_CS pin numbers corrected for Arduino use. The incorrect CircuitPython numbers had been referenced (top side vs bottom side of RP2040 silkscreens).

- Resolves a known issue tof nothing appearing on TFT hat multiple forum users have run into.
