### PR TITLE
Update PiCowbell examples for new PCF8523 library layout

### DIFF
--- a/PiCowbell_Adalogger_Examples/CircuitPython_Datalogger/code.py
+++ b/PiCowbell_Adalogger_Examples/CircuitPython_Datalogger/code.py
@@ -8,14 +8,14 @@ import sdcardio
 import busio
 import storage
 import adafruit_mcp9808
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 
 #  setup for Pico I2C
 i2c = busio.I2C(board.GP5, board.GP4)
 # setup for mcp9808 temp monitor
 mcp9808 = adafruit_mcp9808.MCP9808(i2c)
 # setup for RTC
-rtc = adafruit_pcf8523.PCF8523(i2c)
+rtc = PCF8523(i2c)
 
 #  list of days to print to the text file on boot
 days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")

--- a/PiCowbell_Adalogger_Examples/CircuitPython_Real_Time_Clock/code.py
+++ b/PiCowbell_Adalogger_Examples/CircuitPython_Real_Time_Clock/code.py
@@ -4,10 +4,10 @@
 import time
 import board
 import busio
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 
 I2C = busio.I2C(board.GP5, board.GP4)
-rtc = adafruit_pcf8523.PCF8523(I2C)
+rtc = PCF8523(i2c)
 
 days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
 

--- a/PiCowbell_Adalogger_Examples/CircuitPython_Real_Time_Clock/code.py
+++ b/PiCowbell_Adalogger_Examples/CircuitPython_Real_Time_Clock/code.py
@@ -7,7 +7,7 @@ import busio
 from adafruit_pcf8523.pcf8523 import PCF8523
 
 I2C = busio.I2C(board.GP5, board.GP4)
-rtc = PCF8523(i2c)
+rtc = PCF8523(I2C)
 
 days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
 


### PR DESCRIPTION
Re this thread:
https://forums.adafruit.com/viewtopic.php?t=207734

The PCF8523 library made breaking changes at the 2.0.0 release:
https://github.com/adafruit/Adafruit_CircuitPython_PCF8523/releases/tag/2.0.0

This PR updates the PiCowbell examples to use the new syntax for importing and creating the rtc instance.

**NOT TESTED** dont have HW, relying on forum poster saying this fixed it