### PR TITLE
Update PropMaker FeatherWing examples.

### DIFF
--- a/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_3W_LED_Simpletest/code.py
+++ b/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_3W_LED_Simpletest/code.py
@@ -1,16 +1,29 @@
-# SPDX-FileCopyrightText: 2019 Kattni Rembor for Adafruit Industries
+# SPDX-FileCopyrightText: 2019, 2023 Kattni Rembor for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
 """Simple rainbow swirl example for 3W LED"""
+import time
 import pwmio
 import board
-from rainbowio import colorwheel
 import digitalio
 
 enable = digitalio.DigitalInOut(board.D10)
 enable.direction = digitalio.Direction.OUTPUT
 enable.value = True
+
+
+def colorwheel(pos):
+    if pos < 0 or pos > 255:
+        return 0, 0, 0
+    if pos < 85:
+        return int(255 - pos * 3), int(pos * 3), 0
+    if pos < 170:
+        pos -= 85
+        return 0, int(255 - pos * 3), int(pos * 3)
+    pos -= 170
+    return int(pos * 3), 0, int(255 - pos * 3)
+
 
 red = pwmio.PWMOut(board.D11, duty_cycle=0, frequency=20000)
 green = pwmio.PWMOut(board.D12, duty_cycle=0, frequency=20000)
@@ -22,3 +35,4 @@ while True:
         red.duty_cycle = int(r * 65536 / 256)
         green.duty_cycle = int(g * 65536 / 256)
         blue.duty_cycle = int(b * 65536 / 256)
+        time.sleep(0.05)

--- a/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_Audio_Simpletest/code.py
+++ b/Adafruit_Prop_Maker_FeatherWing/Prop_Maker_Audio_Simpletest/code.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Kattni Rembor for Adafruit Industries
+# SPDX-FileCopyrightText: 2019, 2023 Kattni Rembor for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,8 +6,15 @@
 # This example only works on Feathers that have analog audio out!
 import digitalio
 import board
-import audioio
 import audiocore
+
+try:
+    from audioio import AudioOut
+except ImportError:
+    try:
+        from audiopwmio import PWMAudioOut as AudioOut
+    except ImportError:
+        pass  # not always supported by every board!
 
 WAV_FILE_NAME = "StreetChicken.wav"  # Change to the name of your wav file!
 
@@ -15,7 +22,7 @@ enable = digitalio.DigitalInOut(board.D10)
 enable.direction = digitalio.Direction.OUTPUT
 enable.value = True
 
-with audioio.AudioOut(board.A0) as audio:  # Speaker connector
+with AudioOut(board.A0) as audio:  # Speaker connector
     wave_file = open(WAV_FILE_NAME, "rb")
     wave = audiocore.WaveFile(wave_file)
 


### PR DESCRIPTION
3W LED example probably never worked with `rainbowio`. The Audio example needed the update for CP8, etc.