### PR TITLE
fix incompatibility with ov5640 and Pico

### DIFF
--- a/PiCowbell_Camera_Demos/JPEG_Capture/code.py
+++ b/PiCowbell_Camera_Demos/JPEG_Capture/code.py
@@ -76,7 +76,7 @@ def open_next_image():
         return open(filename, "wb")
 
 cam.colorspace = adafruit_ov5640.OV5640_COLOR_JPEG
-cam.quality = 3
+cam.quality = 5
 b = bytearray(cam.capture_buffer_size)
 jpeg = cam.capture(b)
 


### PR DESCRIPTION
Changes to Adafruit_CircuitPython_OV5640 doubled the memory usage for a given quality setting.  
This makes the latest release of in CircuitPython incompatible with the previous settings of:
- quality setting=3
- colorspace=adafruit_ov5640.OV5640_COLOR_JPEG 

due to that working out an an allocation size of 204800.   This is too much for the first Pico. 
Here is the breaking change:
- https://github.com/adafruit/Adafruit_CircuitPython_OV5640/pull/35 

Quality 4 is still too large at 153,600 bytes.
Quality 5 using 122,880 works.

Successfully Tested on:
- Pico
- Pico W
- Pico 2
- Pico 2 W

Note that Pico 2's could handle quality 3.  May follow up with a subsequent PR that automatically picks the best quality for arbitrary platforms.