### PR TITLE
Update settings.toml to use cp expected name

### DIFF
--- a/ESP32_S2_WiFi_Tests/CPy_Native_WiFi_Test/code.py
+++ b/ESP32_S2_WiFi_Tests/CPy_Native_WiFi_Test/code.py
@@ -24,9 +24,9 @@ for network in wifi.radio.start_scanning_networks():
                                              network.rssi, network.channel))
 wifi.radio.stop_scanning_networks()
 
-print(f"Connecting to {os.getenv('WIFI_SSID')}")
-wifi.radio.connect(os.getenv("WIFI_SSID"), os.getenv("WIFI_PASSWORD"))
-print(f"Connected to {os.getenv('WIFI_SSID')}")
+print(f"Connecting to {os.getenv('CIRCUITPY_WIFI_SSID')}")
+wifi.radio.connect(os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD"))
+print(f"Connected to {os.getenv('CIRCUITPY_WIFI_SSID')}")
 print(f"My IP address: {wifi.radio.ipv4_address}")
 
 ping_ip = ipaddress.IPv4Address("8.8.8.8")

--- a/ESP32_S2_WiFi_Tests/CPy_Native_WiFi_Test/settings.toml
+++ b/ESP32_S2_WiFi_Tests/CPy_Native_WiFi_Test/settings.toml
@@ -5,5 +5,5 @@
 # This is where you store the credentials necessary for your code.
 # The associated demo only requires WiFi, but you can include any
 # credentials here, such as Adafruit IO username and key, etc.
-WIFI_SSID = "your-wifi-ssid"
-WIFI_PASSWORD = "your-wifi-password"
+CIRCUITPY_WIFI_SSID = "your-wifi-ssid"
+CIRCUITPY_WIFI_PASSWORD = "your-wifi-password"


### PR DESCRIPTION
Since the settings.toml in this test is used in guide pages to represent the default setting.toml, it should use the correct names of the settings. See https://docs.circuitpython.org/en/latest/docs/environment.html#environment-variables. @kattni, since you last updated this file, I'll just tag you to ensure it doesn't break something.