### PR TITLE
CLUE Light Painter ::  bmp2led.py

### DIFF
--- a/CLUE_Light_Painter/bmp2led.py
+++ b/CLUE_Light_Painter/bmp2led.py
@@ -339,6 +339,8 @@ class BMP2LED:
                         # Accumulated error vals will all now be 0.0 to <2.0.
                         # Quantizing err into a new uint8 ndarray, all values
                         # will be 0 or 1.
+                        # Convert float values in err to integers
+                        err = [int(min(max(0, e), 255)) for e in err]
                         err_bits = ulab.numpy.array(err, dtype=ulab.numpy.uint8)
                         # Add the 1's back into 'got', increasing the
                         # brightness of certain pixels by 1. Because the max


### PR DESCRIPTION
Single line change to accommodate different behavior with ulab processing arrays in CircuitPython 9.x. The example guide code had been failing after CP8.x.

```
BLE:Reconnecting | code.py | 9.0.5\Traceback (most recent call last):
  File "code.py", line 555, in <module>
  File "code.py", line 546, in run
  File "code.py", line 245, in load_image
  File "bmp2led.py", line 342, in process
OverflowError: value must fit in 1 byte(s)
BLE:Reconnecting | 342@bmp2led.py OverflowError | 9.0.5\
```

This has been tested with a CLUE nRF52840 on CP 9.0.5. Also with a CPB. Both myself and [adafruit forum user JayPi](https://forums.adafruit.com/viewtopic.php?t=211550) have verified this stops the crashing and the code runs as expected. 

```
# Convert float values in err to integers
err = [int(min(max(0, e), 255)) for e in err]
```