### PR TITLE
Make the CPX Simple Simon compatible with CPB

### DIFF
--- a/CPX_Simple_Simon/code.py
+++ b/CPX_Simple_Simon/code.py
@@ -14,7 +14,7 @@ import random
 import math
 import board
 from analogio import AnalogIn
-from adafruit_circuitplayground.express import cpx
+from adafruit_circuitplayground import cp
 
 FAILURE_TONE        = 100
 SEQUENCE_DELAY      = 0.8
@@ -30,56 +30,51 @@ SIMON_BUTTONS = {
   1 : { 'pads':(4,5), 'pixels':(0,1,2), 'color':0x00FF00, 'freq':415 },
   2 : { 'pads':(6,7), 'pixels':(2,3,4), 'color':0xFFFF00, 'freq':252 },
   3 : { 'pads':(1, ), 'pixels':(5,6,7), 'color':0x0000FF, 'freq':209 },
-  4 : { 'pads':(2,3), 'pixels':(7,8,9), 'color':0xFF0000, 'freq':310 },  
+  4 : { 'pads':(2,3), 'pixels':(7,8,9), 'color':0xFF0000, 'freq':310 },
 }
 
 def choose_skill_level():
     # Default
     skill_level = 1
     # Loop until button B is pressed
-    while not cpx.button_b:
+    while not cp.button_b:
         # Button A increases skill level setting
-        if cpx.button_a:
+        if cp.button_a:
             skill_level += 1
             skill_level = skill_level if skill_level < 5 else 1
             # Indicate current skill level
-            cpx.pixels.fill(0)
+            cp.pixels.fill(0)
             for p in range(skill_level):
-                cpx.pixels[p] = 0xFFFFFF
+                cp.pixels[p] = 0xFFFFFF
             time.sleep(DEBOUNCE)
     return skill_level
 
 def new_game(skill_level):
     # Seed the random function with noise
-    a4 = AnalogIn(board.A4)
-    a5 = AnalogIn(board.A5)
-    a6 = AnalogIn(board.A6)
-    a7 = AnalogIn(board.A7)
+    with AnalogIn(board.A4) as a4, AnalogIn(board.A5) as a5, AnalogIn(board.A6) as a6:
+        seed  = a4.value
+        seed += a5.value
+        seed += a6.value
 
-    seed  = a4.value
-    seed += a5.value
-    seed += a6.value
-    seed += a7.value
+        random.seed(seed)
 
-    random.seed(seed)    
-
-    # Populate the game sequence
-    return [random.randint(1,4) for i in range(SEQUENCE_LENGTH[skill_level])]
+        # Populate the game sequence
+        return [random.randint(1,4) for i in range(SEQUENCE_LENGTH[skill_level])]
 
 def indicate_button(button, duration):
     # Turn them all off
-    cpx.pixels.fill(0)
+    cp.pixels.fill(0)
     # Turn on the ones for the given button
     for p in button['pixels']:
-        cpx.pixels[p] = button['color']
+        cp.pixels[p] = button['color']
     # Play button tone
     if button['freq'] == None:
         time.sleep(duration)
     else:
-        cpx.play_tone(button['freq'], duration)
+        cp.play_tone(button['freq'], duration)
     # Turn them all off again
-    cpx.pixels.fill(0)
-    
+    cp.pixels.fill(0)
+
 def show_sequence(sequence, step):
     # Set tone playback duration based on current location
     if step <= 5:
@@ -88,21 +83,21 @@ def show_sequence(sequence, step):
         duration = 0.320
     else:
         duration = 0.220
-    
+
     # Play back sequence up to current step
     for b in range(step):
         time.sleep(0.05)
-        indicate_button(SIMON_BUTTONS[sequence[b]], duration)    
+        indicate_button(SIMON_BUTTONS[sequence[b]], duration)
 
 def cap_map(b):
-    if b == 1: return cpx.touch_A1
-    if b == 2: return cpx.touch_A2
-    if b == 3: return cpx.touch_A3
-    if b == 4: return cpx.touch_A4
-    if b == 5: return cpx.touch_A5
-    if b == 6: return cpx.touch_A6
-    if b == 7: return cpx.touch_A7    
-    
+    if b == 1: return cp.touch_A1
+    if b == 2: return cp.touch_A2
+    if b == 3: return cp.touch_A3
+    if b == 4: return cp.touch_A4
+    if b == 5: return cp.touch_A5
+    if b == 6: return cp.touch_A6
+    if b == 7: return cp.touch_TX
+
 def get_button_press():
     # Loop over all the buttons
     for button in SIMON_BUTTONS.values():
@@ -115,61 +110,61 @@ def get_button_press():
 
 def game_lost(step):
     # Show button that should have been pressed
