### PR TITLE
When creating feeds, also add the first value

### DIFF
--- a/Two_Way_Servo_Telegraph/code.py
+++ b/Two_Way_Servo_Telegraph/code.py
@@ -55,7 +55,7 @@ if servo_one:
         out_feed = io.get_feed("touch-1")
         in_feed = io.get_feed("touch-2")
     except AdafruitIO_RequestError:
-        # if no feed exists, create one
+        # if no feed exists, create one and push the first value
         out_feed = io.create_new_feed("touch-1")
         in_feed = io.create_new_feed("touch-2")
         io.send_data(in_feed["key"], float(abs((ANGLE_MAX-ANGLE_MIN)/2)))
@@ -68,7 +68,7 @@ if servo_two:
         out_feed = io.get_feed("touch-2")
         in_feed = io.get_feed("touch-1")
     except AdafruitIO_RequestError:
-        # if no feed exists, create one
+        # if no feed exists, create one and push the first value
         out_feed = io.create_new_feed("touch-2")
         in_feed = io.create_new_feed("touch-1")
         io.send_data(in_feed["key"], float(abs((ANGLE_MAX-ANGLE_MIN)/2)))

--- a/Two_Way_Servo_Telegraph/code.py
+++ b/Two_Way_Servo_Telegraph/code.py
@@ -18,6 +18,10 @@ from adafruit_motor import servo
 servo_one = True
 #  servo_two = True
 
+#  angles for servo
+ANGLE_MIN = 0
+ANGLE_MAX = 180
+
 try:
     from secrets import secrets
 except ImportError:
@@ -54,6 +58,7 @@ if servo_one:
         # if no feed exists, create one
         out_feed = io.create_new_feed("touch-1")
         in_feed = io.create_new_feed("touch-2")
+        io.send_data(in_feed["key"], float(abs((ANGLE_MAX-ANGLE_MIN)/2)))
 #  setup for display 2
 if servo_two:
     CALIB_MIN = 15668
@@ -66,6 +71,7 @@ if servo_two:
         # if no feed exists, create one
         out_feed = io.create_new_feed("touch-2")
         in_feed = io.create_new_feed("touch-1")
+        io.send_data(in_feed["key"], float(abs((ANGLE_MAX-ANGLE_MIN)/2)))
 
 received_data = io.receive_data(in_feed["key"])
 
@@ -73,10 +79,6 @@ received_data = io.receive_data(in_feed["key"])
 SERVO_PIN = board.A1
 FEEDBACK_PIN = board.A2
 touch = touchio.TouchIn(board.TX)
-
-#  angles for servo
-ANGLE_MIN = 0
-ANGLE_MAX = 180
 
 # servo setup
 pwm = pwmio.PWMOut(SERVO_PIN, duty_cycle=2 ** 15, frequency=50)


### PR DESCRIPTION
# What
When creating feeds, also add the first value to avoid an error at the start. The problem is that the following error is raised at line 76:

```
Zurückverfolgung (jüngste Aufforderung zuletzt): Datei "code.py", 
Zeile 74, in <module> Datei "adafruit_io/adafruit_io.py", 
Zeile 707, in receive_data Datei "adafruit_io/adafruit_io.py", 
Zeile 588, in _get Datei "adafruit_io/adafruit_io.py", 
Zeile 554, in _handle_error AdafruitIO_RequestError: Adafruit IO Error 404: not found - API documentation can be found at https://io.adafruit.com/api/docs
```

if the feed is there but no values. I just took the average value and push it directly when creating the feeds.

# Test
Tested under the same hardware configuration as described in the instructions: https://learn.adafruit.com/two-way-display-with-analog-feedback-servos/code-the-two-way-telegraph

