### PR TITLE
Fix releases

### DIFF
--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -1,10 +1,9 @@
 name: Arduino Library CI
 
 on:
-  schedule:
-    - cron: 0 3 * * *
   workflow_dispatch:
   pull_request:
+  push:
 
 
 jobs:


### PR DESCRIPTION
Fixes #2559

Since adabot handles the actualy cron, the scheduling event type is not needed and instead the push event is.