### PR TITLE
fix to mp3 streaming code

### DIFF
--- a/Walkmp3rson/code.py
+++ b/Walkmp3rson/code.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 John Park and Tod Kurt for Adafruit Industries
 # SPDX-License-Identifier: MIT
-# Walkmp3rson digital cassette tape player (ok fine it's just SD cards)
+'''Walkmp3rson digital cassette tape player (ok fine it's just SD cards)'''
+
 import time
 import os
 import board
@@ -143,12 +144,15 @@ volume_bar.value = mixer.voice[0].level * 100
 def change_track(tracknum):
     # pylint: disable=global-statement
     global mp3_filename
+    # pylint: disable=global-statement
+    global mp3stream
     mp3_filename = mp3s[tracknum]
     song_name_fc = tracktext(mp3_filename, 2)
     artist_name_fc = tracktext(mp3_filename, 1)
     mp3_file_fc = open(mp3_filename, "rb")
-    mp3stream_fc = audiomp3.MP3Decoder(mp3_file_fc)
-    mp3_bytes_fc = os.stat(mp3_filename)[6]  # size in bytes is position 6
+    mp3stream.file = mp3_file_fc
+    mp3stream_fc = mp3stream
+    mp3_bytes_fc = os.stat(mp3_filename)[6]
     return (mp3_file_fc, mp3stream_fc, song_name_fc, artist_name_fc, mp3_bytes_fc)
 
 print("Walkmp3rson")


### PR DESCRIPTION
there was a memory problem a forum user caught due to mp3 stream method being called repeatedly. tested the fix on hardware, works great.