### PR TITLE
added UART timeouts

### DIFF
--- a/Meowsic_MIDI/code.py
+++ b/Meowsic_MIDI/code.py
@@ -45,7 +45,7 @@ key_matrix = keypad.KeyMatrix(
     row_pins=(board.D10, board.MOSI, board.MISO, board.CLK, board.A0, board.A1)
 )
 
-midi_uart = busio.UART(board.TX, None, baudrate=31250)
+midi_uart = busio.UART(board.TX, None, baudrate=31250, timeout=0.001)
 
 midi_usb_channel = 1
 midi_usb = adafruit_midi.MIDI(midi_out=usb_midi.ports[1], out_channel=midi_usb_channel-1)

--- a/TrellisM4_Simple_MIDI_UART/code.py
+++ b/TrellisM4_Simple_MIDI_UART/code.py
@@ -8,7 +8,7 @@ import adafruit_trellism4
 from rainbowio import colorwheel
 import board
 import busio
-midiuart = busio.UART(board.SDA, board.SCL, baudrate=31250)
+midiuart = busio.UART(board.SDA, board.SCL, baudrate=31250, timeout=0.001)
 print("MIDI UART EXAMPLE")
 
 trellis = adafruit_trellism4.TrellisM4Express()


### PR DESCRIPTION
added `timeout=0.001` to UART MIDI examples, without it some systems (e.g., Metro M7) can exhibit long delays when receiving messages.