### PR TITLE
Update async keyboard code

### DIFF
--- a/CircuitPython_Commodore_16_KB2040/advanced/code.py
+++ b/CircuitPython_Commodore_16_KB2040/advanced/code.py
@@ -142,7 +142,7 @@ class AsyncEventQueue:
         self._events = events
 
     async def __await__(self):
-        yield asyncio.core._io_queue.queue_read(self._events)
+        await asyncio.core._io_queue.queue_read(self._events)
         return self._events.get()
 
     def __enter__(self):


### PR DESCRIPTION
... per https://github.com/adafruit/circuitpython/issues/8412 Otherwise this is incompatible with both 8.x and 9.
