### PR TITLE
Update RPi eInk Bonnet guides with new SSD1680B driver

### DIFF
--- a/EInk_Bonnet_Event_Calendar/code.py
+++ b/EInk_Bonnet_Event_Calendar/code.py
@@ -18,6 +18,7 @@ from PIL import Image, ImageDraw, ImageFont
 from adafruit_epd.epd import Adafruit_EPD
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 
 spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 ecs = digitalio.DigitalInOut(board.CE0)
@@ -39,7 +40,8 @@ MAX_LINES = 2
 DEBOUNCE_DELAY = 0.3
 
 # Initialize the Display
-display = Adafruit_SSD1680(     # Newer eInk Bonnet
+display = Adafruit_SSD1680B(    # Newer eInk Bonnet (GDEY0213B74 display)
+# display = Adafruit_SSD1680(   # Old eInk Bonnet
 # display = Adafruit_SSD1675(   # Older eInk Bonnet
     122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
 )

--- a/EInk_Bonnet_Weather_Station/code.py
+++ b/EInk_Bonnet_Weather_Station/code.py
@@ -15,7 +15,7 @@ import busio
 import board
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
-from adafruit_epd.ssd1680 import Adafruit_SSD1680Z
+from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from weather_graphics import Weather_Graphics
 
 spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
@@ -43,8 +43,8 @@ params = {"q": LOCATION, "appid": OPEN_WEATHER_TOKEN}
 data_source = DATA_SOURCE_URL + "?" + urllib.parse.urlencode(params)
 
 # Initialize the Display
-display = Adafruit_SSD1680Z(     # New Bonnet ssd1680z [GDEY0213B74]
-#display = Adafruit_SSD1680(     # Old eInk Bonnet ssd1680
+display = Adafruit_SSD1680B(   # Newer eInk Bonnet (GDEY0213B74 display)
+#display = Adafruit_SSD1680(   # Old eInk Bonnet ssd1680
 #display = Adafruit_SSD1675(   # Older eInk Bonnet ssd1675
 #    122, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,
     120, 250, spi, cs_pin=ecs, dc_pin=dc, sramcs_pin=None, rst_pin=rst, busy_pin=busy,


### PR DESCRIPTION
This PR accompanies (and depends on changes within) adafruit/Adafruit_CircuitPython_EPD#86. This PR should be merged **after** that one.

#### Scope

Updates the [EInk_Bonnet_Event_Calendar](./EInk_Bonnet_Event_Calendar) and [EInk_Bonnet_Weather_Station](./EInk_Bonnet_Weather_Station) guides with the updated SSD1680**B** driver, which is required for the most recent GDEY0213B74-based boards.

#### Limitations

The example now imports and instantiates a new `Adafruit_SSD1680B` driver, which is only compatible with the latest board revision. However, older driver imports and instantiations remain in the guide to make it clear how to use other driver variants.

#### Tests

Successfully (no warnings/errors) executed the `pylint_check.sh` script (`pylint==2.7.1` on Python 3.10.16).