### PR TITLE
Correct references to "esp32_camera"

### DIFF
--- a/CircuitPython_ESP32_Camera/esp32-kaluga-onionskin-gif/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-kaluga-onionskin-gif/code.py
@@ -47,7 +47,7 @@ the one which usually uses rotation=90 to get a landscape display.
 import os
 import struct
 
-import esp32_camera
+import espcamera
 import analogio
 import board
 import busio
@@ -109,14 +109,14 @@ sdcard = sdcardio.SDCard(sd_spi, sd_cs, baudrate=24_000_000)
 vfs = storage.VfsFat(sdcard)
 storage.mount(vfs, "/sd")
 
-cam = esp32_camera.Camera(
+cam = espcamera.Camera(
     data_pins=board.CAMERA_DATA,
     external_clock_pin=board.CAMERA_XCLK,
     pixel_clock_pin=board.CAMERA_PCLK,
     vsync_pin=board.CAMERA_VSYNC,
     href_pin=board.CAMERA_HREF,
-    pixel_format=esp32_camera.PixelFormat.RGB565,
-    frame_size=esp32_camera.FrameSize.QVGA,
+    pixel_format=espcamera.PixelFormat.RGB565,
+    frame_size=espcamera.FrameSize.QVGA,
     i2c=board.I2C(),
     external_clock_frequency=20_000_000,
     framebuffer_count=2)

--- a/CircuitPython_ESP32_Camera/esp32-s3-eye-adafruitio-and-lcd/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-s3-eye-adafruitio-and-lcd/code.py
@@ -15,7 +15,7 @@ import struct
 from adafruit_io.adafruit_io import IO_MQTT
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 import board
-import esp32_camera
+import espcamera
 import keypad
 import socketpool
 import wifi
@@ -42,14 +42,14 @@ io = IO_MQTT(mqtt_client)
 
 
 print("Initializing camera")
-cam = esp32_camera.Camera(
+cam = espcamera.Camera(
     data_pins=board.CAMERA_DATA,
     external_clock_pin=board.CAMERA_XCLK,
     pixel_clock_pin=board.CAMERA_PCLK,
     vsync_pin=board.CAMERA_VSYNC,
     href_pin=board.CAMERA_HREF,
-    pixel_format=esp32_camera.PixelFormat.RGB565,
-    frame_size=esp32_camera.FrameSize.R240X240,
+    pixel_format=espcamera.PixelFormat.RGB565,
+    frame_size=espcamera.FrameSize.R240X240,
     i2c=board.I2C(),
     external_clock_frequency=20_000_000,
     framebuffer_count=2,
@@ -72,8 +72,8 @@ while True:
     display_bus.send(44, frame)
     if (ev := shutter_button.events.get()) and ev.pressed:
         cam.reconfigure(
-            pixel_format=esp32_camera.PixelFormat.JPEG,
-            frame_size=esp32_camera.FrameSize.SVGA,
+            pixel_format=espcamera.PixelFormat.JPEG,
+            frame_size=espcamera.FrameSize.SVGA,
         )
         frame = cam.take(1)
         if isinstance(frame, memoryview):
@@ -86,7 +86,7 @@ while True:
 
             io.publish("image", encoded_data)
         cam.reconfigure(
-            pixel_format=esp32_camera.PixelFormat.RGB565,
-            frame_size=esp32_camera.FrameSize.R240X240,
+            pixel_format=espcamera.PixelFormat.RGB565,
+            frame_size=espcamera.FrameSize.R240X240,
         )
     print(end=".")

--- a/CircuitPython_ESP32_Camera/esp32-s3-eye-adafruitio/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-s3-eye-adafruitio/code.py
@@ -24,7 +24,7 @@ import time
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
 import board
-import esp32_camera
+import espcamera
 import socketpool
 import wifi
 
@@ -33,17 +33,17 @@ aio_key = os.getenv('AIO_KEY')
 
 image_feed = "image"
 
-cam = esp32_camera.Camera(
+cam = espcamera.Camera(
     data_pins=board.CAMERA_DATA,
     external_clock_pin=board.CAMERA_XCLK,
     pixel_clock_pin=board.CAMERA_PCLK,
     vsync_pin=board.CAMERA_VSYNC,
     href_pin=board.CAMERA_HREF,
-    pixel_format=esp32_camera.PixelFormat.JPEG,
-    frame_size=esp32_camera.FrameSize.SVGA,
+    pixel_format=espcamera.PixelFormat.JPEG,
+    frame_size=espcamera.FrameSize.SVGA,
     i2c=board.I2C(),
     external_clock_frequency=20_000_000,
-    grab_mode=esp32_camera.GrabMode.WHEN_EMPTY)
+    grab_mode=espcamera.GrabMode.WHEN_EMPTY)
 cam.vflip = True
 
 

--- a/CircuitPython_ESP32_Camera/esp32-s3-eye-lcdview/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-s3-eye-lcdview/code.py
@@ -18,23 +18,23 @@ import struct
 import adafruit_ticks
 import board
 import displayio
-import esp32_camera
+import espcamera
 import keypad
 
 button = keypad.Keys((board.BOOT,), value_when_pressed=False)
 
-cam = esp32_camera.Camera(
+cam = espcamera.Camera(
     data_pins=board.CAMERA_DATA,
     external_clock_pin=board.CAMERA_XCLK,
     pixel_clock_pin=board.CAMERA_PCLK,
     vsync_pin=board.CAMERA_VSYNC,
     href_pin=board.CAMERA_HREF,
-    pixel_format=esp32_camera.PixelFormat.RGB565,
-    frame_size=esp32_camera.FrameSize.R240X240,
+    pixel_format=espcamera.PixelFormat.RGB565,
+    frame_size=espcamera.FrameSize.R240X240,
     i2c=board.I2C(),
     external_clock_frequency=20_000_000,
     framebuffer_count=2,
-    grab_mode=esp32_camera.GrabMode.WHEN_EMPTY)
+    grab_mode=espcamera.GrabMode.WHEN_EMPTY)
 
 cam.vflip = True
 

--- a/CircuitPython_ESP32_Camera/esp32-s3-eye-qrio-repl/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-s3-eye-qrio-repl/code.py
@@ -9,18 +9,18 @@ ILI9341 display.
 
 import struct
 import board
-import esp32_camera
+import espcamera
 import qrio
 
 print("Initializing camera")
-cam = esp32_camera.Camera(
+cam = espcamera.Camera(
     data_pins=board.CAMERA_DATA,
     external_clock_pin=board.CAMERA_XCLK,
     pixel_clock_pin=board.CAMERA_PCLK,
     vsync_pin=board.CAMERA_VSYNC,
     href_pin=board.CAMERA_HREF,
-    pixel_format=esp32_camera.PixelFormat.RGB565,
-    frame_size=esp32_camera.FrameSize.R240X240,
+    pixel_format=espcamera.PixelFormat.RGB565,
+    frame_size=espcamera.FrameSize.R240X240,
     i2c=board.I2C(),
     external_clock_frequency=20_000_000,
     framebuffer_count=2)


### PR DESCRIPTION
This was renamed during the development of 8.x but examples weren't fixed.