### PR TITLE
Fix check for adabot scheduled release

### DIFF
--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -15,11 +15,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Check if scheduled
+      - name: Check if run by adabot
         id: check-cron
         run: |
           iscron=false
-          [[ "${{ github.event_name }}" == "schedule" ]] && iscron=true
+          [[ "${{ github.event_name }}" == "push" && "${{ github.actor }}" == "adabot" ]] && iscron=true
           echo "status=$iscron" >> "$GITHUB_OUTPUT"
       - name: Check if dispatched
         id: check-dispatch


### PR DESCRIPTION
Since the cron is actually triggered by adabot and is a "push" event, this fixes the CI to trigger on said events.