### PR TITLE
Specify the right pylintrc file no matter where pylint_check is run

### DIFF
--- a/pylint_check.sh
+++ b/pylint_check.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+SOURCE_LOCATION="$(dirname "$0")"
 PYLINT="`type -p pylint-learn 2>/dev/null || type -p pylint3 2>/dev/null || type -p pylint`"
 echo "Using pylint bin at $PYLINT"
+PYLINTRC=$SOURCE_LOCATION/.pylintrc
 
 # Use * as the default argument to avoid descending into hidden directories like .git
+# don't use advanced functions of find without verifying they are present in
+# the archaic default version on macos
 function find_pyfiles() {
     if [ $# -eq 0 ]; then set -- *; fi
     for f in $(find "$@" -type f -iname '*.py'); do
@@ -13,4 +17,4 @@ function find_pyfiles() {
     done
 }
 
-find_pyfiles "$@" | xargs "$PYLINT"
+find_pyfiles "$@" | xargs "$PYLINT" --rcfile "$PYLINTRC"


### PR DESCRIPTION
If you ran the pylint_check script not from the top directory, the correct pylintrc file wouldn't be used. This change adds the correct pylintrc file explicitly when running pylint.