### PR TITLE
Move app name a few pixel down for better vertical alignment

### DIFF
--- a/Macropad_Hotkeys/code.py
+++ b/Macropad_Hotkeys/code.py
@@ -74,10 +74,10 @@ for key_index in range(12):
                                                 macropad.display.height - 1 -
                                                 (3 - y) * 12),
                              anchor_point=(x / 2, 1.0)))
-rect = Rect(0, 0, macropad.display.width, 12, fill=0xFFFFFF)
+rect = Rect(0, 0, macropad.display.width, 13, fill=0xFFFFFF)
 group.append(rect)
 group.append(label.Label(terminalio.FONT, text='', color=0x000000,
-                         anchored_position=(macropad.display.width//2, -2),
+                         anchored_position=(macropad.display.width//2, 0),
                          anchor_point=(0.5, 0.0)))
 macropad.display.root_group = group
 


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**
For the MacroPad Hotkeys project the "app name" is touching the top of the header bar.
As there is "enough" space this change makes the header bar one pixel higher and moves the text 2 pixels down.
This tiny changes improves the vertical aligment of the "app name". 

- **Describe any known limitations with your change.**
Applies only to the "MacroPad Hotkeys project / code".
