### PR TITLE
Slider_Trinked MIDI: Typo for initial 2nd neopixel and show not needed.

### DIFF
--- a/Slider_Trinkey/MIDI_CC_Cross_Fader/code.py
+++ b/Slider_Trinkey/MIDI_CC_Cross_Fader/code.py
@@ -64,11 +64,10 @@ color_a = hsv2rgb(hue_a, sat_a, val_a)
 hue_b = 127
 sat_b = 255
 val_b = 255
-color_b = hsv2rgb(hue_a, sat_a, val_a)
+color_b = hsv2rgb(hue_b, sat_b, val_b)
 
 pixels[0] = color_a
 pixels[1] = color_b
-pixels.show()
 
 while True:
     cc_val = slider.value // 512  # make 0-127 range for MIDI CC


### PR DESCRIPTION
There is likely a copy and paste mistake.
It is not visible because in the main loop it is likely overwritten.

There is also a "show" that is not needed as default is auto update.

Not tested because I don't have install midi library, but I saw the problem by copying the initialisation only... and noticing both LED were red despite different hue.

UPDATE: Tested without the midi code, and my version works.