### PR TITLE
adding examples for the neorgb stemma breakout

### DIFF
--- a/NeoRGB_Stemma_Examples/arduino_rainbow_neorgb/arduino_rainbow_neorgb.ino
+++ b/NeoRGB_Stemma_Examples/arduino_rainbow_neorgb/arduino_rainbow_neorgb.ino
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2024 Limor Fried for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+
+#include <Adafruit_NeoPixel.h>
+#ifdef __AVR__
+ #include <avr/power.h> // Required for 16 MHz Adafruit Trinket
+#endif
+
+// Which pin on the Arduino is connected to the NeoPixels?
+// On a Trinket or Gemma we suggest changing this to 1:
+#define LED_PIN    6
+
+// How many NeoPixels are attached to the Arduino?
+#define LED_COUNT 1
+
+// Declare our NeoPixel strip object:
+Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+// Argument 1 = Number of pixels in NeoPixel strip
+// Argument 2 = Arduino pin number (most are valid)
+// Argument 3 = Pixel type flags
+
+void setup() {
+  // These lines are specifically to support the Adafruit Trinket 5V 16 MHz.
+  // Any other board, you can remove this part (but no harm leaving it):
+#if defined(__AVR_ATtiny85__) && (F_CPU == 16000000)
+  clock_prescale_set(clock_div_1);
+#endif
+  // END of Trinket-specific code.
+
+  strip.begin();           // INITIALIZE NeoPixel strip object (REQUIRED)
+  strip.show();            // Turn OFF all pixels ASAP
+  strip.setBrightness(50); // Set BRIGHTNESS to about 1/5 (max = 255)
+}
+void loop() {
+
+  rainbow(10);             // Flowing rainbow cycle along the whole strip
+}
+
+// Rainbow cycle along whole strip. Pass delay time (in ms) between frames.
+void rainbow(int wait) {
+  // Hue of first pixel runs 5 complete loops through the color wheel.
+  // Color wheel has a range of 65536 but it's OK if we roll over, so
+  // just count from 0 to 5*65536. Adding 256 to firstPixelHue each time
+  // means we'll make 5*65536/256 = 1280 passes through this loop:
+  for(long firstPixelHue = 0; firstPixelHue < 5*65536; firstPixelHue += 256) {
+    // strip.rainbow() can take a single argument (first pixel hue) or
+    // optionally a few extras: number of rainbow repetitions (default 1),
+    // saturation and value (brightness) (both 0-255, similar to the
+    // ColorHSV() function, default 255), and a true/false flag for whether
+    // to apply gamma correction to provide 'truer' colors (default true).
+    strip.rainbow(firstPixelHue);
+    // Above line is equivalent to:
+    // strip.rainbow(firstPixelHue, 1, 255, 255, true);
+    strip.show(); // Update strip with new contents
+    delay(wait);  // Pause for a moment
+  }
+}

--- a/NeoRGB_Stemma_Examples/circuitpython/code.py
+++ b/NeoRGB_Stemma_Examples/circuitpython/code.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2024 Liz Clark for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import time
+import board
+from rainbowio import colorwheel
+import neopixel
+
+num_pixels = 1
+# pylint: disable=simplifiable-condition
+# check to see if its a raspberry pi
+if "CE0" and "CE1" in dir(board):  # pi only zone
+    pixel_pin = board.D18
+# otherwise assume a microcontroller
+else:
+    pixel_pin = board.D5
+
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels)
+
+color_offset = 0
+
+while True:
+    for i in range(num_pixels):
+        rc_index = (i * 256 // num_pixels) + color_offset
+        pixels[i] = colorwheel(rc_index & 255)
+    pixels.show()
+    color_offset += 1
+    time.sleep(0.01)


### PR DESCRIPTION
adding arduino and CP examples for the neorgb stemma breakout. CP example checks for raspberry pi