### PR TITLE
tile_height error changing from 14 to 12 for font

### DIFF
--- a/CircuitPython_RGBMatrix/scroller/code.py
+++ b/CircuitPython_RGBMatrix/scroller/code.py
@@ -32,7 +32,7 @@ display = framebufferio.FramebufferDisplay(matrix, auto_refresh=False)
 def tilegrid(palette):
     return displayio.TileGrid(
         bitmap=terminalio.FONT.bitmap, pixel_shader=palette,
-        width=1, height=1, tile_width=6, tile_height=14, default_tile=32)
+        width=1, height=1, tile_width=6, tile_height=12, default_tile=32)
 
 g = displayio.Group()
 


### PR DESCRIPTION
A forum user was seeing the following error with the CircuitPython_RGBMatrix two line scroller color scroller.

https://forums.adafruit.com/viewtopic.php?t=203685

```
ValueError: Tile height must exactly divide bitmap height
```

I was able to reproduce the same error on a MatrixPortal m4 with 64x32 display and found the fix was to change the tile_height from 14 --> 12.


```
def tilegrid(palette):
    return displayio.TileGrid(
        bitmap=terminalio.FONT.bitmap, pixel_shader=palette,
        width=1, height=1, tile_width=6, tile_height=12, default_tile=32)
```
The forum user Azzura was also able to confirm this worked on their setup. 