### PR TITLE
Use Scripting key in Adafruit IO CircuitPython Example

### DIFF
--- a/CircuitPython_Templates/adafruit_io_cpu_temp_neopixel_color/code.py
+++ b/CircuitPython_Templates/adafruit_io_cpu_temp_neopixel_color/code.py
@@ -21,8 +21,8 @@ except ImportError:
 # Add your Adafruit IO Username and Key to secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need to obtain your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
+aio_username = secrets["ADAFRUIT_IO_USERNAME"]
+aio_key = secrets["ADAFRUIT_IO_KEY"]
 
 # WiFi
 try:


### PR DESCRIPTION
Address forum feedback (https://forums.adafruit.com/viewtopic.php?t=206628) regarding this example:

`aio_username` and `aio_key` are not the variable names underneath "Scripting" when a user clicks the key icon on Adafruit IO:
![IO_-_Devices](https://github.com/adafruit/Adafruit_Learning_System_Guides/assets/322428/b07bf104-8b2a-47e6-8a19-967d4d880653)

This PR changes both variables within the secrets file to match the expected values in the secrets file if the user is following along with Adafruit.io.