### PR TITLE
replace cardSize() with sectorCount()

### DIFF
--- a/MEMENTO/Memento_Face_Detect_Recognize/memento_platformio_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.cpp
+++ b/MEMENTO/Memento_Face_Detect_Recognize/memento_platformio_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.cpp
@@ -172,7 +172,7 @@ bool Adafruit_PyCamera::initSD(void) {
   }
 
   Serial.println("Card successfully initialized");
-  uint32_t size = sd.card()->cardSize();
+  uint32_t size = sd.card()->sectorCount();
   if (size == 0) {
     Serial.println("Can't determine the card size");
   } else {
@@ -497,7 +497,7 @@ bool Adafruit_PyCamera::takePhoto(const char *filename_base,
     return false;
   }
 
-  if (!sd.card() || (sd.card()->cardSize() == 0)) {
+  if (!sd.card() || (sd.card()->sectorCount() == 0)) {
     Serial.println("No SD card found");
     // try to initialize?
     if (!initSD())

--- a/MEMENTO/Memento_Face_Detect_Recognize/memento_platformio_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.h
+++ b/MEMENTO/Memento_Face_Detect_Recognize/memento_platformio_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.h
@@ -6,7 +6,7 @@
 #include <Adafruit_AW9523.h>
 #include <Adafruit_NeoPixel.h>
 #include <Adafruit_ST7789.h> // Hardware-specific library for ST7789
-#include <SdFat.h>
+#include <SdFat_Adafruit_Fork.h>
 
 #ifndef TAG
 #define TAG "PYCAM"

--- a/MEMENTO/Memento_Shoulder_Robot/platformio_memento_shoulder_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.cpp
+++ b/MEMENTO/Memento_Shoulder_Robot/platformio_memento_shoulder_camera/lib/Adafruit_PyCamera/Adafruit_PyCamera.cpp
@@ -172,7 +172,7 @@ bool Adafruit_PyCamera::initSD(void) {
   }
 
   Serial.println("Card successfully initialized");
-  uint32_t size = sd.card()->cardSize();
+  uint32_t size = sd.card()->sectorCount();
   if (size == 0) {
     Serial.println("Can't determine the card size");
   } else {
@@ -497,7 +497,7 @@ bool Adafruit_PyCamera::takePhoto(const char *filename_base,
     return false;
   }
 
-  if (!sd.card() || (sd.card()->cardSize() == 0)) {
+  if (!sd.card() || (sd.card()->sectorCount() == 0)) {
     Serial.println("No SD card found");
     // try to initialize?
     if (!initSD())


### PR DESCRIPTION
cardSize() is removed from upstream, although we enabled backward-compatible (up coming release). It is still better to use sectorCount() instead
also include SdFat_Adafruit_Fork.h instead of SdFat.h

