### PR TITLE
add buffering for mp3 playback to reduce popping on I2S when I2C or S…

### DIFF
--- a/Walkmp3rson/code.py
+++ b/Walkmp3rson/code.py
@@ -83,7 +83,7 @@ audio = audiobusio.I2SOut(bit_clock=board.D24, word_select=board.D25, data=board
 # Feather M4
 # audio = audiobusio.I2SOut(bit_clock=board.D1, word_select=board.D10, data=board.D11)
 mixer = audiomixer.Mixer(voice_count=1, sample_rate=22050, channel_count=1,
-                         bits_per_sample=16, samples_signed=True)
+                         bits_per_sample=16, samples_signed=True, buffer_size=32768)
 mixer.voice[0].level = 0.15
 
 # Colors


### PR DESCRIPTION
A loud popping noise has been reported while playing MP3 files. Adding a 32k buffer to the audiomixer appears to prevent the I2C or SPI bus from interfering with I2S playback. 

forum thread, tested by user:
https://forums.adafruit.com/viewtopic.php?p=971267

CircuitPython issue that suggested using a buffer:
audio glitches when I2C or SPI display is updated #7322
https://github.com/adafruit/circuitpython/issues/7322