### PR TITLE
Use pylint-learn as the pylint version, if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ This is a work in progress.
 
 [learn]: https://learn.adafruit.com/
 
+## Running pylint locally
+Install a specific version of pylint under the name "pylint-learn":
+```
+pip instal pipx
+pipx install --suffix -learn pylint==2.7.1
+```
+Then use the `pylint_check` script to run pylint on the files or directories
+of your choice:
+```
+./pylint_check CircuitPython_Cool_Project
+```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a work in progress.
 Install a specific version of pylint under the name "pylint-learn":
 ```
 pip instal pipx
-pipx install --suffix -learn pylint==2.7.1
+pipx install --suffix=-learn pylint==2.7.1
 ```
 Then use the `pylint_check` script to run pylint on the files or directories
 of your choice:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ This is a work in progress.
 ## Running pylint locally
 Install a specific version of pylint under the name "pylint-learn":
 ```
-pip instal pipx
+pip install pipx
 pipx install --suffix=-learn pylint==2.7.1
 ```
 Then use the `pylint_check` script to run pylint on the files or directories
-of your choice:
+of your choice (note that your terminal *must* be in the top directory of
+Adafruit_Learning_System_Guides, not a sub-directory):
 ```
 ./pylint_check CircuitPython_Cool_Project
 ```

--- a/pylint_check.sh
+++ b/pylint_check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYLINT="`type -p pylint3 2>/dev/null || type -p pylint`"
+PYLINT="`type -p pylint-learn 2>/dev/null || type -p pylint3 2>/dev/null || type -p pylint`"
 echo "Using pylint bin at $PYLINT"
 
 # Use * as the default argument to avoid descending into hidden directories like .git


### PR DESCRIPTION
.. this allows a user to install the specific version of pylint required, under the specific name:
```
pipx install --suffix=-learn pylint==2.7.1
```
and run pylint_check more easily locally.