### PR TITLE
Spirit Board Improvements

### DIFF
--- a/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_board.py
+++ b/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_board.py
@@ -240,6 +240,8 @@ class SpiritBoard(displayio.Group):
         # loop over the words in the message
         for index, word in enumerate(message_words):
             print(f"index: {index}, word: {word}")
+            # send it to lowercase to get rid of capital letters
+            word = word.lower()
 
             # if the current word is one of the full words on the board
             if word in SpiritBoard.FULL_WORDS:
@@ -269,12 +271,17 @@ class SpiritBoard(displayio.Group):
 
                 # loop over each character in the word
                 for character in word:
-                    # slide the planchette to the current characters location
-                    self.slide_planchette(SpiritBoard.LOCATIONS[character],
-                                          delay=delay, step_size=step_size)
+                    # if the character is in our locations mapping
+                    if character in SpiritBoard.LOCATIONS.keys():
+                        # slide the planchette to the current characters location
+                        self.slide_planchette(SpiritBoard.LOCATIONS[character],
+                                              delay=delay, step_size=step_size)
 
-                    # pause after we arrive
-                    time.sleep(0.5)
+                        # pause after we arrive
+                        time.sleep(0.5)
+                    else:
+                        # character is not in our mapping
+                        print(f"Skipping '{character}', it's not on the board.")
 
             # if we are not skipping spaces, and we are not done with the message
             if not skip_spaces and index < len(message_words) - 1:

--- a/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_board.py
+++ b/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_board.py
@@ -272,7 +272,7 @@ class SpiritBoard(displayio.Group):
                 # loop over each character in the word
                 for character in word:
                     # if the character is in our locations mapping
-                    if character in SpiritBoard.LOCATIONS.keys():
+                    if character in SpiritBoard.LOCATIONS:
                         # slide the planchette to the current characters location
                         self.slide_planchette(SpiritBoard.LOCATIONS[character],
                                               delay=delay, step_size=step_size)

--- a/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_messages.txt
+++ b/TFT_Spirit_Board/esp32s3_s2_tft_featherwing_480x320/spirit_messages.txt
@@ -1,0 +1,4 @@
+hello world
+spirits are near
+i <3 circuitpython
+goodbye

--- a/TFT_Spirit_Board/pyportal/spirit_board.py
+++ b/TFT_Spirit_Board/pyportal/spirit_board.py
@@ -240,6 +240,8 @@ class SpiritBoard(displayio.Group):
         # loop over the words in the message
         for index, word in enumerate(message_words):
             print(f"index: {index}, word: {word}")
+            # send it to lowercase to get rid of capital letters
+            word = word.lower()
 
             # if the current word is one of the full words on the board
             if word in SpiritBoard.FULL_WORDS:
@@ -269,12 +271,17 @@ class SpiritBoard(displayio.Group):
 
                 # loop over each character in the word
                 for character in word:
-                    # slide the planchette to the current characters location
-                    self.slide_planchette(SpiritBoard.LOCATIONS[character],
-                                          delay=delay, step_size=step_size)
+                    # if the character is in our locations mapping
+                    if character in SpiritBoard.LOCATIONS.keys():
+                        # slide the planchette to the current characters location
+                        self.slide_planchette(SpiritBoard.LOCATIONS[character],
+                                              delay=delay, step_size=step_size)
 
-                    # pause after we arrive
-                    time.sleep(0.5)
+                        # pause after we arrive
+                        time.sleep(0.5)
+                    else:
+                        # character is not in our mapping
+                        print(f"Skipping '{character}', it's not on the board.")
 
             # if we are not skipping spaces, and we are not done with the message
             if not skip_spaces and index < len(message_words) - 1:

--- a/TFT_Spirit_Board/pyportal/spirit_board.py
+++ b/TFT_Spirit_Board/pyportal/spirit_board.py
@@ -272,7 +272,7 @@ class SpiritBoard(displayio.Group):
                 # loop over each character in the word
                 for character in word:
                     # if the character is in our locations mapping
-                    if character in SpiritBoard.LOCATIONS.keys():
+                    if character in SpiritBoard.LOCATIONS:
                         # slide the planchette to the current characters location
                         self.slide_planchette(SpiritBoard.LOCATIONS[character],
                                               delay=delay, step_size=step_size)

--- a/TFT_Spirit_Board/pyportal/spirit_messages.txt
+++ b/TFT_Spirit_Board/pyportal/spirit_messages.txt
@@ -1,0 +1,4 @@
+hello world
+spirits are near
+i <3 circuitpython
+goodbye

--- a/TFT_Spirit_Board/pyportal_titano/spirit_board.py
+++ b/TFT_Spirit_Board/pyportal_titano/spirit_board.py
@@ -240,6 +240,8 @@ class SpiritBoard(displayio.Group):
         # loop over the words in the message
         for index, word in enumerate(message_words):
             print(f"index: {index}, word: {word}")
+            # send it to lowercase to get rid of capital letters
+            word = word.lower()
 
             # if the current word is one of the full words on the board
             if word in SpiritBoard.FULL_WORDS:
@@ -269,12 +271,17 @@ class SpiritBoard(displayio.Group):
 
                 # loop over each character in the word
                 for character in word:
-                    # slide the planchette to the current characters location
-                    self.slide_planchette(SpiritBoard.LOCATIONS[character],
-                                          delay=delay, step_size=step_size)
+                    # if the character is in our locations mapping
+                    if character in SpiritBoard.LOCATIONS.keys():
+                        # slide the planchette to the current characters location
+                        self.slide_planchette(SpiritBoard.LOCATIONS[character],
+                                              delay=delay, step_size=step_size)
 
-                    # pause after we arrive
-                    time.sleep(0.5)
+                        # pause after we arrive
+                        time.sleep(0.5)
+                    else:
+                        # character is not in our mapping
+                        print(f"Skipping '{character}', it's not on the board.")
 
             # if we are not skipping spaces, and we are not done with the message
             if not skip_spaces and index < len(message_words) - 1:

--- a/TFT_Spirit_Board/pyportal_titano/spirit_board.py
+++ b/TFT_Spirit_Board/pyportal_titano/spirit_board.py
@@ -272,7 +272,7 @@ class SpiritBoard(displayio.Group):
                 # loop over each character in the word
                 for character in word:
                     # if the character is in our locations mapping
-                    if character in SpiritBoard.LOCATIONS.keys():
+                    if character in SpiritBoard.LOCATIONS:
                         # slide the planchette to the current characters location
                         self.slide_planchette(SpiritBoard.LOCATIONS[character],
                                               delay=delay, step_size=step_size)

--- a/TFT_Spirit_Board/pyportal_titano/spirit_messages.txt
+++ b/TFT_Spirit_Board/pyportal_titano/spirit_messages.txt
@@ -1,0 +1,4 @@
+hello world
+spirits are near
+i <3 circuitpython
+goodbye


### PR DESCRIPTION
A few more improvements based on feedback from JP.

- Included the `spirit_messages.txt` file in the project so the user can modify an existing file instead of having to create it. This should make it also appear on the drive structure screenshots as well I believe.
- Handle uppercase characters in the message by moving everything to lowercase before looking up the location in the dictionary map (which has all lowercase keys)
- More gracefully handle invalid characters that aren't on the spirit board. Previously the code would raise an exception when it attempts to lookup the character in the locations dictionary. Now it will print out a message in the serial output and skip the invalid character moving on to the next character in the message.