### PR TITLE
CircuitPython Logger fixes

### DIFF
--- a/CircuitPython_Logger/.circuitpython.skip
+++ b/CircuitPython_Logger/.circuitpython.skip
@@ -1,4 +1,0 @@
-CircuitPython_Logger/ble_handler.py 16: Bad option value 'missing-super-argument' (bad-option-value)
-CircuitPython_Logger/uart_handler.py 16: Bad option value 'missing-super-argument' (bad-option-value)
-CircuitPython_Logger/file_handler.py 15: Bad option value 'missing-super-argument' (bad-option-value)
-CircuitPython_Logger/aio_handler.py 15: Bad option value 'missing-super-argument' (bad-option-value)

--- a/CircuitPython_Logger/aio_test/aio_handler.py
+++ b/CircuitPython_Logger/aio_test/aio_handler.py
@@ -17,29 +17,20 @@ All text above must be included in any redistribution.
 """
 
 from adafruit_portalbase import PortalBase
+from adafruit_logging import Handler, NOTSET
 
-# Example:
-#
-# from aio_handler import AIOHandler
-# import adafruit_logging as logging
-# l = logging.getLogger('aio')
-# # Pass in the device object based on portal_base
-# # (Funhouse, PyPortal, MagTag, etc) as the 2nd parameter
-# l.addHandler(AIOHandler('test', portal_device))
-# l.level = logging.ERROR
-# l.error("test")
-
-from adafruit_logging import Handler
 
 class AIOHandler(Handler):
 
-    def __init__(self, name, portal_device):
+    def __init__(self, name, portal_device, level: int = NOTSET):
         """Create an instance."""
-        self._log_feed_name=f"{name}-logging"
+        super().__init__(name)
+        self._log_feed_name = f"{name}-logging"
         if not issubclass(type(portal_device), PortalBase):
-            raise TypeError("portal_device must be a PortalBase or subclass of PortalBase")
+            raise TypeError(
+                "portal_device must be a PortalBase or subclass of PortalBase"
+            )
         self._portal_device = portal_device
-
 
     def emit(self, record):
         """Generate the message and write it to the AIO Feed.

--- a/CircuitPython_Logger/aio_test/aio_handler.py
+++ b/CircuitPython_Logger/aio_test/aio_handler.py
@@ -24,7 +24,7 @@ class AIOHandler(Handler):
 
     def __init__(self, name, portal_device, level: int = NOTSET):
         """Create an instance."""
