### PR TITLE
Fix key release pixel effect.

### DIFF
--- a/NeoKey_MX_and_CHOC_Breakouts/CircuitPython/HID/code.py
+++ b/NeoKey_MX_and_CHOC_Breakouts/CircuitPython/HID/code.py
@@ -71,6 +71,6 @@ while True:
     # If there is a key released event, run this block.
     if event and event.released:
         # Turn off the LEDs.
-        pixels.fill((0, 0, 0))
+        pixels[event.key_number] = (0, 0, 0)
         # Report that the key switch has been released.
         keyboard.release_all()


### PR DESCRIPTION
Before it meant that a key release would turn off both LEDs, even if the other key was still pressed. Now the release event only turns off the LED associated with that key.