### PR TITLE
MatrixPortal_S3_Flight_Proximity_Tracker: fix AERO_API_KEY typo

### DIFF
--- a/MatrixPortal_S3_Flight_Proximity_Tracker/code.py
+++ b/MatrixPortal_S3_Flight_Proximity_Tracker/code.py
@@ -136,7 +136,7 @@ def fetch_flight_data():
 
     headers = {
         "Accept": "application/json; charset=UTF-8",
-        "x-apikey": os.getenv("AREO_API_KEY"),  # Replace with your actual API key
+        "x-apikey": os.getenv("AERO_API_KEY"),  # Replace with your actual API key
     }
     full_url = f"{base_url}?{construct_query_string(params)}"
     response = requests.get(full_url, headers=headers)


### PR DESCRIPTION
`AREO_API_KEY` -> `AERO_API_KEY`

Noted by https://forums.adafruit.com/viewtopic.php?t=207064