### PR TITLE
Set Fan Motion Outlet code to use MQTT by default

### DIFF
--- a/FunHouse_Motion_Outlet/code.py
+++ b/FunHouse_Motion_Outlet/code.py
@@ -13,7 +13,7 @@ from adafruit_funhouse import FunHouse
 OUTLET_STATE_TOPIC = "funhouse/outlet/state"
 OUTLET_COMMAND_TOPIC = "funhouse/outlet/set"
 MOTION_TIMEOUT = 300  # Timeout in seconds
-USE_MQTT = False
+USE_MQTT = True
 
 # Use dict to avoid reassigning the variable
 timestamps = {


### PR DESCRIPTION
While updating the code, I realized the guide expects this value should be set to True by default to make it easier for users and somehow it was changed to False along the way (probably while testing something).