### PR TITLE
add root_path argument to server init

### DIFF
--- a/PicoW_CircuitPython_HTTP_Server/code.py
+++ b/PicoW_CircuitPython_HTTP_Server/code.py
@@ -82,7 +82,7 @@ wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_P
 
 print("Connected to WiFi")
 pool = socketpool.SocketPool(wifi.radio)
-server = HTTPServer(pool)
+server = HTTPServer(pool, "/static")
 
 #  variables for HTML
 #  comment/uncomment desired temp unit


### PR DESCRIPTION
Fix for the latest releast of adafruit_httpserver library. 

I don't have all hardware needed to test the full project. But did run this code on a PicoW with the components I do have and confirmed it executes successfully with the latest version of the library once these changes are made. 

Might be worth waiting until tomorrow (04/25/23) so that the new bundle will be released that includes the new library. Until then the bundle currently includes the old version of the library which would require the current version of this project code rather than the edited one here in the PR. 

After tomorrow the bundle will contain the updated library and from then moving forward this modified code from this PR will be required.