### PR TITLE
Fix black square in the neopixel remote

### DIFF
--- a/FunHouse_IOT_Hub/neopixel_remote/code.py
+++ b/FunHouse_IOT_Hub/neopixel_remote/code.py
@@ -136,7 +136,7 @@ while True:
         # Used to prevent the touchscreen sending incorrect results
         if last_index == index:
             color = colors[index]
-            if colors[index]:
+            if colors[index] is not None:
                 group[1].fill = color
                 if last_color != color:
                     color_str = "#{:06x}".format(color)


### PR DESCRIPTION
The if statement: 

```
if colors[index]:
```

Will evaluate to `False` for the color `BLACK` because it has a numerical value of `0` and zero is treated as "falsy" by python interpretation.  Due to that evaluating as false, it means that when the user clicks on the black square it will appear as if "nothing happens" because this if statement is preventing it from taking action. 

This change addresses that issue by checking against `None` specifically, which allows the case for `BLACK` or `0` to work as expected, while still filtering out any of the ones that are actually `None` 

I tested this change successfully with a PyPortal Titano `8.2.0-beta.0 `
