### PR TITLE
User must provide a mount_sd.py script

### DIFF
--- a/CircuitPython_sdcardio_sdioio/benchmark/code.py
+++ b/CircuitPython_sdcardio_sdioio/benchmark/code.py
@@ -5,6 +5,8 @@
 import time
 import os
 
+# pylint: disable=unused-import
+import mount_sd # You must create a module mount_sd.py that mounts your sd card!
 
 # First, just write the file 'hello.txt' to the card
 with open("/sd/hello.txt", "w") as f:

--- a/CircuitPython_sdcardio_sdioio/list_files/code.py
+++ b/CircuitPython_sdcardio_sdioio/list_files/code.py
@@ -4,6 +4,9 @@
 
 import os
 
+# pylint: disable=unused-import
+import mount_sd # You must create a module mount_sd.py that mounts your sd card!
+
 def print_directory(path, tabs=0):
     for file in os.listdir(path):
         stats = os.stat(path + "/" + file)

--- a/CircuitPython_sdcardio_sdioio/log_temperature/code.py
+++ b/CircuitPython_sdcardio_sdioio/log_temperature/code.py
@@ -8,6 +8,9 @@ import board
 import digitalio
 import microcontroller
 
+# pylint: disable=unused-import
+import mount_sd # You must create a module mount_sd.py that mounts your sd card!
+
 led = digitalio.DigitalInOut(board.D13)
 led.direction = digitalio.Direction.OUTPUT
 

--- a/CircuitPython_sdcardio_sdioio/play_mp3s/code.py
+++ b/CircuitPython_sdcardio_sdioio/play_mp3s/code.py
@@ -8,6 +8,9 @@ import time
 import board
 import digitalio
 
+# pylint: disable=unused-import
+import mount_sd # You must create a module mount_sd.py that mounts your sd card!
+
 # Updating the display can interfere with MP3 playback if it is not
 # done carefully
 try:


### PR DESCRIPTION
this import line was removed without checking, because it caused a pylint message. (24dacb7fe6c5d4702b8b81c59cfcea0a7b7ce416) -- the guide may need to be reviewed as well, to make sure usage of mount.py is explained (I'll tackle this next)
