### PR TITLE
fix for 7seg test script, removed negative numbers, added str cast fo…

### DIFF
--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/sevensegment_test/code.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/sevensegment_test/code.py
@@ -31,11 +31,11 @@ display[2] = 'A'
 display[3] = 'B'
 time.sleep(1)
 
-numbers = [0.0, 1.0, -1.0, 0.55, -0.55, 10.23, -10.2, 100.5, -100.5]
+numbers = [0.0, 1.0, 0.55, 10.23, 100.5] 
 
-# print negative and positive floating point numbers
+# print floating point numbers
 for i in numbers:
-    display.print(i)
+    display.print(str(i))
     time.sleep(0.5)
 
 # print hex values, enable colon

--- a/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/sevensegment_test/code.py
+++ b/Matrix_7-Segment_LED_Backpack_Raspberry_Pi/sevensegment_test/code.py
@@ -31,7 +31,7 @@ display[2] = 'A'
 display[3] = 'B'
 time.sleep(1)
 
-numbers = [0.0, 1.0, 0.55, 10.23, 100.5] 
+numbers = [0.0, 1.0, 0.55, 10.23, 100.5]
 
 # print floating point numbers
 for i in numbers:


### PR DESCRIPTION
The CircuitPython library ht16k33 has changed and does not support directly printing negative numbers. It also needs a string conversion to print floating point values. The example test script has been modified so it will run without error. 