### PR TITLE
Update SHT4x trinkey demo

### DIFF
--- a/SHT4x_Trinkey_Demos/CircuitPython/sht4x_temp_humidity/code.py
+++ b/SHT4x_Trinkey_Demos/CircuitPython/sht4x_temp_humidity/code.py
@@ -8,7 +8,8 @@ import adafruit_sht4x
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 sht = adafruit_sht4x.SHT4x(i2c)
-print("Found SHT4x with serial number", hex(sht.serial_number))
+# overflow issue with sht41, not present with sht45
+# print("Found SHT4x with serial number", hex(sht.serial_number))
 
 sht.mode = adafruit_sht4x.Mode.NOHEAT_HIGHPRECISION
 print("Current mode is: ", adafruit_sht4x.Mode.string[sht.mode])


### PR DESCRIPTION
guide feedback for sht4x trinkey guide said error was being thrown for the main CP demo. seems that sht41 sensors have an overflow when calling the serial_number while sht45 sensors do not. commenting out the line for now for the guide and opening an issue in the library.