### PR TITLE
Soundboard Speaker I2S fix

### DIFF
--- a/Soundboard_Scooter_Bike/code.py
+++ b/Soundboard_Scooter_Bike/code.py
@@ -28,7 +28,7 @@ KEY_PINS = (
 
 km = keypad.Keys( KEY_PINS, value_when_pressed=False, pull=True)
 
-audio = audiobusio.I2SOut(board.RX, board.TX, board.D9)
+audio = audiobusio.I2SOut(board.TX, board.RX, board.D9)
 
 mixer = audiomixer.Mixer(voice_count=len(wav_files), sample_rate=22050, channel_count=1,
                          bits_per_sample=16, samples_signed=True)


### PR DESCRIPTION
The [Soundboard Speaker for Bikes & Scooters](https://learn.adafruit.com/soundboard-speaker-for-bikes-scooters) has a discrepancy between the Circuit Diagram and the Code. 

This small code.py change from:

`audio = audiobusio.I2SOut(board.RX, board.TX, board.D9)
`

to:

`audio = audiobusio.I2SOut(board.TX, board.RX, board.D9)
`

swaps the bit clock and word select pins so the Circuit Diagram is correct. 

This came up in a [lengthy forum issue](https://forums.adafruit.com/viewtopic.php?t=212333) and resolved the problem.