### PR TITLE
make feather can ack example work with stm32f405

### DIFF
--- a/FeatherCAN_CircuitPython/listener-ack/code.py
+++ b/FeatherCAN_CircuitPython/listener-ack/code.py
@@ -50,5 +50,5 @@ while True:
     if gap != 1:
         print(f"gap: {gap}")
 
-    print("Sending ACK")
+    print(f"Sending ACK: {count}")
     can.send(canio.Message(id=0x409, data=struct.pack("<I", count)))

--- a/FeatherCAN_CircuitPython/sender-ack/code.py
+++ b/FeatherCAN_CircuitPython/sender-ack/code.py
@@ -38,24 +38,31 @@ while True:
     print(f"Sending message: count={count} now_ms={now_ms}")
 
     message = canio.Message(id=0x408, data=struct.pack("<II", count, now_ms))
+
+    # Keep trying to send the same message until confirmed.
     while True:
+        received_ack_confirmed = False
         can.send(message)
 
-        message_in = listener.receive()
-        if message_in is None:
-            print("No ACK received within timeout")
-            continue
+        # Read in all messages.
+        for message_in in listener:
+            data = message_in.data
+            if len(data) != 4:
+                print(f"Unusual message length {len(data)}")
+                continue
 
-        data = message_in.data
-        if len(data) != 4:
-            print(f"Unusual message length {len(data)}")
-            continue
+            ack_count = struct.unpack("<I", data)[0]
+            if ack_count == count:
+                print(f"Received ACK: {ack_count}")
+                received_ack_confirmed = True
+                break
+            else:
+                print(f"Received incorrect ACK: {ack_count} should be {count}")
 
-        ack_count = struct.unpack("<I", data)[0]
-        if ack_count == count:
-            print("Received ACK")
+        if received_ack_confirmed:
             break
-        print(f"Received incorrect ACK: {ack_count} should be {count}")
+
+        print(f"No ACK received within receive timeout, sending {count} again")
 
     time.sleep(.5)
     count += 1

--- a/FeatherCAN_CircuitPython/sender-ack/code.py
+++ b/FeatherCAN_CircuitPython/sender-ack/code.py
@@ -56,8 +56,8 @@ while True:
                 print(f"Received ACK: {ack_count}")
                 received_ack_confirmed = True
                 break
-            else:
-                print(f"Received incorrect ACK: {ack_count} should be {count}")
+
+            print(f"Received incorrect ACK: {ack_count} should be {count}")
 
         if received_ack_confirmed:
             break


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Avoids the issue in https://github.com/adafruit/circuitpython/issues/3644

The STM32F405 Feather differes from the other adafruit CAN friendly boards because it has 3 "transmit mailboxes". The other boards seem to have only 1 tx buffer (not 100% sure about this). The current ack example does not work well on the stm boards after bus errors because it assumes the next received message will be after the most recent sent message, which is not the case because of these 3 transmit mailboxes. For example:

1. send 1, receive 1
2. send 2, receive 2
3. *can bus disconnection*
4. send 3, buffer (tx mailbox0)
5. resend 3, buffer (tx mailbox1)
6. resend 3, buffer (tx mailbox2)
7. resend 3, buffer (out of mailboxes, replaces value in mailbox0)
8. *can bus reconnection*
9. recieves 3! behind the scenes, the stm transmits the remaining 2 messages in the transmit buffer
10. send 4, receives 3 (oops! this was a 3 in the buffer)
11. resend 4, receives 3 (oops! this was the last 3 in the buffer)
12. resend 4, receives 4 (yay! but this is the wrong one, and it was actually the first 4 from step 10)
13. send 5, receives 4 (oops! that is the second 4... process continues...)

This is very clear in the screenshot here https://github.com/adafruit/circuitpython/issues/3644#issuecomment-1982235235

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

I am worried the iterator over the listener may be a little confusing to the novice ciruitpython user. This is the easier way though for the CiruitPython loop to _consume_ all of those "pending" transmit attempts before moving on.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I ran this locally and it seems to work well.

