### PR TITLE
Secrets Cleanup: A

### DIFF
--- a/Adafruit_Feather_ESP32-S2/BME280_LC709203_Simple_Data/code.py
+++ b/Adafruit_Feather_ESP32-S2/BME280_LC709203_Simple_Data/code.py
@@ -5,8 +5,8 @@ CircuitPython Simple Example for BME280 and LC709203 Sensors
 """
 import time
 import board
-from adafruit_bme280 import basic as adafruit_bme280
 from adafruit_lc709203f import LC709203F, PackSize
+from adafruit_bme280 import basic as adafruit_bme280
 
 # Create sensor objects, using the board's default I2C bus.
 i2c = board.I2C()  # uses board.SCL and board.SDA

--- a/Adafruit_Feather_TFT_ESP32-S2/LC709203_Adafruit_IO/code.py
+++ b/Adafruit_Feather_TFT_ESP32-S2/LC709203_Adafruit_IO/code.py
@@ -3,6 +3,8 @@
 """
 CircuitPython Adafruit IO Example for LC709203 Sensor
 """
+
+from os import getenv
 import time
 import ssl
 import alarm
@@ -13,11 +15,21 @@ import socketpool
 import adafruit_requests
 from adafruit_io.adafruit_io import IO_HTTP
 from adafruit_lc709203f import LC709203F, PackSize
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi and Adafruit IO credentials are kept in secrets.py, please add them there!")
-    raise
+
+# Get WiFi details and Adafruit IO keys, ensure these are setup in settings.toml
+# (visit io.adafruit.com if you need to create an account, or if you need your Adafruit IO key.)
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+aio_username = getenv("ADAFRUIT_AIO_USERNAME")
+aio_key = getenv("ADAFRUIT_AIO_KEY")
+
+if None in [ssid, password, aio_username, aio_key]:
+    raise RuntimeError(
+        "WiFi and Adafruit IO settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "'ADAFRUIT_AIO_USERNAME' and 'ADAFRUIT_AIO_KEY' at a minimum."
+    )
 
 # Duration of sleep in seconds. Default is 600 seconds (10 minutes).
 # Feather will sleep for this duration between sensor readings / sending data to AdafruitIO
@@ -58,9 +70,9 @@ def send_io_data(feed, value):
 # Wi-Fi connections can have issues! This ensures the code will continue to run.
 try:
     # Connect to Wi-Fi
-    wifi.radio.connect(secrets["ssid"], secrets["password"])
-    print("Connected to {}!".format(secrets["ssid"]))
-    print("IP:", wifi.radio.ipv4_address)
+    wifi.radio.connect(ssid, password)
+    print(f"Connected to {ssid}!")
+    print(f"IP: {wifi.radio.ipv4_address}")
 
     pool = socketpool.SocketPool(wifi.radio)
     requests = adafruit_requests.Session(pool, ssl.create_default_context())
@@ -69,12 +81,6 @@ try:
 except Exception as e:  # pylint: disable=broad-except
     print(e)
     go_to_sleep(60)
-
-# Set your Adafruit IO Username and Key in secrets.py
-# (visit io.adafruit.com if you need to create an account,
-# or if you need your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
 
 # Initialize an Adafruit IO HTTP API object
 io = IO_HTTP(aio_username, aio_key, requests)

--- a/Adafruit_Feather_TFT_ESP32-S2/TFT_GitHub_Stars/code.py
+++ b/Adafruit_Feather_TFT_ESP32-S2/TFT_GitHub_Stars/code.py
@@ -3,6 +3,8 @@
 """
 CircuitPython GitHub Stars viewer
 """
+
+from os import getenv
 import time
 import ssl
 import wifi
@@ -13,12 +15,17 @@ from adafruit_display_text import bitmap_label
 from adafruit_bitmap_font import bitmap_font
 import adafruit_requests
 
-# Get WiFi details secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+
+if None in [ssid, password]:
+    raise RuntimeError(
+        "WiFi settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "at a minimum."
+    )
 
 display = board.DISPLAY
 
@@ -38,10 +45,10 @@ group.append(text_area)
 display.root_group = group
 
 # Connect to WiFi
-print("Connecting to %s"%secrets["ssid"])
-wifi.radio.connect(secrets["ssid"], secrets["password"])
-print("Connected to %s!"%secrets["ssid"])
-print("My IP address is", wifi.radio.ipv4_address)
+print(f"Connecting to {ssid}")
+wifi.radio.connect(ssid, password)
+print(f"Connected to {ssid}!")
+print(f"My IP address is {wifi.radio.ipv4_address}")
 
 pool = socketpool.SocketPool(wifi.radio)
 requests = adafruit_requests.Session(pool, ssl.create_default_context())

--- a/Adafruit_IO_Power_Relay/code.py
+++ b/Adafruit_IO_Power_Relay/code.py
@@ -14,12 +14,19 @@ from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-### WiFi ###
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
 
-secrets = {
-    "ssid" : os.getenv("CIRCUITPY_WIFI_SSID"),
-    "password" : os.getenv("CIRCUITPY_WIFI_PASSWORD"),
-}
+if None in [ssid, password]:
+    raise RuntimeError(
+        "WiFi settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "at a minimum."
+    )
+
+### WiFi ###
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -34,19 +41,19 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
+status_pixel = neopixel.NeoPixel(
     board.NEOPIXEL, 1, brightness=0.2
 )  # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
-# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# status_pixel = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 # Uncomment below for an externally defined RGB LED
 # import adafruit_rgbled
 # from adafruit_esp32spi import PWMOut
 # RED_LED = PWMOut.PWMOut(esp, 26)
 # GREEN_LED = PWMOut.PWMOut(esp, 27)
 # BLUE_LED = PWMOut.PWMOut(esp, 25)
-# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+# status_pixel = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+wifi = adafruit_esp32spi_wifimanager.WiFiManager(esp, ssid, password, status_pixel=status_pixel)
 
 # Set up a pin for controlling the relay
 power_pin = DigitalInOut(board.D3)

--- a/Adafruit_IO_Power_Relay/code_light_sensor/code.py
+++ b/Adafruit_IO_Power_Relay/code_light_sensor/code.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import time
 import board
 import busio
@@ -14,6 +15,21 @@ from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
+# Get WiFi details and Adafruit IO keys, ensure these are setup in settings.toml
+# (visit io.adafruit.com if you need to create an account, or if you need your Adafruit IO key.)
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+aio_username = getenv("ADAFRUIT_AIO_USERNAME")
+aio_key = getenv("ADAFRUIT_AIO_KEY")
+
+if None in [ssid, password, aio_username, aio_key]:
+    raise RuntimeError(
+        "WiFi and Adafruit IO settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "'ADAFRUIT_AIO_USERNAME' and 'ADAFRUIT_AIO_KEY' at a minimum."
+    )
+
 ### Sensor Calibration ###
 # Appliance power LED's light level, in Lux
 APPLIANCE_ON_LUX = 30.0
@@ -21,13 +37,6 @@ APPLIANCE_ON_LUX = 30.0
 SENSOR_READ_TIME = 10.0
 
 ### WiFi ###
-
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -42,19 +51,19 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
+status_pixel = neopixel.NeoPixel(
     board.NEOPIXEL, 1, brightness=0.2
 )  # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
-# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# status_pixel = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 # Uncomment below for an externally defined RGB LED
 # import adafruit_rgbled
 # from adafruit_esp32spi import PWMOut
 # RED_LED = PWMOut.PWMOut(esp, 26)
 # GREEN_LED = PWMOut.PWMOut(esp, 27)
 # BLUE_LED = PWMOut.PWMOut(esp, 25)
-# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+# status_pixel = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+wifi = adafruit_esp32spi_wifimanager.WiFiManager(esp, ssid, password, status_pixel=status_pixel)
 
 # Set up a pin for controlling the relay
 power_pin = DigitalInOut(board.D3)
@@ -67,10 +76,10 @@ sensor = adafruit_bh1750.BH1750(i2c)
 
 ### Feeds ###
 # Set up a feed named Relay for subscribing to the relay feed on Adafruit IO
-feed_relay = secrets["aio_username"] + "/feeds/relay"
+feed_relay = f"{aio_username}/feeds/relay"
 
 # Set up a feed named status for subscribing to the status feed on Adafruit IO
-feed_status = secrets["aio_username"] + "/feeds/status"
+feed_status = f"{aio_username}/feeds/status"
 
 ### Code ###
 
@@ -122,8 +131,8 @@ ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
     broker="io.adafruit.com",
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl_context,
 )

--- a/Adafruit_IO_Schedule_Trigger/code.py
+++ b/Adafruit_IO_Schedule_Trigger/code.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from os import getenv
 import time
 import board
 import busio
@@ -13,14 +14,22 @@ import neopixel
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
 
-### WiFi ###
+# Get WiFi details and Adafruit IO keys, ensure these are setup in settings.toml
+# (visit io.adafruit.com if you need to create an account, or if you need your Adafruit IO key.)
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+aio_username = getenv("ADAFRUIT_AIO_USERNAME")
+aio_key = getenv("ADAFRUIT_AIO_KEY")
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+if None in [ssid, password, aio_username, aio_key]:
+    raise RuntimeError(
+        "WiFi and Adafruit IO settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "'ADAFRUIT_AIO_USERNAME' and 'ADAFRUIT_AIO_KEY' at a minimum."
+    )
+
+### WiFi ###
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -35,19 +44,19 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 """Use below for Most Boards"""
-status_light = neopixel.NeoPixel(
+status_pixel = neopixel.NeoPixel(
     board.NEOPIXEL, 1, brightness=0.2
 )  # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
-# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# status_pixel = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 # Uncomment below for an externally defined RGB LED
 # import adafruit_rgbled
 # from adafruit_esp32spi import PWMOut
 # RED_LED = PWMOut.PWMOut(esp, 26)
 # GREEN_LED = PWMOut.PWMOut(esp, 27)
 # BLUE_LED = PWMOut.PWMOut(esp, 25)
-# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+# status_pixel = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+wifi = adafruit_esp32spi_wifimanager.WiFiManager(esp, ssid, password, status_pixel=status_pixel)
 
 # Set up a pin for controlling the relay
 power_pin = DigitalInOut(board.D3)
@@ -110,8 +119,8 @@ ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl_context,
 )

--- a/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
+++ b/Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
@@ -7,6 +7,7 @@ library example esp32spi_simpletest.py:
 https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/
 blob/master/examples/esp32spi_simpletest.py '''
 
+from os import getenv
 import board
 import busio
 from digitalio import DigitalInOut
@@ -14,12 +15,17 @@ import adafruit_connection_manager
 import adafruit_requests
 from adafruit_esp32spi import adafruit_esp32spi
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Get WiFi details, ensure these are setup in settings.toml
+ssid = getenv("CIRCUITPY_WIFI_SSID")
+password = getenv("CIRCUITPY_WIFI_PASSWORD")
+
+if None in [ssid, password]:
+    raise RuntimeError(
+        "WiFi settings are kept in settings.toml, "
+        "please add them there. The settings file must contain "
+        "'CIRCUITPY_WIFI_SSID', 'CIRCUITPY_WIFI_PASSWORD', "
+        "at a minimum."
+    )
 
 print("Arduino Nano RP2040 Connect webclient test")
 
@@ -51,7 +57,7 @@ for ap in esp.scan_networks():
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(secrets["ssid"], secrets["password"])
+        esp.connect_AP(ssid, password)
     except RuntimeError as e:
         print("could not connect to AP, retrying: ", e)
         continue


### PR DESCRIPTION
Round of removing secrets from learn guides

- [x] Adafruit_Feather_ESP32-S2
  - /BME280_LC709203_Adafruit_IO/code.py
    - found on https://learn.adafruit.com/adafruit-esp32-s2-feather/i2c-on-board-sensors
    - shows example of `secrets.py `
    - no changes needed from code updates
  - /BME280_LC709203_Simple_Data/code.py
    - found on https://learn.adafruit.com/adafruit-esp32-s2-feather/i2c-on-board-sensors
    - shows example of `secrets.py `
    - no changes needed from code updates
- [x] Adafruit_Feather_TFT_ESP32-S2
  - LC709203_Adafruit_IO/code.py
    - **CAN NOT FIND** 
  - TFT_GitHub_Stars/code.py
    - found on https://learn.adafruit.com/adafruit-esp32-s2-tft-feather/tft-github-stars-wifi-demo
    - shows example of `secrets.py `
    - no changes needed from code updates
- [x] Adafruit_IO_Air_Quality/code.py
    - found on https://learn.adafruit.com/diy-air-quality-monitor/
    - shows example of `secrets.py `
    - walks through `from secrets import secrets`
- [x] Adafruit_IO_Power_Relay
  - /code.py
    - found on https://learn.adafruit.com/adafruit-io-a-c-power-relay/
    - no changes needed from code updates
- [x] Adafruit_IO_Schedule_Trigger/code.py
  - found on https://learn.adafruit.com/adafruit-io-a-c-power-relay/going-further-add-a-feedback-indicator
  -  no changes needed from code updates
- [x] Arduino_Nano_RP2040_Connect/arduino_nano_rp2040_connect_wifi/code.py
  - found on https://learn.adafruit.com/circuitpython-on-the-arduino-nano-rp2040-connect/wifi
  - no changes needed from code updates
- [x] Azure_Food_Scale/code.py
   - shows example of `secrets.py `
   - multiple walkthrough blocks need to be updated