### PR TITLE
update actions to use node.js 20

### DIFF
--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       answer: ${{ steps.is-needed.outputs.answer }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Check if run by adabot
@@ -65,11 +65,10 @@ jobs:
     if: needs.check-if-needed.outputs.answer == 'true'
     needs: check-if-needed
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -98,7 +97,7 @@ jobs:
 
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.event.repository.name }}.${{ github.sha }}
         path: |

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -6,11 +6,11 @@ jobs:
   spdx:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Checkout Current Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: check SPDX licensing
       run: python ./SPDX.py
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Versions
@@ -29,7 +29,7 @@ jobs:
       run: |
         pip install --force-reinstall pylint==2.7.1
     - name: Checkout Current Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: lint
       run: ./pylint_check.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -21,10 +21,10 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
 


### PR DESCRIPTION
Update actions to remove warnings about needing to update to actions that use Node.js 20.

Also remove one redundant line.

Not sure about the reference to `softprops/action-gh-release`. That action hasn't been updated since November 2022.