### PR TITLE
Make Arduino build conditional and scheduled

### DIFF
--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -1,0 +1,128 @@
+name: Arduino Library CI
+
+on:
+  schedule:
+    - cron: 0 3 * * *
+  workflow_dispatch:
+  pull_request:
+
+
+jobs:
+  check-if-needed:
+    runs-on: ubuntu-latest
+    outputs:
+      answer: ${{ steps.is-needed.outputs.answer }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Check if scheduled
+        id: check-cron
+        run: |
+          iscron=false
+          [[ "${{ github.event_name }}" == "schedule" ]] && iscron=true
+          echo "status=$iscron" >> "$GITHUB_OUTPUT"
+      - name: Check if dispatched
+        id: check-dispatch
+        run: |
+          isdispatch=false
+          [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && isdispatch=true
+          echo "status=$isdispatch" >> "$GITHUB_OUTPUT"
+      - name: Check for Arduino file updates
+        id: check-updated
+        if: ${{ steps.check-cron.outputs.status }} == false && ${{ steps.check-dispatch.outputs.status }} == false
+        run: |
+          changedfiles=$(git diff --name-only -r HEAD^1 HEAD)
+          ischanged=false
+          for changedfile in ${changedfiles[*]}; do
+            echo $changedfile
+            if [[ $changedfile == *.c ]] ||
+               [[ $changedfile == *.cpp ]] ||
+               [[ $changedfile == *.h ]] ||
+               [[ $changedfile == *.hpp ]] ||
+               [[ $changedfile == *.ino ]]; then
+                ischanged=true
+                break
+            fi
+          done
+          echo "status=$ischanged" >> "$GITHUB_OUTPUT"
+      - name: Output Arduino needed
+        id: is-needed
+        run: |
+          isneeded=false
+          if [[ ${{ steps.check-cron.outputs.status }} == true ]] ||
+             [[ ${{ steps.check-dispatch.outputs.status }} == true ]] ||
+             [[ ${{ steps.check-updated.outputs.status }} == true ]]; then
+              isneeded=true
+          fi
+          echo "answer=$isneeded" >> "$GITHUB_OUTPUT"
+
+  arduino:
+    strategy:
+      fail-fast: false
+      matrix:
+        arduino-platform: ["cpb", "cpc", "cpx_ada", "esp32", "esp8266", "feather32u4", "feather_m0_express", "feather_m4_express", "feather_rp2040", "flora", "funhouse", "gemma", "gemma_m0", "hallowing_m0", "hallowing_m4_tinyusb", "magtag", "metro_m0", "metro_m0_tinyusb", "metro_m4", "metro_m4_tinyusb", "monster_m4sk", "monster_m4sk_tinyusb", "neokeytrinkey_m0", "neotrellis_m4", "nrf52832", "nrf52840", "protrinket_5v", "proxlighttrinkey_m0", "pybadge", "pygamer", "pyportal", "qt2040_trinkey", "qtpy_m0", "qtpy_esp32s2", "rotarytrinkey_m0", "slidetrinkey_m0", "trinket_m0", "uno", "trinket_5v", "ledglasses_nrf52840" ]
+    runs-on: ubuntu-latest
+    needs: check-if-needed
+    if: ${{ needs.check-if-needed.outputs.answer == true }}
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+
+    - name: pre-install
+      run: bash ci/actions_install.sh
+
+    # manually install some libraries
+    - name: extra libraries
+      run: |
+        git clone --quiet https://github.com/adafruit/Cryptosuite.git /home/runner/Arduino/libraries/Cryptosuite
+        git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
+        git clone --quiet https://github.com/adafruit/Adafruit_LSM303.git /home/runner/Arduino/libraries/Adafruit_LSM303
+        git clone --quiet https://github.com/moderndevice/CapSense.git /home/runner/Arduino/libraries/CapSense
+        git clone --quiet https://github.com/PaintYourDragon/ffft.git /home/runner/Arduino/libraries/ffft
+        git clone --quiet https://github.com/adafruit/RadioHead.git /home/runner/Arduino/libraries/RadioHead
+        git clone --quiet https://github.com/me-no-dev/ESPAsyncTCP /home/runner/Arduino/libraries/ESPAsyncTCP
+        git clone --quiet https://github.com/adafruit/Talkie /home/runner/Arduino/libraries/Talkie
+        git clone --quiet https://github.com/Infineon/arduino-optiga-trust-m /home/runner/Arduino/libraries/arduinoOptigaTrustM
+        git clone --quiet https://github.com/adafruit/HID /home/runner/Arduino/libraries/HID_Project
+        rm -rf /home/runner/Arduino/libraries/ArduinoHttpClient
+        git clone --quiet https://github.com/arduino-libraries/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
+
+    - name: test platforms
+      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
+
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.event.repository.name }}.${{ github.sha }}
+        path: |
+            build/*.hex
+            build/*.bin
+            build/*.uf2
+
+    - name: Zip release files
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        if [ -d build ]; then
+            (
+            echo "Built from Adafruit Learning System Guides `git describe --tags` for ${{ matrix.arduino-platform }}"
+            echo "Source code: https://github.com/adafruit/"
+            echo "Adafruit Learning System: https://learn.adafruit.com/"
+            ) > build/README.txt
+            cd build && zip -9 -o ${{ matrix.arduino-platform }}.zip *.hex *.bin *.uf2 *.txt
+        fi
+
+    - name: Create release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: build/${{ matrix.arduino-platform }}.zip
+        fail_on_unmatched_files: false
+        body: "Select the zip file corresponding to your board from the list below."

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,4 +1,4 @@
-name: Arduino Library CI
+name: SPDX and Pylint
 
 on: [pull_request, push, repository_dispatch]
 
@@ -14,75 +14,6 @@ jobs:
 
     - name: check SPDX licensing
       run: python ./SPDX.py
-
-  arduino:
-    strategy:
-      fail-fast: false
-      matrix:
-        arduino-platform: ["cpb", "cpc", "cpx_ada", "esp32", "esp8266", "feather32u4", "feather_m0_express", "feather_m4_express", "feather_rp2040", "flora", "funhouse", "gemma", "gemma_m0", "hallowing_m0", "hallowing_m4_tinyusb", "magtag", "metro_m0", "metro_m0_tinyusb", "metro_m4", "metro_m4_tinyusb", "monster_m4sk", "monster_m4sk_tinyusb", "neokeytrinkey_m0", "neotrellis_m4", "nrf52832", "nrf52840", "protrinket_5v", "proxlighttrinkey_m0", "pybadge", "pygamer", "pyportal", "qt2040_trinkey", "qtpy_m0", "qtpy_esp32s2", "rotarytrinkey_m0", "slidetrinkey_m0", "trinket_m0", "uno", "trinket_5v", "ledglasses_nrf52840" ]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-
-    - name: pre-install
-      run: bash ci/actions_install.sh
-
-    # manually install some libraries
-    - name: extra libraries
-      run: |
-        git clone --quiet https://github.com/adafruit/Cryptosuite.git /home/runner/Arduino/libraries/Cryptosuite
-        git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
-        git clone --quiet https://github.com/adafruit/Adafruit_LSM303.git /home/runner/Arduino/libraries/Adafruit_LSM303
-        git clone --quiet https://github.com/moderndevice/CapSense.git /home/runner/Arduino/libraries/CapSense
-        git clone --quiet https://github.com/PaintYourDragon/ffft.git /home/runner/Arduino/libraries/ffft
-        git clone --quiet https://github.com/adafruit/RadioHead.git /home/runner/Arduino/libraries/RadioHead
-        git clone --quiet https://github.com/me-no-dev/ESPAsyncTCP /home/runner/Arduino/libraries/ESPAsyncTCP
-        git clone --quiet https://github.com/adafruit/Talkie /home/runner/Arduino/libraries/Talkie
-        git clone --quiet https://github.com/Infineon/arduino-optiga-trust-m /home/runner/Arduino/libraries/arduinoOptigaTrustM
-        git clone --quiet https://github.com/adafruit/HID /home/runner/Arduino/libraries/HID_Project
-        rm -rf /home/runner/Arduino/libraries/ArduinoHttpClient
-        git clone --quiet https://github.com/arduino-libraries/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
-
-    - name: test platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
-
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ github.event.repository.name }}.${{ github.sha }}
-        path: |
-            build/*.hex
-            build/*.bin
-            build/*.uf2
-
-    - name: Zip release files
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        if [ -d build ]; then
-            (
-            echo "Built from Adafruit Learning System Guides `git describe --tags` for ${{ matrix.arduino-platform }}"
-            echo "Source code: https://github.com/adafruit/"
-            echo "Adafruit Learning System: https://learn.adafruit.com/"
-            ) > build/README.txt
-            cd build && zip -9 -o ${{ matrix.arduino-platform }}.zip *.hex *.bin *.uf2 *.txt
-        fi
-
-    - name: Create release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: build/${{ matrix.arduino-platform }}.zip
-        fail_on_unmatched_files: false
-        body: "Select the zip file corresponding to your board from the list below."
 
   pylint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@kattni - I mocked changes for what I think might be a good shift.  Happy to modify, but I wanted to have something to point to.

This breaks out the Arduino build steps to their own file, which now only runs when at least one of these is true:

* It is 3 am (daily)
* A PR is submitted that updates a file with extensions `.ino`, `.c`, `.cpp`, `.h`, or `.hpp`
* The workflow is manually triggered to run