### PR TITLE
quick fix broken imports/calls of pcf8523

### DIFF
--- a/Daily_Cheer_Automaton/CircuitPython/code.py
+++ b/Daily_Cheer_Automaton/CircuitPython/code.py
@@ -40,7 +40,7 @@ import busio as io
 # import bitbangio as io
 
 # import adafruit_ds3231
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 
 # SD card
 import sdcardio
@@ -115,7 +115,7 @@ i2c = io.I2C(board.SCL, board.SDA)  # Change to the appropriate I2C clock & data
 
 # Create the RTC instance:
 # rtc = adafruit_ds3231.DS3231(i2c)
-rtc = adafruit_pcf8523.PCF8523(i2c)
+rtc = PCF8523(i2c)
 
 # Lookup table for names of days (nicer printing).
 days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")

--- a/Macropad_2FA_TOTP/code.py
+++ b/Macropad_2FA_TOTP/code.py
@@ -10,7 +10,7 @@ import keypad
 import rotaryio
 import neopixel
 # crypto stuff
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 import adafruit_hashlib as hashlib
 # UI stuff
 import displayio
@@ -45,7 +45,7 @@ except KeyError:
 # set board to use PCF8523 as its RTC
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-pcf = adafruit_pcf8523.PCF8523(i2c)
+pcf = PCF8523(i2c)
 rtc.set_time_source(pcf)
 
 #-------------------------------------------------------------------------

--- a/Macropad_2FA_TOTP/rtc_setter.py
+++ b/Macropad_2FA_TOTP/rtc_setter.py
@@ -4,11 +4,11 @@
 
 import time
 import board
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-pcf = adafruit_pcf8523.PCF8523(i2c)
+pcf = PCF8523(i2c)
 
 # values to set
 YEAR = 2021

--- a/Pulse_Oximeter_Logger/code.py
+++ b/Pulse_Oximeter_Logger/code.py
@@ -21,7 +21,7 @@ import sdcardio
 import board
 import busio
 import storage
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 import _bleio
 import adafruit_ble
 from adafruit_ble.advertising.standard import Advertisement
@@ -39,7 +39,7 @@ log_interval = 2  # you can adjust this to log at a different rate
 
 # RTC setup
 I2C = busio.I2C(board.SCL, board.SDA)
-rtc = adafruit_pcf8523.PCF8523(I2C)
+rtc = PCF8523(I2C)
 
 days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 

--- a/blahaj/code.py
+++ b/blahaj/code.py
@@ -6,14 +6,14 @@ import time
 
 import board
 from adafruit_lc709203f import LC709203F
-import adafruit_pcf8523
+from adafruit_pcf8523.pcf8523 import PCF8523
 from simpleio import tone
 import neopixel
 from adafruit_led_animation.animation.rainbow import Rainbow
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-rtc = adafruit_pcf8523.PCF8523(i2c)
+rtc = PCF8523(i2c)
 battery = LC709203F(i2c)
 indicator = neopixel.NeoPixel(board.A1, 1)
 


### PR DESCRIPTION
Several example files incorrectly `import adafruit_pcf8523` and do `rtc = adafruit_pcf8523.PCF8523(I2C)` when they should `from adafruit_pcf8523.pcf8523 import PCF8523` and `rtc = PCF8523(I2C)`. This PR corrects these imports and makes no other changes. I don't own the various bits of hardware necessary to test these examples, but my changes here *should* have no other impact.