-    cpx.pixels.fill(0)
+    cp.pixels.fill(0)
     for p in SIMON_BUTTONS[sequence[step]]['pixels']:
-        cpx.pixels[p] = SIMON_BUTTONS[sequence[step]]['color']
-   
+        cp.pixels[p] = SIMON_BUTTONS[sequence[step]]['color']
+
     # Play sad sound :(
-    cpx.play_tone(FAILURE_TONE, 1.5)
-    
+    cp.play_tone(FAILURE_TONE, 1.5)
+
     # And just sit here until reset
     while True:
         pass
-    
+
 def game_won():
     # Play 'razz' special victory signal
     for i in range(3):
-        indicate_button(SIMON_BUTTONS[4], 0.1)        
-        indicate_button(SIMON_BUTTONS[2], 0.1)        
-        indicate_button(SIMON_BUTTONS[3], 0.1)        
-        indicate_button(SIMON_BUTTONS[1], 0.1)        
-    indicate_button(SIMON_BUTTONS[4], 0.1)            
+        indicate_button(SIMON_BUTTONS[4], 0.1)
+        indicate_button(SIMON_BUTTONS[2], 0.1)
+        indicate_button(SIMON_BUTTONS[3], 0.1)
+        indicate_button(SIMON_BUTTONS[1], 0.1)
+    indicate_button(SIMON_BUTTONS[4], 0.1)
     indicate_button(SIMON_BUTTONS[2], 0.1)
 
     # Change tones to failure tone
     for button in SIMON_BUTTONS.values():
         button['freq'] = FAILURE_TONE
-        
+
     # Continue for another 0.8 seconds
     for i in range(2):
-        indicate_button(SIMON_BUTTONS[3], 0.1)        
-        indicate_button(SIMON_BUTTONS[1], 0.1)        
-        indicate_button(SIMON_BUTTONS[4], 0.1)        
-        indicate_button(SIMON_BUTTONS[2], 0.1)        
-    
+        indicate_button(SIMON_BUTTONS[3], 0.1)
+        indicate_button(SIMON_BUTTONS[1], 0.1)
+        indicate_button(SIMON_BUTTONS[4], 0.1)
+        indicate_button(SIMON_BUTTONS[2], 0.1)
+
     # Change tones to silence
     for button in SIMON_BUTTONS.values():
         button['freq'] = None
-    
+
     # Loop lights forever
     while True:
-        indicate_button(SIMON_BUTTONS[3], 0.1)        
-        indicate_button(SIMON_BUTTONS[1], 0.1)        
-        indicate_button(SIMON_BUTTONS[4], 0.1)        
-        indicate_button(SIMON_BUTTONS[2], 0.1)                
+        indicate_button(SIMON_BUTTONS[3], 0.1)
+        indicate_button(SIMON_BUTTONS[1], 0.1)
+        indicate_button(SIMON_BUTTONS[4], 0.1)
+        indicate_button(SIMON_BUTTONS[2], 0.1)
 
-# Initialize setup    
-cpx.pixels.fill(0)
-cpx.pixels[0] = 0xFFFFFF
+# Initialize setup
+cp.pixels.fill(0)
+cp.pixels[0] = 0xFFFFFF
 skill_level = choose_skill_level()
 sequence = new_game(skill_level)
 current_step = 1
 
-#Loop forever
+# Loop forever
 while True:
     # Show sequence up to current step
     show_sequence(sequence, current_step)
-    
+
     # Read player button presses
     for step in range(current_step):
         start_guess_time = time.monotonic()
@@ -177,12 +172,12 @@ while True:
         while (time.monotonic() - start_guess_time < GUESS_TIMEOUT) and (guess == None):
             guess = get_button_press()
         if not guess == SIMON_BUTTONS[sequence[step]]:
-            game_lost(sequence[step])
+            game_lost(step)
 
     # Advance the game forward
     current_step += 1
     if current_step > len(sequence):
         game_won()
-    
-    # Small delay before continuing    
+
+    # Small delay before continuing
     time.sleep(SEQUENCE_DELAY)


### PR DESCRIPTION
This makes the code for the Circuit Playground Simple Simon compatible with the CPB.
I don't think there is another version of it that already works ?
https://learn.adafruit.com/circuit-playground-simple-simon/code-walk-through

- use `cp` not `cpx` from the `adafruit_circuitplayground` library
- do not read the analog pin A7 (not available on CPB)
- reference `cp.touch_TX` (available on both) instead of `cp.touch_A7`

Also:
- fix the call to `game_lost()` which takes a step and not a sequence[setp]
- use a context manager to setup and deinit the analog pins
- some spaces at the end of lines
