### PR TITLE
fixed held note error in mono note mode

### DIFF
--- a/Hexpad/code.py
+++ b/Hexpad/code.py
@@ -199,7 +199,7 @@ def send_note_off(note_num):
         midi_usb.send(NoteOff(note_num+12, 0))
     else:
         note_num = root_notes[note_num] + (12*octv)
-        midi_usb.send(NoteOff(note, 0))
+        midi_usb.send(NoteOff(note_num, 0))
 
 def send_midi_panic():
     for x in range(128):


### PR DESCRIPTION
A user found an error where note off messages were being sent for the wrong value -- `note` instead of `note_num` -- resulting in stuck notes. I fixed this and tested it, all should be right in the world of hexpad midi now.