### PR TITLE
add optional pullup code for BLE HID project

### DIFF
--- a/CPB_Keybutton_BLE/code.py
+++ b/CPB_Keybutton_BLE/code.py
@@ -9,7 +9,7 @@ Attach five buttons with pullup resistors to Feather nRF52840
 """
 import time
 import board
-from digitalio import DigitalInOut, Direction
+from digitalio import DigitalInOut, Direction, Pull
 
 import adafruit_ble
 from adafruit_ble.advertising import Advertisement
@@ -31,6 +31,13 @@ button_2.direction = Direction.INPUT
 button_3.direction = Direction.INPUT
 button_4.direction = Direction.INPUT
 button_5.direction = Direction.INPUT
+
+# NOTE: If you are not using buttons with built-in pullups, uncomment the five lines below.
+# button_1.pull = Pull.UP
+# button_2.pull = Pull.UP
+# button_3.pull = Pull.UP
+# button_4.pull = Pull.UP
+# button_5.pull = Pull.UP
 
 hid = HIDService()
 


### PR DESCRIPTION
User was not using pushbutton breakouts for this project, and didn't realize initially they needed to set pull-ups. Added warnings to the guide and extra code.
https://forums.adafruit.com/viewtopic.php?t=207389