### PR TITLE
Metro RP2350 CP 10.x /sd

### DIFF
--- a/Metro_RP2350_Examples/CircuitPython_SDCard_ListFiles/code-cp10x.py
+++ b/Metro_RP2350_Examples/CircuitPython_SDCard_ListFiles/code-cp10x.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2017 Limor Fried for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+CircuitPython 10.x SD Card Directory Listing Demo
+Assumes the SD card is auto-mounted at /sd by the runtime.
+"""
+
+import os
+
+def print_directory(path, tabs=0):
+    for name in os.listdir(path):
+        full_path = f"{path}/{name}"
+        stats     = os.stat(full_path)
+        filesize  = stats[6]
+        isdir     = bool(stats[0] & 0x4000)
+
+        # human-readable size
+        if   filesize < 1_000:
+            sizestr = f"{filesize} bytes"
+        elif filesize < 1_000_000:
+            sizestr = f"{filesize/1_000:.1f} KB"
+        else:
+            sizestr = f"{filesize/1_000_000:.1f} MB"
+
+        indent       = "   " * tabs
+        display_name = indent + name + ("/" if isdir else "")
+
+        # <40 pads or truncates to 40 chars, then we append the size
+        print(f"{display_name:<40} Size: {sizestr}")
+
+        if isdir:
+            print_directory(full_path, tabs + 1)
+
+print("Files on /sd:")
+print("====================")
+print_directory("/sd")

--- a/Metro_RP2350_Examples/CircuitPython_SDCard_ListFiles/code.py
+++ b/Metro_RP2350_Examples/CircuitPython_SDCard_ListFiles/code.py
@@ -3,7 +3,7 @@
 
 """
 CircuitPython Essentials SD Card Read Demo
-
+* Not compatible with CircuitPython 10.x
 """
 
 import os

--- a/Metro_RP2350_Examples/CircuitPython_SDCard_Write/code-cp10x.py
+++ b/Metro_RP2350_Examples/CircuitPython_SDCard_Write/code-cp10x.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2017 Limor Fried for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+CircuitPython 10.x SD Write Demo
+  • Assumes /sd is auto-mounted by the runtime
+  • Just open and append — no mount or SD driver code needed
+  • Not compatible with CircuitPython 9.x
+  • Uses SDIO
+"""
+
+import time
+import microcontroller
+
+print("Logging temperature to /sd/temperature.txt")
+
+while True:
+    t = microcontroller.cpu.temperature
+    print("T = %0.1f °C" % t)
+    with open("/sd/temperature.txt", "a") as f:
+        f.write("%0.1f\n" % t)
+    time.sleep(1)

--- a/Metro_RP2350_Examples/CircuitPython_SDCard_Write/code.py
+++ b/Metro_RP2350_Examples/CircuitPython_SDCard_Write/code.py
@@ -8,6 +8,8 @@ REMOVE THIS LINE AND ALL BELOW IT BEFORE SUBMITTING TO LEARN
 Update CHIP_SELECT_PIN to match the CS pin on your board.
 
 For example, for the Metro ESP32-S3, you would use: board.SD_CS.
+
+This code stops working with CircuitPython 10.x which automounts /sd
 """
 
 import time


### PR DESCRIPTION
Demo code for CircuitPython 10.x SD card list and write. The 9.x examples are not compatible.

Addresses CircuitPython Issue # [10419](https://github.com/adafruit/circuitpython/issues/10419)

Addresses Forum Issue: [SD Card on Metro RP2350 Setup](https://forums.adafruit.com/viewtopic.php?p=1058272#p1058272)

CircuitPython 10.x introduces automounting of /sd. The Metro RP2350 no detects and automounts a /sd card using SDIO. No initialization is required in the example code. Example code for 9.x and 10.x will need to be in place for some time to prevent mass hysteria. 

Tested on both 10.x read / write scripts with:

```
+------------------------+-------------------------+
| Component              | Details                 |
+------------------------+-------------------------+
| Board                  | Metro RP2350            |
| microSD Card           | SanDisk Ultra A1 16 GB  |
| CircuitPython Version  | 9.2.8                    |
| CircuitPython Version  | 10.0.0-alpha6            |
+------------------------+-------------------------+
```