### PR TITLE
Add code comment for Accel Range (sensitivity)

### DIFF
--- a/Feather_RP2040_Prop-Maker_Lightsaber/code.py
+++ b/Feather_RP2040_Prop-Maker_Lightsaber/code.py
@@ -77,6 +77,7 @@ pixels.brightness = 0.8
 i2c = board.I2C()
 int1 = DigitalInOut(board.ACCELEROMETER_INTERRUPT)
 lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
+# Accelerometer Range (can be 2_G, 4_G, 8_G, 16_G)
 lis3dh.range = adafruit_lis3dh.RANGE_2_G
 lis3dh.set_tap(1, HIT_THRESHOLD)
 


### PR DESCRIPTION
Accelerometer range is basically hit detection sensitivity.  Had a beginner in Discord that didn't know how to change it because it's not documented in the learn guide.  Need a better way to make this parameter configurable and easy to use. Please also add something into the learn guide about using this for lowering sensitivity.  By default the lightsaber is set to 2G which is its most sensitive setting. Setting it to RANGE_4_G will decrease the sensitivity which is what they needed.
