### PR TITLE
adds small correction to Super Nintendo USB controller guide

### DIFF
--- a/Super_Nintendo_USB_Controller/boot.py
+++ b/Super_Nintendo_USB_Controller/boot.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Robert Dale Smith for Adafruit Industries
 #
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
+# USB HID descriptor for generic DirectInput compatible gamepad.
 
 import usb_hid
 
@@ -67,7 +68,7 @@ gamepad = usb_hid.Device(
     usage_page=0x01,           # Generic Desktop Control
     usage=0x05,                # Gamepad
     report_ids=(0,),           # Descriptor uses report ID 0.
-    in_report_lengths=(19,),    # This gamepad sends 6 bytes in its report.
+    in_report_lengths=(19,),   # This gamepad sends 19 bytes in its report.
     out_report_lengths=(0,),   # It does not receive any reports.
 )
 

--- a/Super_Nintendo_USB_Controller/code.py
+++ b/Super_Nintendo_USB_Controller/code.py
@@ -92,6 +92,11 @@ else:
 
 report = bytearray(19)
 report[2] = 0x08  # default released hat switch value
+report[3] = 127  # default x center value
+report[4] = 127  # default y center value
+report[5] = 127  # default z center value
+report[6] = 127  # default rz center value
+
 prev_report = bytearray(report)
 
 while True:


### PR DESCRIPTION
For Super Nintendo USB Controller guide: https://learn.adafruit.com/super-nintendo-usb-controller/overview

- Adds MIT licenses identifier to boot.py file.
- Adds default state for unused analog values.
- Comment correction for HID descriptor size.