### PR TITLE
Correct field names for Adafruit IO to match website

### DIFF
--- a/CircuitPython_Templates/adafruit_io_cpu_temp_neopixel_color/code.py
+++ b/CircuitPython_Templates/adafruit_io_cpu_temp_neopixel_color/code.py
@@ -48,8 +48,8 @@ pool = socketpool.SocketPool(wifi.radio)
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    username=os.getenv("ADAFRUIT_IO_USERNAME"),
-    password=os.getenv("ADAFRUIT_IO_KEY"),
+    username=os.getenv("ADAFRUIT_AIO_USERNAME"),
+    password=os.getenv("ADAFRUIT_AIO_KEY"),
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )


### PR DESCRIPTION
As reported in Slack, JP found the IO site doesn't match the code in the boards learn guides for using Circuitpython with Adafruit IO.
This updates the code in line with the newest version of the field name