### PR TITLE
adding error handling for settings.toml

### DIFF
--- a/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Adafruit_IO/code.py
+++ b/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Adafruit_IO/code.py
@@ -13,10 +13,18 @@ import adafruit_requests
 import adafruit_ahtx0
 from adafruit_io.adafruit_io import IO_HTTP, AdafruitIO_RequestError
 
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+try:
+    wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+except TypeError:
+    print("Could not find WiFi info. Check your settings.toml file!")
+    raise
 
-aio_username = os.getenv('aio_username')
-aio_key = os.getenv('aio_key')
+try:
+    aio_username = os.getenv('ADAFRUIT_AIO_USERNAME')
+    aio_key = os.getenv('ADAFRUIT_AIO_KEY')
+except TypeError:
+    print("Could not find Adafruit IO info. Check your settings.toml file!")
+    raise
 
 pool = socketpool.SocketPool(wifi.radio)
 requests = adafruit_requests.Session(pool, ssl.create_default_context())

--- a/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Azure_IoT_Central/code.py
+++ b/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Azure_IoT_Central/code.py
@@ -19,7 +19,11 @@ i2c = busio.I2C(board.GP1, board.GP0)
 aht20 = adafruit_ahtx0.AHTx0(i2c)
 
 print("Connecting to WiFi...")
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+try:
+    wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+except TypeError:
+    print("Could not find WiFi info. Check your settings.toml file!")
+    raise
 
 print("Connected to WiFi!")
 
@@ -38,9 +42,13 @@ else:
 # Create an IoT Hub device client and connect
 esp = None
 pool = socketpool.SocketPool(wifi.radio)
-device = IoTCentralDevice(
-    pool, esp, os.getenv('id_scope'), os.getenv('device_id'), os.getenv('device_primary_key')
-)
+try:
+    device = IoTCentralDevice(
+        pool, esp, os.getenv('id_scope'), os.getenv('device_id'), os.getenv('device_primary_key')
+    )
+except TypeError:
+    print("Could not find Azure IoT info. Check your settings.toml file!")
+    raise
 
 print("Connecting to Azure IoT Central...")
 

--- a/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Basic_WiFi_Test/code.py
+++ b/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Basic_WiFi_Test/code.py
@@ -11,7 +11,11 @@ print()
 print("Connecting to WiFi")
 
 #  connect to your SSID
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+try:
+    wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+except TypeError:
+    print("Could not find WiFi info. Check your settings.toml file!")
+    raise
 
 print("Connected to WiFi")
 

--- a/Pico_W_CircuitPython_WiFi_Examples/Pico_W_JSON_Feed/code.py
+++ b/Pico_W_CircuitPython_WiFi_Examples/Pico_W_JSON_Feed/code.py
@@ -10,15 +10,23 @@ import socketpool
 import microcontroller
 import adafruit_requests
 
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+try:
+    wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+except TypeError:
+    print("Could not find WiFi info. Check your settings.toml file!")
+    raise
 
 # Use cityname, country code where countrycode is ISO3166 format.
 # E.g. "New York, US" or "London, GB"
 location = "Manhattan, US"
 
 # openweathermap URL, brings in your location & your token
-url = "http://api.openweathermap.org/data/2.5/weather?q="+location
-url += "&appid="+os.getenv('openweather_token')
+try:
+    url = "http://api.openweathermap.org/data/2.5/weather?q="+location
+    url += "&appid="+os.getenv('openweather_token')
+except TypeError:
+    print("Could not find OpenWeatherMap token. Check your settings.toml file!")
+    raise
 
 pool = socketpool.SocketPool(wifi.radio)
 requests = adafruit_requests.Session(pool, ssl.create_default_context())

--- a/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Requests/code.py
+++ b/Pico_W_CircuitPython_WiFi_Examples/Pico_W_Requests/code.py
@@ -14,7 +14,11 @@ import adafruit_requests
 quotes_url = "https://www.adafruit.com/api/quotes.php"
 
 #  connect to SSID
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+try:
+    wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+except TypeError:
+    print("Could not find WiFi info. Check your settings.toml file!")
+    raise
 
 pool = socketpool.SocketPool(wifi.radio)
 requests = adafruit_requests.Session(pool, ssl.create_default_context())


### PR DESCRIPTION
Adding error handling for settings.toml to pico w wifi examples. if a settings.toml entry is not found/incorrect then a type error is raised but it isn't very descriptive, especially for beginners