-        super().__init__(name)
+        super().__init__(level)
         self._log_feed_name = f"{name}-logging"
         if not issubclass(type(portal_device), PortalBase):
             raise TypeError(

--- a/CircuitPython_Logger/aio_test/code.py
+++ b/CircuitPython_Logger/aio_test/code.py
@@ -8,27 +8,28 @@ from adafruit_pyportal import PyPortal
 from aio_handler import AIOHandler
 import adafruit_logging as logging
 
-device=PyPortal()
+device = PyPortal()
 
-l = logging.getLogger('aio')
-l.addHandler(AIOHandler('test', device))
+l = logging.getLogger("aio")
+l.addHandler(AIOHandler("test", device))
+
 
 def go():
     while True:
         t = random.randint(1, 5)
         if t == 1:
-            print('debug')
+            print("debug")
             l.debug("debug message: %d", random.randint(0, 1000))
         elif t == 2:
-            print('info')
+            print("info")
             l.info("info message: %d", random.randint(0, 1000))
         elif t == 3:
-            print('warning')
+            print("warning")
             l.warning("warning message: %d", random.randint(0, 1000))
         elif t == 4:
-            print('error')
+            print("error")
             l.error("error message: %d", random.randint(0, 1000))
         elif t == 5:
-            print('critical')
+            print("critical")
             l.critical("critical message: %d", random.randint(0, 1000))
         time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/aio_test/code.py
+++ b/CircuitPython_Logger/aio_test/code.py
@@ -13,23 +13,21 @@ device = PyPortal()
 l = logging.getLogger("aio")
 l.addHandler(AIOHandler("test", device))
 
-
-def go():
-    while True:
-        t = random.randint(1, 5)
-        if t == 1:
-            print("debug")
-            l.debug("debug message: %d", random.randint(0, 1000))
-        elif t == 2:
-            print("info")
-            l.info("info message: %d", random.randint(0, 1000))
-        elif t == 3:
-            print("warning")
-            l.warning("warning message: %d", random.randint(0, 1000))
-        elif t == 4:
-            print("error")
-            l.error("error message: %d", random.randint(0, 1000))
-        elif t == 5:
-            print("critical")
-            l.critical("critical message: %d", random.randint(0, 1000))
-        time.sleep(5.0 + (random.random() * 5.0))
+while True:
+    t = random.randint(1, 5)
+    if t == 1:
+        print("debug")
+        l.debug("debug message: %d", random.randint(0, 1000))
+    elif t == 2:
+        print("info")
+        l.info("info message: %d", random.randint(0, 1000))
+    elif t == 3:
+        print("warning")
+        l.warning("warning message: %d", random.randint(0, 1000))
+    elif t == 4:
+        print("error")
+        l.error("error message: %d", random.randint(0, 1000))
+    elif t == 5:
+        print("critical")
+        l.critical("critical message: %d", random.randint(0, 1000))
+    time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/ble_test/ble_handler.py
+++ b/CircuitPython_Logger/ble_test/ble_handler.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2019 Dave Astels for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+BLE based message handler for CircuitPython logging.
+
+Adafruit invests time and resources providing this open source code.
+Please support Adafruit and open source hardware by purchasing
+products from Adafruit!
+
+Written by Dave Astels for Adafruit Industries
+Copyright (c) 2018 Adafruit Industries
+Licensed under the MIT license.
+
+All text above must be included in any redistribution.
+"""
+
+
+from adafruit_logging import Handler, NOTSET
+from adafruit_ble.uart import UARTServer
+
+
+class BLEHandler(Handler):
+    """Send logging output to the BLE uart port."""
+
+    def __init__(self, level: int = NOTSET):
+        """Create an instance.
+
+        :param uart: the busio.UART instance to which to write messages
+        """
+        super().__init__(level)
+        self._advertising_now = False
+        self._uart = UARTServer()
+        self._uart.start_advertising()
+
+    def format(self, record):
+        """Generate a string to log.
+
+        :param record: The record (message object) to be logged
+        """
+        return super().format(record) + "\r\n"
+
+    def emit(self, record):
+        """Generate the message and write it to the UART.
+
+        :param record: The record (message object) to be logged
+        """
+        while not self._uart.connected:
+            pass
+        data = bytes(self.format(record), "utf-8")
+        self._uart.write(data)

--- a/CircuitPython_Logger/ble_test/ble_handler.py
+++ b/CircuitPython_Logger/ble_test/ble_handler.py
@@ -18,7 +18,10 @@ All text above must be included in any redistribution.
 
 
 from adafruit_logging import Handler, NOTSET
-from adafruit_ble.uart import UARTServer
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
 
 
 class BLEHandler(Handler):
@@ -31,8 +34,10 @@ class BLEHandler(Handler):
         """
         super().__init__(level)
         self._advertising_now = False
-        self._uart = UARTServer()
-        self._uart.start_advertising()
+        ble = BLERadio()
+        self._uart = UARTService()
+        self._advertisement = ProvideServicesAdvertisement(self._uart)
+        ble.start_advertising(self._advertisement)
 
     def format(self, record):
         """Generate a string to log.
@@ -46,7 +51,5 @@ class BLEHandler(Handler):
 
         :param record: The record (message object) to be logged
         """
-        while not self._uart.connected:
-            pass
         data = bytes(self.format(record), "utf-8")
         self._uart.write(data)

--- a/CircuitPython_Logger/ble_test/code.py
+++ b/CircuitPython_Logger/ble_test/code.py
@@ -11,23 +11,21 @@ l = logging.getLogger("ble")
 
 l.addHandler(BLEHandler())
 
-
-def go():
-    while True:
-        t = random.randint(1, 5)
-        if t == 1:
-            print("debug")
-            l.debug("%d", random.randint(0, 1000))
-        elif t == 2:
-            print("info")
-            l.info("%d", random.randint(0, 1000))
-        elif t == 3:
-            print("warning")
-            l.warning("%d", random.randint(0, 1000))
-        elif t == 4:
-            print("error")
-            l.error("%d", random.randint(0, 1000))
-        elif t == 5:
-            print("critical")
-            l.critical(" %d", random.randint(0, 1000))
-        time.sleep(5.0 + (random.random() * 5.0))
+while True:
+    t = random.randint(1, 5)
+    if t == 1:
+        print("debug")
+        l.debug("%d", random.randint(0, 1000))
+    elif t == 2:
+        print("info")
+        l.info("%d", random.randint(0, 1000))
+    elif t == 3:
+        print("warning")
+        l.warning("%d", random.randint(0, 1000))
+    elif t == 4:
+        print("error")
+        l.error("%d", random.randint(0, 1000))
+    elif t == 5:
+        print("critical")
+        l.critical(" %d", random.randint(0, 1000))
+    time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/ble_test/code.py
+++ b/CircuitPython_Logger/ble_test/code.py
@@ -7,26 +7,27 @@ import random
 from ble_handler import BLEHandler
 import adafruit_logging as logging
 
-l = logging.getLogger('ble')
+l = logging.getLogger("ble")
 
 l.addHandler(BLEHandler())
+
 
 def go():
     while True:
         t = random.randint(1, 5)
         if t == 1:
-            print('debug')
+            print("debug")
             l.debug("%d", random.randint(0, 1000))
         elif t == 2:
-            print('info')
+            print("info")
             l.info("%d", random.randint(0, 1000))
         elif t == 3:
-            print('warning')
+            print("warning")
             l.warning("%d", random.randint(0, 1000))
         elif t == 4:
-            print('error')
+            print("error")
             l.error("%d", random.randint(0, 1000))
         elif t == 5:
-            print('critical')
+            print("critical")
             l.critical(" %d", random.randint(0, 1000))
         time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/file_test/code.py
+++ b/CircuitPython_Logger/file_test/code.py
@@ -21,25 +21,26 @@ sdcard = adafruit_sdcard.SDCard(spi, cs)
 vfs = storage.VfsFat(sdcard)
 storage.mount(vfs, "/sd")
 
-l = logging.getLogger('file')
-l.addHandler(logging.FileHandler('/sd/test.txt'))
+l = logging.getLogger("file")
+l.addHandler(logging.FileHandler("/sd/test.txt"))
+
 
 def go():
     while True:
         t = random.randint(1, 5)
         if t == 1:
-            print('debug')
+            print("debug")
             l.debug("debug message: %d", random.randint(0, 1000))
         elif t == 2:
-            print('info')
+            print("info")
             l.info("info message: %d", random.randint(0, 1000))
         elif t == 3:
-            print('warning')
+            print("warning")
             l.warning("warning message: %d", random.randint(0, 1000))
         elif t == 4:
-            print('error')
+            print("error")
             l.error("error message: %d", random.randint(0, 1000))
         elif t == 5:
-            print('critical')
+            print("critical")
             l.critical("critical message: %d", random.randint(0, 1000))
         time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/file_test/code.py
+++ b/CircuitPython_Logger/file_test/code.py
@@ -24,23 +24,21 @@ storage.mount(vfs, "/sd")
 l = logging.getLogger("file")
 l.addHandler(logging.FileHandler("/sd/test.txt"))
 
-
-def go():
-    while True:
-        t = random.randint(1, 5)
-        if t == 1:
-            print("debug")
-            l.debug("debug message: %d", random.randint(0, 1000))
-        elif t == 2:
-            print("info")
-            l.info("info message: %d", random.randint(0, 1000))
-        elif t == 3:
-            print("warning")
-            l.warning("warning message: %d", random.randint(0, 1000))
-        elif t == 4:
-            print("error")
-            l.error("error message: %d", random.randint(0, 1000))
-        elif t == 5:
-            print("critical")
-            l.critical("critical message: %d", random.randint(0, 1000))
-        time.sleep(5.0 + (random.random() * 5.0))
+while True:
+    t = random.randint(1, 5)
+    if t == 1:
+        print("debug")
+        l.debug("debug message: %d", random.randint(0, 1000))
+    elif t == 2:
+        print("info")
+        l.info("info message: %d", random.randint(0, 1000))
+    elif t == 3:
+        print("warning")
+        l.warning("warning message: %d", random.randint(0, 1000))
+    elif t == 4:
+        print("error")
+        l.error("error message: %d", random.randint(0, 1000))
+    elif t == 5:
+        print("critical")
+        l.critical("critical message: %d", random.randint(0, 1000))
+    time.sleep(5.0 + (random.random() * 5.0))

--- a/CircuitPython_Logger/uart_handler/code.py
+++ b/CircuitPython_Logger/uart_handler/code.py
@@ -1,57 +1,13 @@
 # SPDX-FileCopyrightText: 2018 Dave Astels for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
+import board
+import busio
+from uart_handler import UartHandler
+import adafruit_logging as logging
 
-"""
-UART based message handler for CircuitPython logging.
-
-Adafruit invests time and resources providing this open source code.
-Please support Adafruit and open source hardware by purchasing
-products from Adafruit!
-
-Written by Dave Astels for Adafruit Industries
-Copyright (c) 2018 Adafruit Industries
-Licensed under the MIT license.
-
-All text above must be included in any redistribution.
-"""
-
-
-# Example:
-#
-# import board
-# import busio
-# from uart_handler import UartHandler
-# import adafruit_logging as logging
-#
-# uart = busio.UART(board.TX, board.RX, baudrate=115200)
-# logger = logging.getLogger('uart')
-# logger.addHandler(UartHandler(uart))
-# logger.level = logging.INFO
-# logger.info('testing')
-
-from adafruit_logging import Handler
-
-class UartHandler(Handler):
-    """Send logging output to a serial port."""
-
-    def __init__(self, uart):
-        """Create an instance.
-
-        :param uart: the busio.UART instance to which to write messages
-        """
-        self._uart = uart
-
-    def format(self, record):
-        """Generate a string to log.
-
-        :param record: The record (message object) to be logged
-        """
-        return super().format(record) + '\r\n'
-
-    def emit(self, record):
-        """Generate the message and write it to the UART.
-
-        :param record: The record (message object) to be logged
-        """
-        self._uart.write(bytes(self.format(record), 'utf-8'))
+uart = busio.UART(board.TX, board.RX, baudrate=115200)
+logger = logging.getLogger("test")
+logger.addHandler(UartHandler(uart))
+logger.setLevel(logging.INFO)
+logger.info("testing")

--- a/CircuitPython_Logger/uart_handler/uart_handler.py
+++ b/CircuitPython_Logger/uart_handler/uart_handler.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2019 Dave Astels for Adafruit Industries
+# SPDX-FileCopyrightText: 2018 Dave Astels for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
 """
-BLE based message handler for CircuitPython logging.
+UART based message handler for CircuitPython logging.
 
 Adafruit invests time and resources providing this open source code.
 Please support Adafruit and open source hardware by purchasing
@@ -17,34 +17,30 @@ All text above must be included in any redistribution.
 """
 
 
-from adafruit_logging import Handler
-from adafruit_ble.uart import UARTServer
+from adafruit_logging import Handler, NOTSET
 
-class BLEHandler(Handler):
-    """Send logging output to the BLE uart port."""
 
-    def __init__(self):
+class UartHandler(Handler):
+    """Send logging output to a serial port."""
+
+    def __init__(self, uart, level: int = NOTSET):
         """Create an instance.
 
         :param uart: the busio.UART instance to which to write messages
         """
-        self._advertising_now = False
-        self._uart = UARTServer()
-        self._uart.start_advertising()
+        super().__init__(level)
+        self._uart = uart
 
     def format(self, record):
         """Generate a string to log.
 
         :param record: The record (message object) to be logged
         """
-        return super().format(record) + '\r\n'
+        return super().format(record) + "\r\n"
 
     def emit(self, record):
         """Generate the message and write it to the UART.
 
         :param record: The record (message object) to be logged
         """
-        while not self._uart.connected:
-            pass
-        data = bytes(self.format(record), 'utf-8')
-        self._uart.write(data)
+        self._uart.write(bytes(self.format(record), "utf-8"))


### PR DESCRIPTION
There were people on discord having some trouble with the uart logging example. In testing I discovered that all 3 uart, ble, and aio had a few issues with them. The bundles downloaded from the learn guide do not work as-is.

They seem to have been refactored at some point to not have proper filenames for ble_handler.py, uart_handler.py, and aio_handler.py which caused the example code not to work since it was trying to import from files with those names. 

The handler classes needed to call `super().__init__()` because without it `self.level` does not get initialized which leads to an exception raised during `handle()`. Since the parent class Handler accepts a `level` argument I added that to each of the subclasses.

The ble_handler seemed to be targeting an older version of `adafruit_ble` library. I updated a handful of lines to get things working under the current version of the library.

`.circuitpython.skip` was removed so that actions will run black/pylint on these files, which led to some formatting changes in many of them.

Once this is merged I will update the learn guide page embeds and verify that the new file structure results in bundle downloads that can run on device without modification.

I tested with following hardware:
- uart handler on Feather S3
- AIO handler on PyPortal
- BLE handler on CircuitPlayground Bluefruit

