### PR TITLE
Fix for Karel

### DIFF
--- a/CircuitPython_Karel_The_Robot/karel/circuitpythonkarel.py
+++ b/CircuitPython_Karel_The_Robot/karel/circuitpythonkarel.py
@@ -140,7 +140,7 @@ class World:
         self.world_group = Group()
         self.world_group.append(self.background_group)
 
-        lib_dir = "/".join(__file__.split("/")[0:3])
+        lib_dir = "karel"
         self.spritesheet_bmp, self.spritesheet_palette = adafruit_imageload.load(
             f"{lib_dir}/spritesheet.png"
         )


### PR DESCRIPTION
I accidentally tested with `karel/` in the wrong location on my device at first and missed this. The code can be simplified and fix the sprite loading by hardcoding the directory to match the structure of the project code.