### PR TITLE
Add exported Magic config for IOT Door sensor

### DIFF
--- a/Adafruit_IO_Reed_Switch/rpi-pico-w112213141.json
+++ b/Adafruit_IO_Reed_Switch/rpi-pico-w112213141.json
@@ -1,0 +1,27 @@
+{
+  "exportVersion": "1.0.0",
+  "exportedBy": "tyeth_demo",
+  "exportedAt": "2025-05-02T17:08:03.857Z",
+  "exportedFromDevice": {
+    "board": "rpi-pico-w",
+    "firmwareVersion": "1.0.0-beta.100"
+  },
+  "components": [
+    {
+      "name": "Reed Switch",
+      "pinName": "D13",
+      "type": "reed_switch",
+      "mode": "DIGITAL",
+      "direction": "INPUT",
+      "period": 0,
+      "pull": "UP",
+      "isPin": true,
+      "visualization": {
+        "offLabel": "Open",
+        "offIcon": "fa6:solid:door-open",
+        "onLabel": "Closed",
+        "onIcon": "fa6:regular:door-closed"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adafruit IO devices wippersnapper config exported as JSON for easy import.

https://learn.adafruit.com/iot-open-door-detector-using-notifications-with-adafruit-io
