### PR TITLE
move the guide count text up slightly

### DIFF
--- a/Matrix_Portal_Learn_Stats/code.py
+++ b/Matrix_Portal_Learn_Stats/code.py
@@ -38,7 +38,7 @@ matrixportal.add_text(
     text_font=FONT,
     text_position=(
         (matrixportal.graphics.display.width // 12) - 1,
-        (matrixportal.graphics.display.height // 2) - 4,
+        (matrixportal.graphics.display.height // 2) - 8,
     ),
     text_color=0x800000,
 )


### PR DESCRIPTION
I noticed the guide count number was getting overlapped slightly with the scrolling names of recent guides. 

This change moves it up a few pixels in order to remove the overlap.