### PR TITLE
Fix get_radio_ssl_context

### DIFF
--- a/Adafruit_IO_Power_Relay/code.py
+++ b/Adafruit_IO_Power_Relay/code.py
@@ -10,7 +10,6 @@ import neopixel
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
@@ -102,7 +101,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(

--- a/Adafruit_IO_Power_Relay/code_light_sensor/code.py
+++ b/Adafruit_IO_Power_Relay/code_light_sensor/code.py
@@ -11,7 +11,6 @@ import adafruit_bh1750
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
@@ -117,7 +116,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(

--- a/Adafruit_IO_Schedule_Trigger/code.py
+++ b/Adafruit_IO_Schedule_Trigger/code.py
@@ -9,7 +9,6 @@ from digitalio import DigitalInOut
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -105,7 +104,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
+++ b/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
@@ -12,7 +12,6 @@ import busio
 from digitalio import DigitalInOut
 import adafruit_connection_manager
 import adafruit_requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a secrets.py file
@@ -36,7 +35,8 @@ spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
 
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 requests = adafruit_requests.Session(pool, ssl_context)
 

--- a/CircuitPython_Zorque_Text_Game_openai/code.py
+++ b/CircuitPython_Zorque_Text_Game_openai/code.py
@@ -4,7 +4,6 @@ import os
 import traceback
 
 import adafruit_connection_manager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import adafruit_requests
 import adafruit_touchscreen
 from adafruit_ticks import ticks_ms, ticks_add, ticks_less
@@ -88,7 +87,8 @@ def set_up_wifi():
 
     spi = board.SPI()
     esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp_cs, esp_ready, esp_reset)
-    ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+    pool = adafruit_connection_manager.get_radio_socketpool(esp)
+    ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
     requests = adafruit_requests.Session(pool, ssl_context)
 
     while not esp.is_connected:

--- a/FunHouse_IOT_Hub/battery_peripheral/code.py
+++ b/FunHouse_IOT_Hub/battery_peripheral/code.py
@@ -20,7 +20,6 @@ from digitalio import DigitalInOut
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -75,7 +74,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/FunHouse_IOT_Hub/door_peripheral/code.py
+++ b/FunHouse_IOT_Hub/door_peripheral/code.py
@@ -19,7 +19,6 @@ import busio
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -58,7 +57,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/FunHouse_IOT_Hub/neopixel_remote/feather_code/code.py
+++ b/FunHouse_IOT_Hub/neopixel_remote/feather_code/code.py
@@ -20,7 +20,6 @@ import busio
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -77,7 +76,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/FunHouse_IOT_Hub/relay_heatindex_peripheral/code.py
+++ b/FunHouse_IOT_Hub/relay_heatindex_peripheral/code.py
@@ -22,7 +22,6 @@ import busio
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -76,7 +75,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/FunHouse_IOT_Hub/relay_peripheral/code.py
+++ b/FunHouse_IOT_Hub/relay_peripheral/code.py
@@ -17,7 +17,6 @@ import busio
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -70,7 +69,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(

--- a/Metro_M7_Examples/WiFi/code.py
+++ b/Metro_M7_Examples/WiFi/code.py
@@ -7,7 +7,6 @@ import busio
 from digitalio import DigitalInOut
 import adafruit_connection_manager
 import adafruit_requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 
 print("ESP32 SPI webclient test")
@@ -23,7 +22,8 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 requests = adafruit_requests.Session(pool, ssl_context)
 

--- a/PyPortal/PyPortal_AWS_IOT_Planter/code.py
+++ b/PyPortal/PyPortal_AWS_IOT_Planter/code.py
@@ -19,7 +19,6 @@ import neopixel
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_aws_iot import MQTT_CLIENT
 from adafruit_seesaw.seesaw import Seesaw
@@ -87,7 +86,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Soil Sensor Setup
 i2c_bus = busio.I2C(board.SCL, board.SDA)

--- a/PyPortal/PyPortal_GCP_IOT_Planter/code.py
+++ b/PyPortal/PyPortal_GCP_IOT_Planter/code.py
@@ -18,7 +18,6 @@ import gcp_gfx_helper
 import neopixel
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_gc_iot_core import MQTT_API, Cloud_Core
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_seesaw.seesaw import Seesaw
@@ -49,7 +48,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Soil Sensor Setup
 i2c_bus = busio.I2C(board.SCL, board.SDA)

--- a/PyPortal/PyPortal_MQTT_Control/code.py
+++ b/PyPortal/PyPortal_MQTT_Control/code.py
@@ -12,7 +12,6 @@ import adafruit_adt7410
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text.label import Label
 from adafruit_button import Button
@@ -230,7 +229,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected to WiFi!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(

--- a/PyPortal/PyPortal_Quarantine_Clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/code.py
@@ -7,7 +7,6 @@ import board
 import busio
 import digitalio
 import adafruit_connection_manager
-from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests
 from adafruit_pyportal import PyPortal
@@ -49,7 +48,8 @@ esp32_reset = digitalio.DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 requests = adafruit_requests.Session(pool, ssl_context)
 
 # initialize pyportal

--- a/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
@@ -7,7 +7,6 @@ import board
 import busio
 import digitalio
 import adafruit_connection_manager
-from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_requests
 from adafruit_pyportal import PyPortal
@@ -69,7 +68,8 @@ esp32_reset = digitalio.DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 requests = adafruit_requests.Session(pool, ssl_context)
 
 # initialize pyportal

--- a/PyPortal/PyPortal_Smart_Switch/code.py
+++ b/PyPortal/PyPortal_Smart_Switch/code.py
@@ -7,7 +7,6 @@ import gc
 import board
 import busio
 import adafruit_connection_manager
-from adafruit_esp32spi import adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_requests
 import digitalio
@@ -230,7 +229,8 @@ ts = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=False)
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:

--- a/PyPortal/pyportal_pet_planter/code.py
+++ b/PyPortal/pyportal_pet_planter/code.py
@@ -8,7 +8,6 @@ import board
 import busio
 from digitalio import DigitalInOut
 import adafruit_connection_manager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 import adafruit_imageload
 import displayio
@@ -187,7 +186,8 @@ while not esp.is_connected:
         continue
 print("Connected to WiFi!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(broker="io.adafruit.com",

--- a/Webhook_Plant_Sensor/code.py
+++ b/Webhook_Plant_Sensor/code.py
@@ -8,7 +8,6 @@ from digitalio import DigitalInOut
 import adafruit_connection_manager
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as pool
 import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
@@ -68,7 +67,8 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
-ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(


### PR DESCRIPTION
Correct my mistake of using:
```
ssl_context = adafruit_connection_manager.create_fake_ssl_context(pool, esp)
```
to the right helpers:
```
pool = adafruit_connection_manager.get_radio_socketpool(esp)
ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
```