### PR TITLE
Update TOTP_Friend secrets.py

### DIFF
--- a/PyPortal/PyPortal_TOTP_Friend/secrets.py
+++ b/PyPortal/PyPortal_TOTP_Friend/secrets.py
@@ -6,10 +6,6 @@
 # If you put them in the code you risk committing that info or sharing it
 
 secrets = {
-    'ssid' : 'yourwifissid',
-    'password' : 'yourwifipassword',
-    'timezone' : "America/New_York", # http://worldtimeapi.org/timezones
-    # https://github.com/pyotp/pyotp example
     'totp_keys' : [("Discord ", "JBSWY3DPEHPK3PXP"),
                    ("Gmail", "JBSWY3DPEHPK3PZP"),
                    ("GitHub", "JBSWY5DZEHPK3PXP"),


### PR DESCRIPTION
This is part of updating the TOTP_Friend project to settings.toml. The wifi settings are now in settings.toml, but the keys reamain in secrets.py, because they are in a hierarchical structure.

By mistake, I committed the code.py changes directly instead of making a PR.

Guide already updated.