### PR TITLE
Remove legacy requests.set_socket

### DIFF
--- a/Adafruit_IO_Power_Relay/code.py
+++ b/Adafruit_IO_Power_Relay/code.py
@@ -7,9 +7,10 @@ import board
 import busio
 from digitalio import DigitalInOut
 import neopixel
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
@@ -101,13 +102,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 # Setup the callback methods above

--- a/Adafruit_IO_Power_Relay/code_light_sensor/code.py
+++ b/Adafruit_IO_Power_Relay/code_light_sensor/code.py
@@ -8,9 +8,10 @@ import busio
 from digitalio import DigitalInOut
 import neopixel
 import adafruit_bh1750
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
@@ -116,13 +117,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 # Setup the callback methods above

--- a/Adafruit_IO_Schedule_Trigger/code.py
+++ b/Adafruit_IO_Schedule_Trigger/code.py
@@ -6,9 +6,10 @@ import time
 import board
 import busio
 from digitalio import DigitalInOut
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -104,14 +105,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
+++ b/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
@@ -10,8 +10,9 @@ blob/master/examples/esp32spi_simpletest.py '''
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_requests as requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_requests
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a secrets.py file
@@ -35,7 +36,9 @@ spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
 
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-requests.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")

--- a/CircuitPython_Zorque_Text_Game_openai/code.py
+++ b/CircuitPython_Zorque_Text_Game_openai/code.py
@@ -3,8 +3,9 @@
 import os
 import traceback
 
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_requests as requests
+import adafruit_connection_manager
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
+import adafruit_requests
 import adafruit_touchscreen
 from adafruit_ticks import ticks_ms, ticks_add, ticks_less
 from adafruit_bitmap_font.bitmap_font import load_font
@@ -59,7 +60,13 @@ In case the player wins (or loses) start a fresh game.
 
 clear='\033[2J'
 
+# variable for setup requests.Session
+requests = None
+
+# pylint: disable=global-statement
 def set_up_wifi():
+    global requests
+
     print(end=clear)
     if openai_api_key is None:
         print(
@@ -81,7 +88,8 @@ def set_up_wifi():
 
     spi = board.SPI()
     esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp_cs, esp_ready, esp_reset)
-    requests.set_socket(socket, esp)
+    ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+    requests = adafruit_requests.Session(pool, ssl_context)
 
     while not esp.is_connected:
         print("Connecting to AP...")

--- a/FunHouse_IOT_Hub/battery_peripheral/code.py
+++ b/FunHouse_IOT_Hub/battery_peripheral/code.py
@@ -17,9 +17,10 @@ import board
 from adafruit_lc709203f import LC709203F
 import busio
 from digitalio import DigitalInOut
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -74,14 +75,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/FunHouse_IOT_Hub/door_peripheral/code.py
+++ b/FunHouse_IOT_Hub/door_peripheral/code.py
@@ -16,9 +16,10 @@ either the Feather or the AirLift Featherwing has stacking headers.
 
 import board
 import busio
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -57,14 +58,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/FunHouse_IOT_Hub/neopixel_remote/feather_code/code.py
+++ b/FunHouse_IOT_Hub/neopixel_remote/feather_code/code.py
@@ -17,9 +17,10 @@ But if it doesn't, use stacking headers on either the Feather or the AirLift Fea
 
 import board
 import busio
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -76,14 +77,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/FunHouse_IOT_Hub/relay_heatindex_peripheral/code.py
+++ b/FunHouse_IOT_Hub/relay_heatindex_peripheral/code.py
@@ -19,9 +19,10 @@ a box fan connected to it.
 
 import board
 import busio
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -75,14 +76,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/FunHouse_IOT_Hub/relay_peripheral/code.py
+++ b/FunHouse_IOT_Hub/relay_peripheral/code.py
@@ -14,9 +14,10 @@ Uses:
 """
 import board
 import busio
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -69,14 +70,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/MagTag/MagTag_Webb_Telescope_Status/code.py
+++ b/MagTag/MagTag_Webb_Telescope_Status/code.py
@@ -16,7 +16,7 @@ from adafruit_display_text import bitmap_label
 import wifi
 import socketpool
 import alarm
-import adafruit_requests as requests
+import adafruit_requests
 
 try:
     from secrets import secrets
@@ -70,7 +70,7 @@ if not TEST_RUN:
 
         # Create Socket, initialize requests
         socket = socketpool.SocketPool(wifi.radio)
-        requests = requests.Session(socket, ssl.create_default_context())
+        requests = adafruit_requests.Session(socket, ssl.create_default_context())
     except OSError:
         print("Failed to connect to AP. Rebooting in 3 seconds...")
         time.sleep(3)

--- a/MagTag/MagTag_Webb_Telescope_Status/deprecated_original_version/code.py
+++ b/MagTag/MagTag_Webb_Telescope_Status/deprecated_original_version/code.py
@@ -16,7 +16,7 @@ from adafruit_display_text import bitmap_label
 import wifi
 import socketpool
 import alarm
-import adafruit_requests as requests
+import adafruit_requests
 
 try:
     from secrets import secrets
@@ -68,7 +68,7 @@ if not TEST_RUN:
 
         # Create Socket, initialize requests
         socket = socketpool.SocketPool(wifi.radio)
-        requests = requests.Session(socket, ssl.create_default_context())
+        requests = adafruit_requests.Session(socket, ssl.create_default_context())
     except OSError:
         print("Failed to connect to AP. Rebooting in 3 seconds...")
         time.sleep(3)

--- a/Metro_M7_Examples/WiFi/code.py
+++ b/Metro_M7_Examples/WiFi/code.py
@@ -5,8 +5,9 @@ import os
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_requests as requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_requests
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 
 print("ESP32 SPI webclient test")
@@ -22,7 +23,9 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-requests.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")

--- a/PyPortal/PyPortal_AWS_IOT_Planter/code.py
+++ b/PyPortal/PyPortal_AWS_IOT_Planter/code.py
@@ -16,9 +16,10 @@ import board
 import busio
 from digitalio import DigitalInOut
 import neopixel
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_aws_iot import MQTT_CLIENT
 from adafruit_seesaw.seesaw import Seesaw
@@ -86,8 +87,7 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Soil Sensor Setup
 i2c_bus = busio.I2C(board.SCL, board.SDA)
@@ -128,7 +128,9 @@ def message(client, topic, msg):
 
 # Set up a new MiniMQTT Client
 client =  MQTT.MQTT(broker = secrets['broker'],
-                    client_id = secrets['client_id'])
+                    client_id = secrets['client_id'],
+                    socket_pool=pool,
+                    ssl_context=ssl_context)
 
 # Initialize AWS IoT MQTT API Client
 aws_iot = MQTT_CLIENT(client)

--- a/PyPortal/PyPortal_GCP_IOT_Planter/code.py
+++ b/PyPortal/PyPortal_GCP_IOT_Planter/code.py
@@ -16,8 +16,9 @@ import board
 import busio
 import gcp_gfx_helper
 import neopixel
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_gc_iot_core import MQTT_API, Cloud_Core
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_seesaw.seesaw import Seesaw
@@ -48,8 +49,7 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Soil Sensor Setup
 i2c_bus = busio.I2C(board.SCL, board.SDA)
@@ -148,7 +148,9 @@ print("Your JWT is: ", jwt)
 client = MQTT.MQTT(broker=google_iot.broker,
                    username=google_iot.username,
                    password=jwt,
-                   client_id=google_iot.cid)
+                   client_id=google_iot.cid,
+                   socket_pool=pool,
+                   ssl_context=ssl_context)
 
 # Initialize Google MQTT API Client
 google_mqtt = MQTT_API(client)

--- a/PyPortal/PyPortal_MQTT_Control/code.py
+++ b/PyPortal/PyPortal_MQTT_Control/code.py
@@ -9,9 +9,10 @@ from digitalio import DigitalInOut
 from analogio import AnalogIn
 import neopixel
 import adafruit_adt7410
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text.label import Label
 from adafruit_button import Button
@@ -229,8 +230,7 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected to WiFi!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
@@ -238,6 +238,8 @@ client = MQTT.MQTT(
     port=1883,
     username=secrets["user"],
     password=secrets["pass"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 # Connect callback handlers to client

--- a/PyPortal/PyPortal_Quarantine_Clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/code.py
@@ -6,9 +6,10 @@ import time
 import board
 import busio
 import digitalio
-from adafruit_esp32spi import adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
-import adafruit_requests as requests
+import adafruit_requests
 from adafruit_pyportal import PyPortal
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text import label
@@ -48,7 +49,8 @@ esp32_reset = digitalio.DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-requests.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 # initialize pyportal
 pyportal = PyPortal(esp=esp,

--- a/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
@@ -6,9 +6,10 @@ import time
 import board
 import busio
 import digitalio
-from adafruit_esp32spi import adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
-import adafruit_requests as requests
+import adafruit_requests
 from adafruit_pyportal import PyPortal
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text import label
@@ -68,7 +69,8 @@ esp32_reset = digitalio.DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-requests.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 # initialize pyportal
 pyportal = PyPortal(esp=esp,

--- a/PyPortal/PyPortal_Smart_Switch/code.py
+++ b/PyPortal/PyPortal_Smart_Switch/code.py
@@ -6,9 +6,10 @@ import time
 import gc
 import board
 import busio
-from adafruit_esp32spi import adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_requests as requests
+import adafruit_requests
 import digitalio
 import analogio
 from adafruit_pyportal import PyPortal
@@ -229,7 +230,8 @@ ts = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-requests.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")
@@ -268,11 +270,12 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(
 
 
 # Set up a MiniMQTT Client
-mqtt_client = MQTT(socket,
-                   broker='io.adafruit.com',
+mqtt_client = MQTT(broker='io.adafruit.com',
                    username=secrets['aio_username'],
                    password=secrets['aio_key'],
-                   network_manager=wifi)
+                   network_manager=wifi,
+                   socket_pool=pool,
+                   ssl_context=ssl_context)
 
 mqtt_client.on_connect = connected
 mqtt_client.on_disconnect = disconnected

--- a/PyPortal/pyportal_pet_planter/code.py
+++ b/PyPortal/pyportal_pet_planter/code.py
@@ -7,7 +7,8 @@ import time
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_imageload
 import displayio
@@ -186,13 +187,14 @@ while not esp.is_connected:
         continue
 print("Connected to WiFi!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(broker="io.adafruit.com",
                         username=secrets["aio_user"],
-                        password=secrets["aio_key"])
+                        password=secrets["aio_key"],
+                        socket_pool=pool,
+                        ssl_context=ssl_context)
 
 # Adafruit IO Callback Methods
 # pylint: disable=unused-argument

--- a/Webhook_Plant_Sensor/code.py
+++ b/Webhook_Plant_Sensor/code.py
@@ -5,9 +5,10 @@ import time
 
 import board
 from digitalio import DigitalInOut
+import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -67,14 +68,15 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-# Initialize MQTT interface with the esp interface
-MQTT.set_socket(socket, esp)
+ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl_context,
 )
 
 

--- a/oshwa_magtag_display/code.py
+++ b/oshwa_magtag_display/code.py
@@ -7,7 +7,7 @@ import ssl
 import gc
 import wifi
 import socketpool
-import adafruit_requests as requests
+import adafruit_requests
 from adafruit_magtag.magtag import MagTag
 
 # Get wifi details and more from a secrets.py file
@@ -28,7 +28,7 @@ print(f"Connected to {secrets['ssid']}!")
 print("My IP address is", wifi.radio.ipv4_address)
 
 socket = socketpool.SocketPool(wifi.radio)
-https = requests.Session(socket, ssl.create_default_context())
+https = adafruit_requests.Session(socket, ssl.create_default_context())
 
 # Paste your API token below
 TOKEN = "YOUR_API_TOKEN"


### PR DESCRIPTION
Remove legacy `requests.set_socket` and replace with new `pool` and `ssl_context` helpers from [ConnectionManager](https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager/)