### PR TITLE
Explain magic number in BLE advertisement

### DIFF
--- a/CPB_Keybutton_BLE/code.py
+++ b/CPB_Keybutton_BLE/code.py
@@ -37,6 +37,8 @@ hid = HIDService()
 device_info = DeviceInfoService(software_revision=adafruit_ble.__version__,
                                 manufacturer="Adafruit Industries")
 advertisement = ProvideServicesAdvertisement(hid)
+# Advertise as "Keyboard" (0x03C1) icon when pairing
+# https://www.bluetooth.com/specifications/assigned-numbers/
 advertisement.appearance = 961
 scan_response = Advertisement()
 scan_response.complete_name = "CircuitPython HID"


### PR DESCRIPTION
# Summary 

This code snippet threw me for a loop trying to understand what "961" meant. After a good amount of digging I found the appearance numbers in the bluetooth spec, to see that 961 is 0x03C1 or "keyboard".

Add a comment to hopefully guide future readers.

# Survey Answers

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  
  - This change simply adds a clarifying comment, the code is not changed at all

- **Describe any known limitations with your change.** 
  - Just a comment, only limitation is the reader's literacy level 

- **Please run any tests or examples that can exercise your modified code.** 
  - No tests to run, I assume the compiler will strip comments before executing the code
