### PR TITLE
sparkle motion IR remote corrected neopixel pin & count

### DIFF
--- a/Sparkle_Motion_Examples/CircuitPython_Sparkle_Motion_IR_Remote/code.py
+++ b/Sparkle_Motion_Examples/CircuitPython_Sparkle_Motion_IR_Remote/code.py
@@ -22,7 +22,7 @@ IR_CODE_LEFT = (0, 253, 16, 239)
 
 t0 = next_heartbeat = time.monotonic()
 
-pixel = neopixel.NeoPixel(board.NEOPIXEL, 1)
+pixel = neopixel.NeoPixel(board.D21, 8)
 
 brightness = 1
 pixel.brightness = brightness / 10


### PR DESCRIPTION
While working on the rest of the page this belongs to I realized the pin and LED count were incorrect, this corrects them.