### PR TITLE
adding ssd1680z to Eink Weather Example

### DIFF
--- a/EInk_Bonnet_Weather_Station/code.py
+++ b/EInk_Bonnet_Weather_Station/code.py
@@ -15,6 +15,7 @@ import busio
 import board
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680 import Adafruit_SSD1680Z
 from weather_graphics import Weather_Graphics
 
 spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
@@ -42,9 +43,11 @@ params = {"q": LOCATION, "appid": OPEN_WEATHER_TOKEN}
 data_source = DATA_SOURCE_URL + "?" + urllib.parse.urlencode(params)
 
 # Initialize the Display
-display = Adafruit_SSD1680(     # Newer eInk Bonnet
-# display = Adafruit_SSD1675(   # Older eInk Bonnet
-    122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
+display = Adafruit_SSD1680Z(     # New Bonnet ssd1680z [GDEY0213B74]
+#display = Adafruit_SSD1680(     # Old eInk Bonnet ssd1680
+#display = Adafruit_SSD1675(   # Older eInk Bonnet ssd1675
+#    122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
+    120, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
 )
 
 display.rotation = 1


### PR DESCRIPTION
Minor changes to [EInk Bonnet 2.13 Weather example](https://learn.adafruit.com/raspberry-pi-e-ink-weather-station-using-python/weather-station-code) code to work with latest display ssd1680z update. Hardware change in August of 2024 required an [ssd1680z subclass addition to library](https://github.com/adafruit/Adafruit_CircuitPython_EPD/pull/83). 

Forum user @luisrh01 who initially pointed this out has [tested code as well as myself on a Pi 5's](https://forums.adafruit.com/viewtopic.php?t=213959) running Bookworm and it is working as expected.


