### PR TITLE
Updating neodriver extended bus example

### DIFF
--- a/NeoDriver_seesaw_Examples/Extended_Bus_NeoDriver_seesaw/code.py
+++ b/NeoDriver_seesaw_Examples/Extended_Bus_NeoDriver_seesaw/code.py
@@ -9,12 +9,12 @@ from rainbowio import colorwheel
 from adafruit_extended_bus import ExtendedI2C as I2C
 from adafruit_seesaw import seesaw, neopixel
 
-i2c = I2C(1)
+i2c = I2C(1, frequency=800000)
 ss = seesaw.Seesaw(i2c, addr=0x60)
 neo_pin = 15
-num_pixels = 64
+num_pixels = 30
 
-pixels = neopixel.NeoPixel(ss, neo_pin, num_pixels, brightness = 0.1)
+pixels = neopixel.NeoPixel(ss, neo_pin, num_pixels, brightness = 0.3, auto_write=False)
 
 color_offset = 0
 
@@ -23,5 +23,5 @@ while True:
         rc_index = (i * 256 // num_pixels) + color_offset
         pixels[i] = colorwheel(rc_index & 255)
     pixels.show()
-    color_offset += 1
+    color_offset += 8
     time.sleep(0.01)


### PR DESCRIPTION
Updating the neodriver extended bus example for non-Pi single board computers after some additional testing