### PR TITLE
Adding battery test code

### DIFF
--- a/MAX17048_and_LC709203F_Battery_Monitor_Test/MAX17048_and_LC709203F_Battery_Monitor_Test.ino
+++ b/MAX17048_and_LC709203F_Battery_Monitor_Test/MAX17048_and_LC709203F_Battery_Monitor_Test.ino
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023 Liz Clark for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+//
+// Adafruit Battery Monitor Demo
+// Checks for MAX17048 or LC709203F
+
+#include <Wire.h>
+#include "Adafruit_MAX1704X.h"
+#include "Adafruit_LC709203F.h"
+
+Adafruit_MAX17048 maxlipo;
+Adafruit_LC709203F lc;
+
+// MAX17048 i2c address
+bool addr0x36 = true;
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);    // wait until serial monitor opens
+  Serial.println(F("\nAdafruit Battery Monitor simple demo"));
+  // if no max17048..
+  if (!maxlipo.begin()) {
+    Serial.println(F("Couldnt find Adafruit MAX17048, looking for LC709203F.."));
+    // if no lc709203f..
+    if (!lc.begin()) {
+      Serial.println(F("Couldnt find Adafruit MAX17048 or LC709203F."));
+      while (1) delay(10);
+    }
+    // found lc709203f!
+    else {
+      addr0x36 = false;
+      Serial.println(F("Found LC709203F"));
+      Serial.print("Version: 0x"); Serial.println(lc.getICversion(), HEX);
+      lc.setThermistorB(3950);
+      Serial.print("Thermistor B = "); Serial.println(lc.getThermistorB());
+      lc.setPackSize(LC709203F_APA_500MAH);
+      lc.setAlarmVoltage(3.8);
+    }
+  // found max17048!
+  }
+  else {
+    addr0x36 = true;
+    Serial.print(F("Found MAX17048"));
+    Serial.print(F(" with Chip ID: 0x")); 
+    Serial.println(maxlipo.getChipID(), HEX);
+  }
+}
+
+void loop() {
+  // if you have the max17048..
+  if (addr0x36 == true) {
+    max17048();
+  }
+  // if you have the lc709203f..
+  else {
+    lc709203f();
+  }
+
+  delay(2000);  // dont query too often!
+
+}
+
+void lc709203f() {
+  Serial.print("Batt_Voltage:");
+  Serial.print(lc.cellVoltage(), 3);
+  Serial.print("\t");
+  Serial.print("Batt_Percent:");
+  Serial.print(lc.cellPercent(), 1);
+  Serial.print("\t");
+  Serial.print("Batt_Temp:");
+  Serial.println(lc.getCellTemperature(), 1);
+}
+
+void max17048() {
+  Serial.print(F("Batt Voltage: ")); Serial.print(maxlipo.cellVoltage(), 3); Serial.println(" V");
+  Serial.print(F("Batt Percent: ")); Serial.print(maxlipo.cellPercent(), 1); Serial.println(" %");
+  Serial.println();
+}


### PR DESCRIPTION
Adding a new battery monitor test code. Code determines whether or not the board has a MAX17048 or LC709203F chip.