### PR TITLE
Update mini_pitft_stats.py to use getbbox() instead of getsize()

### DIFF
--- a/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
+++ b/Pi_Hole_Ad_Blocker/mini_pitft_stats.py
@@ -107,26 +107,26 @@ while True:
     y = top
     if not buttonA.value:  # just button A pressed
         draw.text((x, y), IP, font=font, fill="#FFFF00")
-        y += font.getsize(IP)[1]
+        y += font.getbbox(IP)[3]
         draw.text((x, y), CPU, font=font, fill="#FFFF00")
-        y += font.getsize(CPU)[1]
+        y += font.getbbox(CPU)[3]
         draw.text((x, y), MemUsage, font=font, fill="#00FF00")
-        y += font.getsize(MemUsage)[1]
+        y += font.getbbox(MemUsage)[3]
         draw.text((x, y), Disk, font=font, fill="#0000FF")
-        y += font.getsize(Disk)[1]
+        y += font.getbbox(Disk)[3]
         draw.text((x, y), Temp, font=font, fill="#FF00FF")
-        y += font.getsize(Temp)[1]
+        y += font.getbbox(Temp)[3]
     else:
         draw.text((x, y), IP, font=font, fill="#FFFF00")
-        y += font.getsize(IP)[1]
+        y += font.getbbox(IP)[3]
         draw.text((x, y), HOST, font=font, fill="#FFFF00")
-        y += font.getsize(HOST)[1]
+        y += font.getbbox(HOST)[3]
         draw.text((x, y), "Ads Blocked: {}".format(str(ADSBLOCKED)), font=font, fill="#00FF00")
-        y += font.getsize(str(ADSBLOCKED))[1]
+        y += font.getbbox(str(ADSBLOCKED))[3]
         draw.text((x, y), "Clients: {}".format(str(CLIENTS)), font=font, fill="#0000FF")
-        y += font.getsize(str(CLIENTS))[1]
+        y += font.getbbox(str(CLIENTS))[3]
         draw.text((x, y), "DNS Queries: {}".format(str(DNSQUERIES)), font=font, fill="#FF00FF")
-        y += font.getsize(str(DNSQUERIES))[1]
+        y += font.getbbox(str(DNSQUERIES))[3]
 
     # Display image.
     disp.image(image, rotation)


### PR DESCRIPTION
A little update to avoid message "DeprecationWarning: getsize is deprecated and will be removed in Pillow 10 (2023-07-01). Use getbbox or getlength instead."

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
