### PR TITLE
Update to use API key in Pi-Hole Python scripts

### DIFF
--- a/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
+++ b/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
@@ -20,7 +20,7 @@ from PIL import Image, ImageDraw, ImageFont
 import adafruit_rgb_display.st7789 as st7789
 
 API_TOKEN = "YOUR_API_TOKEN_HERE"
-api_url = "http://pi-hole.local/admin/api.php?summaryRaw&auth="+API_TOKEN
+api_url = "http://localhost/admin/api.php?summaryRaw&auth="+API_TOKEN
 
 # Configuration for CS and DC pins (these are FeatherWing defaults on M0/M4):
 cs_pin = digitalio.DigitalInOut(board.CE0)

--- a/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
+++ b/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
@@ -19,7 +19,8 @@ import board
 from PIL import Image, ImageDraw, ImageFont
 import adafruit_rgb_display.st7789 as st7789
 
-api_url = 'http://localhost/admin/api.php'
+API_TOKEN = "YOUR_API_TOKEN_HERE"
+api_url = "http://pi-hole.local/admin/api.php?summaryRaw&auth="+API_TOKEN
 
 # Configuration for CS and DC pins (these are FeatherWing defaults on M0/M4):
 cs_pin = digitalio.DigitalInOut(board.CE0)

--- a/Pi_Hole_Ad_Blocker/stats.py
+++ b/Pi_Hole_Ad_Blocker/stats.py
@@ -46,7 +46,7 @@ import adafruit_ssd1306
 from PIL import Image, ImageDraw, ImageFont
 
 API_TOKEN = "YOUR_API_TOKEN_HERE"
-api_url = "http://pi-hole.local/admin/api.php?summaryRaw&auth="+API_TOKEN
+api_url = "http://localhost/admin/api.php?summaryRaw&auth="+API_TOKEN
 
 # Create the I2C interface.
 i2c = busio.I2C(SCL, SDA)

--- a/Pi_Hole_Ad_Blocker/stats.py
+++ b/Pi_Hole_Ad_Blocker/stats.py
@@ -45,7 +45,8 @@ import adafruit_ssd1306
 # Import Python Imaging Library
 from PIL import Image, ImageDraw, ImageFont
 
-api_url = 'http://localhost/admin/api.php'
+API_TOKEN = "YOUR_API_TOKEN_HERE"
+api_url = "http://pi-hole.local/admin/api.php?summaryRaw&auth="+API_TOKEN
 
 # Create the I2C interface.
 i2c = busio.I2C(SCL, SDA)


### PR DESCRIPTION
The Pi-Hole server recently added authentication requirements for accessing info via their API:
https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required

This broke things for the older version of the Python scripts which were simply trying to access without authorizing:
https://forums.adafruit.com/viewtopic.php?t=197708

These code changes will go along with Learn Guide changes that will discuss how to find the `YOUR_API_TOKEN_HERE` value and update the code.

Tested with `stats.py` and a Pi OLED. Did *not* test the TFT version, but it uses the exact same API query.