### PR TITLE
Update Matrix Portal New Guide Scroller Code.py

### DIFF
--- a/Matrix_Portal/Matrix_Portal_Learn_Stats/code.py
+++ b/Matrix_Portal/Matrix_Portal_Learn_Stats/code.py
@@ -13,7 +13,7 @@ from adafruit_matrixportal.matrixportal import MatrixPortal
 DISPLAY_NUM_GUIDES = 5
 # Data source URL
 DATA_SOURCE = (
-    "https://learn.adafruit.com/api/guides/new.json?count=%d" % DISPLAY_NUM_GUIDES
+    "https://learn.adafruit.com/api/guides.json?count=%d" % DISPLAY_NUM_GUIDES
 )
 TITLE_DATA_LOCATION = ["guides"]
 
@@ -65,7 +65,7 @@ def get_guide_info(index):
     print("Obtaining guide info for guide %d..." % index)
 
     # Traverse JSON data for title
-    guide_count = matrixportal.network.json_traverse(als_data.json(), ["guide_count"])
+    guide_count = matrixportal.network.json_traverse(als_data.json(), ["guides_total_count"])
 
     # Set guide count
     matrixportal.set_text(guide_count, 0)


### PR DESCRIPTION
This pull request includes updates to the `Matrix_Portal/Matrix_Portal_Learn_Stats/code.py` file to adjust the data source URL and modify the JSON traversal key for guide information.

Learn Feedback
```
https://learn.adafruit.com/api/guides/new.json?count=5 display 1181 learn guide, but https://learn.adafruit.com/guides/latest say there are "2942 tutorials in group"

So it seems that the json file is stuck in 2020.
```