### PR TITLE
add readonly= keyword to storage.remount where not already present

### DIFF
--- a/CLUE_Light_Painter/boot.py
+++ b/CLUE_Light_Painter/boot.py
@@ -21,5 +21,5 @@ IO = digitalio.DigitalInOut(PIN)
 IO.direction = digitalio.Direction.INPUT
 IO.pull = digitalio.Pull.UP
 
-if IO.value:                    # No connection
-    storage.remount('/', False) # Remount storage as read/write for painter
+if IO.value:                             # No connection
+    storage.remount('/', readonly=False) # Remount storage as read/write for painter

--- a/CircuitPython_Essentials/CircuitPython_Logger/boot.py
+++ b/CircuitPython_Essentials/CircuitPython_Logger/boot.py
@@ -20,4 +20,4 @@ switch.direction = digitalio.Direction.INPUT
 switch.pull = digitalio.Pull.UP
 
 # If the switch pin is connected to ground CircuitPython can write to the drive
-storage.remount("/", switch.value)
+storage.remount("/", readonly=switch.value)

--- a/Crickits/flying_trapeze/boot.py
+++ b/Crickits/flying_trapeze/boot.py
@@ -13,4 +13,4 @@ switch.direction = digitalio.Direction.INPUT
 switch.pull = digitalio.Pull.UP
 
 # If the switch pin is connected to ground CircuitPython can write to the drive
-storage.remount("/", switch.value)
+storage.remount("/", readonly=switch.value)

--- a/Crickits/yanny_or_laurel/boot.py
+++ b/Crickits/yanny_or_laurel/boot.py
@@ -11,4 +11,4 @@ switch.direction = digitalio.Direction.INPUT
 switch.pull = digitalio.Pull.UP
 
 # If the switch pin is connected to ground CircuitPython can write to the drive
-storage.remount("/", switch.value)
+storage.remount("/", readonly=switch.value)

--- a/EInk_Autostereograms/boot.py
+++ b/EInk_Autostereograms/boot.py
@@ -28,4 +28,4 @@ if readonly:
     print("OS has write access to CircuitPython drive")
 else:
     print("CircuitPython has write access to drive")
-storage.remount("/", readonly)
+storage.remount("/", readonly=readonly)

--- a/Introducing_Gemma_M0/Gemma_Logger_boot/code.py
+++ b/Introducing_Gemma_M0/Gemma_Logger_boot/code.py
@@ -12,4 +12,4 @@ switch.pull = digitalio.Pull.UP
 
 # If the D0 is connected to ground with a wire
 # CircuitPython can write to the drive
-storage.remount("/", switch.value)
+storage.remount("/", readonly=switch.value)

--- a/Web_Workflow_Quickstart/env.py
+++ b/Web_Workflow_Quickstart/env.py
@@ -45,7 +45,7 @@ def get_current_toml_file(enumerated_files):
 # Erase settings.toml then write the contents of the new settings.toml file
 def change_toml_file(toml_file):
     try:
-        storage.remount("/", False)
+        storage.remount("/", readonly=False)
         with open("settings.toml", "w") as settings:
             settings.write("")
         with open("settings.toml", "w") as settings, open(toml_file) as f:


### PR DESCRIPTION
Clarify calls to `storage.remount()` when `readonly` arg is given by always giving the `readonly` keyword. This is a tricky argument to get right. I'll tweak the guide pages after it's merged.