### PR TITLE
Update cap touch pin script.

### DIFF
--- a/CircuitPython_Templates/cap_touch_pin_script/code.py
+++ b/CircuitPython_Templates/cap_touch_pin_script/code.py
@@ -80,7 +80,7 @@ for possible_touch_pin in get_pin_names():  # Get the pin name.
             "pulldown" in error_message  # If the ValueError is regarding needing a pulldown...
         ):
             print(
-                "Touch (no pulldown) on:", str(possible_touch_pin).replace("board.", "")
+                "Touch on:", str(possible_touch_pin).replace("board.", "")
             )
         else:
             print("No touch on:", str(possible_touch_pin).replace("board.", ""))


### PR DESCRIPTION
Moving forward we will be including a 1 MΩ resistor regardless of whether the microcontroller has built-in pulldowns on the touch capable pins. Using the build-in pulldowns can lead to odd results.

Therefore, there is no reason to differentiate between which pins have a pulldown and which pins don't. I still need to catch the `ValueError` it throws, so the only change is in the resulting print.