### PR TITLE
fixed issue of reading Network object in code.py of example for Arduino Nano …

### DIFF
--- a/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
+++ b/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
@@ -46,7 +46,7 @@ print("Firmware vers.", esp.firmware_version)
 print("MAC addr:", [hex(i) for i in esp.MAC_address])
 
 for ap in esp.scan_networks():
-    print("\t%s\t\tRSSI: %d" % (str(ap['ssid'], 'utf-8'), ap['rssi']))
+    print("\t%s\t\tRSSI: %d" % (str(ap.ssid, 'utf-8'), ap.rssi))
 
 print("Connecting to AP...")
 while not esp.is_connected:
@@ -55,7 +55,7 @@ while not esp.is_connected:
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
+print("Connected to", str(esp.ap_info.ssid, "utf-8"), "\tRSSI:", esp.ap_info.rssi)
 print("My IP address is", esp.pretty_ip(esp.ip_address))
 
 print(


### PR DESCRIPTION
…RP2040 Connect

### Description
This is a fix for few syntex errors and also an update for the example according to the latest documentation.

### Working environment: 
CircuitPython version: 9.2.4

### Target platform
Arduino Nano RP2040 Connect

#### Line 49:
The `ap` is a `Network` object which is not in dictionay type, so the content should be retrieved by `obj.attribute_name`

#### Line 58:
The `esp` object has no dictionary keys named `ssid `and `rssi`, but which are packed in the `ap_info` object according to the official documentation: [adafruit_esp32spi - ap_info](https://docs.circuitpython.org/projects/esp32spi/en/latest/api.html#adafruit_esp32spi.adafruit_esp32spi.ESP_SPIcontrol.ap_info)
