### PR TITLE
Use new OnDiskBitmap API

### DIFF
--- a/Buckaroo_Plant_Care_Bot/code.py
+++ b/Buckaroo_Plant_Care_Bot/code.py
@@ -22,31 +22,17 @@ clue.pixel.fill(0)  # turn off NeoPixel
 clue_display = displayio.Group()
 
 # draw the dry plant
-dry_plant_file = open("dry.bmp", "rb")
-dry_plant_bmp = displayio.OnDiskBitmap(dry_plant_file)
-# CircuitPython 6 & 7 compatible
+dry_plant_bmp = displayio.OnDiskBitmap("dry.bmp")
 dry_plant_sprite = displayio.TileGrid(
-    dry_plant_bmp,
-    pixel_shader=getattr(dry_plant_bmp, "pixel_shader", displayio.ColorConverter()),
+    dry_plant_bmp, pixel_shader=dry_plant_bmp.pixel_shader
 )
-# CircuitPython 7 compatible
-# dry_plant_sprite = displayio.TileGrid(
-#     dry_plant_bmp, pixel_shader=dry_plant_bmp.pixel_shader
-# )
 clue_display.append(dry_plant_sprite)
 
 # draw the happy plant on top (so it can be moved out of the way when needed)
-happy_plant_file = open("happy.bmp", "rb")
-happy_plant_bmp = displayio.OnDiskBitmap(happy_plant_file)
-# CircuitPython 6 & 7 compatible
+happy_plant_bmp = displayio.OnDiskBitmap("happy.bmp")
 happy_plant_sprite = displayio.TileGrid(
-    happy_plant_bmp,
-    pixel_shader=getattr(happy_plant_bmp, "pixel_shader", displayio.ColorConverter()),
+    happy_plant_bmp, pixel_shader=happy_plant_bmp.pixel_shader
 )
-# CircuitPython 7 compatible
-# happy_plant_sprite = displayio.TileGrid(
-#     happy_plant_bmp, pixel_shader=happy_plant_bmp.pixel_shader
-# )
 clue_display.append(happy_plant_sprite)
 
 # Create text

--- a/CLUE/CLUE_Egg_Drop/code.py
+++ b/CLUE/CLUE_Egg_Drop/code.py
@@ -22,32 +22,14 @@ splash = displayio.Group()
 # bad egg
 BAD_EGG_FILENAME = "broken_egg.bmp"
 
-# CircuitPython 6 & 7 compatible
-begg_file = open(BAD_EGG_FILENAME, "rb")
-begg_bmp = displayio.OnDiskBitmap(begg_file)
-begg_sprite = displayio.TileGrid(
-    begg_bmp,
-    pixel_shader=getattr(begg_bmp, 'pixel_shader', displayio.ColorConverter())
-)
-
-# # CircuitPython 7+ compatible
-# begg_bmp = displayio.OnDiskBitmap(BAD_EGG_FILENAME)
-# begg_sprite = displayio.TileGrid(begg_bmp, pixel_shader=begg_bmp.pixel_shader)
+begg_bmp = displayio.OnDiskBitmap(BAD_EGG_FILENAME)
+begg_sprite = displayio.TileGrid(begg_bmp, pixel_shader=begg_bmp.pixel_shader)
 
 # good egg
 GOOD_EGG_FILENAME = "good_egg.bmp"
 
-# CircuitPython 6 & 7 compatible
-gegg_file = open(GOOD_EGG_FILENAME, "rb")
-gegg_bmp = displayio.OnDiskBitmap(gegg_file)
-gegg_sprite = displayio.TileGrid(
-    gegg_bmp,
-    pixel_shader=getattr(gegg_bmp, 'pixel_shader', displayio.ColorConverter())
-)
-
-# # CircuitPython 7+ compatible
-# gegg_bmp = displayio.OnDiskBitmap(GOOD_EGG_FILENAME)
-# gegg_sprite = displayio.TileGrid(gegg_bmp, pixel_shader=gegg_bmp.pixel_shader)
+gegg_bmp = displayio.OnDiskBitmap(GOOD_EGG_FILENAME)
+gegg_sprite = displayio.TileGrid(gegg_bmp, pixel_shader=gegg_bmp.pixel_shader)
 
 # draw the bad egg!
 splash.append(begg_sprite)

--- a/CLUE/CLUE_Hand_Wash_Timer/code.py
+++ b/CLUE/CLUE_Hand_Wash_Timer/code.py
@@ -21,38 +21,18 @@ clue_display = displayio.Group()
 
 # draw the background image
 WASH_ON_FILENAME = "wash_on.bmp"
-
-# CircuitPython 6 & 7 compatible
-wash_on_file = open(WASH_ON_FILENAME, "rb")
-wash_on_bmp = displayio.OnDiskBitmap(wash_on_file)
-wash_on_sprite = displayio.TileGrid(
-    wash_on_bmp,
-    pixel_shader=getattr(wash_on_bmp, 'pixel_shader', displayio.ColorConverter())
-)
-
-# # CircuitPython 7+ compatible
-# wash_on_bmp = displayio.OnDiskBitmap(WASH_ON_FILENAME)
-# wash_on_sprite = displayio.TileGrid(wash_on_bmp, pixel_shader=wash_on_bmp.pixel_shader)
+wash_on_bmp = displayio.OnDiskBitmap(WASH_ON_FILENAME)
+wash_on_sprite = displayio.TileGrid(wash_on_bmp, pixel_shader=wash_on_bmp.pixel_shader)
 
 clue_display.append(wash_on_sprite)
 
 # draw the foreground image
 WASH_OFF_FILENAME = "wash_off.bmp"
 
-# CircuitPython 6 & 7 compatible
-wash_off_file = open(WASH_OFF_FILENAME, "rb")
-wash_off_bmp = displayio.OnDiskBitmap(wash_off_file)
-wash_off_sprite = displayio.TileGrid(
-    wash_off_bmp,
-    pixel_shader=getattr(wash_off_bmp, 'pixel_shader', displayio.ColorConverter())
-)
-
-# # CircuitPython 7+ compatible
-# wash_off_bmp = displayio.OnDiskBitmap(WASH_OFF_FILENAME)
-# wash_off_sprite = displayio.TileGrid(wash_off_bmp, pixel_shader=wash_off_bmp.pixel_shader)
+wash_off_bmp = displayio.OnDiskBitmap(WASH_OFF_FILENAME)
+wash_off_sprite = displayio.TileGrid(wash_off_bmp, pixel_shader=wash_off_bmp.pixel_shader)
 
 clue_display.append(wash_off_sprite)
-
 
 # Create text
 # first create the group

--- a/CLUE/Clue_Step_Counter/code.py
+++ b/CLUE/Clue_Step_Counter/code.py
@@ -65,17 +65,9 @@ clue_display.brightness = 0.5
 clueGroup = displayio.Group()
 
 #  loading bitmap background
-# CircuitPython 6 & 7 compatible
-clue_bg = displayio.OnDiskBitmap(open(clue_bgBMP, "rb"))
-clue_tilegrid = displayio.TileGrid(
-    clue_bg, pixel_shader=getattr(clue_bg, 'pixel_shader', displayio.ColorConverter())
-)
+clue_bg = displayio.OnDiskBitmap(clue_bgBMP)
+clue_tilegrid = displayio.TileGrid(clue_bg, pixel_shader=clue_bg.pixel_shader)
 clueGroup.append(clue_tilegrid)
-
-# # CircuitPython 7+ compatible
-# clue_bg = displayio.OnDiskBitmap(clue_bgBMP)
-# clue_tilegrid = displayio.TileGrid(clue_bg, pixel_shader=clue_bg.pixel_shader)
-# clueGroup.append(clue_tilegrid)
 
 #  creating the ProgressBar object
 bar_group = displayio.Group()

--- a/CPB_AMS_Gizmo_BLE/code.py
+++ b/CPB_AMS_Gizmo_BLE/code.py
@@ -33,15 +33,8 @@ a.solicited_services.append(AppleMediaService)
 radio.start_advertising(a)
 
 def wrap_in_tilegrid(filename:str):
-    # CircuitPython 6 & 7 compatible
-    odb = displayio.OnDiskBitmap(open(filename, "rb"))
-    return displayio.TileGrid(
-        odb, pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter())
-    )
-
-    # # CircuitPython 7+ compatible
-    # odb = displayio.OnDiskBitmap(filename)
-    # return displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    odb = displayio.OnDiskBitmap(filename)
+    return displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
 def make_background(width, height, color):
     color_bitmap = displayio.Bitmap(width, height, 1)

--- a/CPB_ANCS/code.py
+++ b/CPB_ANCS/code.py
@@ -93,15 +93,8 @@ advertisement.complete_name = "CIRCUITPY"
 advertisement.solicited_services.append(AppleNotificationCenterService)
 
 def wrap_in_tilegrid(filename:str):
-    # CircuitPython 6 & 7 compatible
-    odb = displayio.OnDiskBitmap(open(filename, "rb"))
-    return displayio.TileGrid(
-        odb, pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter())
-    )
-
-    # # CircuitPython 7+ compatible
-    # odb = displayio.OnDiskBitmap(filename)
-    # return displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    odb = displayio.OnDiskBitmap(filename)
+    return displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
 display = tft_gizmo.TFT_Gizmo()
 group = displayio.Group()

--- a/CircuitPython_JEplayer_mp3/code.py
+++ b/CircuitPython_JEplayer_mp3/code.py
@@ -127,31 +127,15 @@ class PlaybackDisplay:
             if i == self._bitmap_filename:
                 return # Already loaded
 
-            # CircuitPython 6 & 7 compatible
             try:
-                bitmap_file = open(i, 'rb')
+                bitmap = displayio.OnDiskBitmap(i)
             except OSError:
                 continue
-            bitmap = displayio.OnDiskBitmap(bitmap_file)
             self._bitmap_filename = i
             # Create a TileGrid to hold the bitmap
             self.tile_grid = displayio.TileGrid(
-                bitmap,
-                pixel_shader=getattr(
-                    bitmap, "pixel_shader", displayio.ColorConverter()
-                ),
+                bitmap, pixel_shader=bitmap.pixel_shader
             )
-
-            # # CircuitPython 7+ compatible
-            # try:
-            #     bitmap = displayio.OnDiskBitmap(i)
-            # except OSError:
-            #     continue
-            # self._bitmap_filename = i
-            # # Create a TileGrid to hold the bitmap
-            # self.tile_grid = displayio.TileGrid(
-            #     bitmap, pixel_shader=bitmap.pixel_shader
-            # )
 
             # Add the TileGrid to the Group
             if len(self.group) == 0:

--- a/CircuitPython_RGBMatrix/fruit/code.py
+++ b/CircuitPython_RGBMatrix/fruit/code.py
@@ -25,14 +25,8 @@ display = framebufferio.FramebufferDisplay(matrix, auto_refresh=False)
 
 filename = "emoji.bmp"
 
-# CircuitPython 6 & 7 compatible
-bitmap_file = open(filename, 'rb')
-bitmap = displayio.OnDiskBitmap(bitmap_file)
-pixel_shader = getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
-
-# # CircuitPython 7+ compatible
-# bitmap = displayio.OnDiskBitmap(filename)
-# pixel_shader = bitmap.pixel_shader
+bitmap = displayio.OnDiskBitmap(filename)
+pixel_shader = bitmap.pixel_shader
 
 # Each wheel can be in one of three states:
 STOPPED, RUNNING, BRAKING = range(3)

--- a/CircuitPython_RGBMatrix/tiled/code.py
+++ b/CircuitPython_RGBMatrix/tiled/code.py
@@ -46,23 +46,13 @@ DISPLAY = framebufferio.FramebufferDisplay(MATRIX, auto_refresh=False,
 # Load BMP image, create Group and TileGrid to hold it
 FILENAME = "wales.bmp"
 
-# CircuitPython 6 & 7 compatible
-BITMAP = displayio.OnDiskBitmap(open(FILENAME, "rb"))
+BITMAP = displayio.OnDiskBitmap(FILENAME)
 TILEGRID = displayio.TileGrid(
     BITMAP,
-    pixel_shader=getattr(BITMAP, 'pixel_shader', displayio.ColorConverter()),
+    pixel_shader=BITMAP.pixel_shader,
     tile_width=BITMAP.width,
     tile_height=BITMAP.height
 )
-
-# # CircuitPython 7+ compatible
-# BITMAP = displayio.OnDiskBitmap(FILENAME)
-# TILEGRID = displayio.TileGrid(
-#     BITMAP,
-#     pixel_shader=BITMAP.pixel_shader,
-#     tile_width=BITMAP.width,
-#     tile_height=BITMAP.height
-# )
 
 GROUP = displayio.Group()
 GROUP.append(TILEGRID)

--- a/CircuitPython_sdcardio_sdioio/show_bitmaps/code.py
+++ b/CircuitPython_sdcardio_sdioio/show_bitmaps/code.py
@@ -21,17 +21,8 @@ while True:
     for filename in bmpfiles:
         print("showing", filename)
 
-        # CircuitPython 6 & 7 compatible
-        bitmap_file = open(filename, "rb")
-        bitmap = displayio.OnDiskBitmap(bitmap_file)
-        tile_grid = displayio.TileGrid(
-            bitmap,
-            pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
-        )
-
-        # # CircuitPython 7+ compatible
-        # bitmap = displayio.OnDiskBitmap(filename)
-        # tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
+        bitmap = displayio.OnDiskBitmap(filename)
+        tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
 
         group = displayio.Group()
         group.append(tile_grid)

--- a/EInk_CircuitPython_Quickstart/213_tricolor_eink_fw_badge/code.py
+++ b/EInk_CircuitPython_Quickstart/213_tricolor_eink_fw_badge/code.py
@@ -77,18 +77,9 @@ g.append(bg_sprite)
 filename = "/picture.bmp"
 
 # Create a Tilegrid with the bitmap and put in the displayio group
-
-# CircuitPython 6 & 7 compatible
-pic = displayio.OnDiskBitmap(open(filename, "rb"))
-t = displayio.TileGrid(
-    pic, pixel_shader=getattr(pic, 'pixel_shader', displayio.ColorConverter())
-)
+pic = displayio.OnDiskBitmap(filename)
+t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
 g.append(t)
-
-# # CircuitPython 7+ compatible
-# pic = displayio.OnDiskBitmap(filename)
-# t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
-# g.append(t)
 
 # Draw simple text using the built-in font into a displayio group
 # For smaller text, change scale=2 to scale=1

--- a/EInk_CircuitPython_Quickstart/27_tricolor_eink_shield_badge/code.py
+++ b/EInk_CircuitPython_Quickstart/27_tricolor_eink_shield_badge/code.py
@@ -73,18 +73,9 @@ g.append(bg_sprite)
 filename = "/picture.bmp"
 
 # Create a Tilegrid with the bitmap and put in the displayio group
-
-# CircuitPython 6 & 7 compatible
-pic = displayio.OnDiskBitmap(open(filename, "rb"))
-t = displayio.TileGrid(
-    pic, pixel_shader=getattr(pic, 'pixel_shader', displayio.ColorConverter())
-)
+pic = displayio.OnDiskBitmap(filename)
+t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
 g.append(t)
-
-# # CircuitPython 7+ compatible
-# pic = displayio.OnDiskBitmap(filename)
-# t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
-# g.append(t)
 
 # Draw simple text using the built-in font into a displayio group
 # For smaller text, change scale=2 to scale=1 as scale 2 doesn't

--- a/Feather_RP2040_ThinkInk_Examples/CircuitPython_ACeP_Example/code.py
+++ b/Feather_RP2040_ThinkInk_Examples/CircuitPython_ACeP_Example/code.py
@@ -30,16 +30,13 @@ display = adafruit_spd1656.SPD1656(
 
 g = displayio.Group()
 
-fn = "/display-ruler-720p.bmp"
+pic = displayio.OnDiskBitmap("/display-ruler-720p.bmp")
+t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+g.append(t)
 
-with open(fn, "rb") as f:
-    pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
-    g.append(t)
+display.root_group = g
 
-    display.root_group = g
-
-    display.refresh()
+display.refresh()
 
 while True:
     pass

--- a/Feather_RP2040_ThinkInk_Examples/CircuitPython_Tri-Color_Example/code.py
+++ b/Feather_RP2040_ThinkInk_Examples/CircuitPython_Tri-Color_Example/code.py
@@ -37,20 +37,17 @@ display = adafruit_ssd1680.SSD1680(
 
 g = displayio.Group()
 
-with open("/display-ruler.bmp", "rb") as f:
-    pic = displayio.OnDiskBitmap(f)
 
-    t = displayio.TileGrid(
-        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
-    )
+pic = displayio.OnDiskBitmap("/display-ruler.bmp")
+t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
 
-    g.append(t)
+g.append(t)
 
-    display.root_group = g
+display.root_group = g
 
-    display.refresh()
+display.refresh()
 
-    print("refreshed")
+print("refreshed")
 
 while True:
     pass

--- a/HalloWing_Cat_Toy/code.py
+++ b/HalloWing_Cat_Toy/code.py
@@ -75,17 +75,8 @@ def play_wave(filename):
 # Display an image on the HalloWing TFT screen
 
 def show_image(filename):
-    # CircuitPython 6 & 7 compatible
-    image_file = open(filename, "rb")
-    odb = displayio.OnDiskBitmap(image_file)
-    face = displayio.TileGrid(
-        odb,
-        pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter())
-    )
-
-    # # CircuitPython 7+ compatible
-    # odb = displayio.OnDiskBitmap(filename)
-    # face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    odb = displayio.OnDiskBitmap(filename)
+    face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
     backlight.value = False
     splash.append(face)

--- a/HalloWing_Jump_Scare_Trap/code.py
+++ b/HalloWing_Jump_Scare_Trap/code.py
@@ -98,17 +98,9 @@ images = ["trap_sprung.bmp", "reset_trap.bmp", "please_standby.bmp",
           "trap_set.bmp"]
 # Function for displaying images on HalloWing TFT screen
 def show_image(filename):
-    # CircuitPython 6 & 7 compatible
-    image_file = open(filename, "rb")
-    odb = displayio.OnDiskBitmap(image_file)
-    face = displayio.TileGrid(
-        odb,
-        pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter())
-    )
 
-    # # CircuitPython 7+ compatible
-    # odb = displayio.OnDiskBitmap(filename)
-    # face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    odb = displayio.OnDiskBitmap(filename)
+    face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
     backlight.duty_cycle = 0
     splash.append(face)

--- a/HalloWing_Tour_Guide/code.py
+++ b/HalloWing_Tour_Guide/code.py
@@ -64,23 +64,12 @@ def play_wave(filename):
         pass
 
 def show_image(filename):
-    # CircuitPython 6 & 7 compatible
-    try:
-        image_file = open(filename, "rb")
-    except OSError:
-        image_file = open("missing.bmp", "rb")
-    odb = displayio.OnDiskBitmap(image_file)
-    face = displayio.TileGrid(
-        odb,
-        pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter())
-    )
 
-    # # CircuitPython 7+ compatible
-    # try:
-    #     odb = displayio.OnDiskBitmap(filename)
-    # except (OSError, ValueError):
-    #     odb = displayio.OnDiskBitmap("missing.bmp")
-    # face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    try:
+        odb = displayio.OnDiskBitmap(filename)
+    except (OSError, ValueError):
+        odb = displayio.OnDiskBitmap("missing.bmp")
+    face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
     backlight.value = False
     splash.append(face)

--- a/Hallowing_Jump_Sound/jump-sound/code.py
+++ b/Hallowing_Jump_Sound/jump-sound/code.py
@@ -102,7 +102,6 @@ try:
     SCREEN = displayio.Group()
     board.DISPLAY.root_group = SCREEN
 
-    # CircuitPython 7+ compatible
     BITMAP = displayio.OnDiskBitmap(IMAGEFILE)
     TILEGRID = displayio.TileGrid(BITMAP, pixel_shader=BITMAP.pixel_shader)
 

--- a/Hallowing_Jump_Sound/stomp-and-roar/code.py
+++ b/Hallowing_Jump_Sound/stomp-and-roar/code.py
@@ -98,7 +98,6 @@ try:
     SCREEN = displayio.Group()
     board.DISPLAY.root_group = SCREEN
 
-    # CircuitPython 7+ compatible
     BITMAP = displayio.OnDiskBitmap(IMAGEFILE)
     TILEGRID = displayio.TileGrid(BITMAP, pixel_shader=BITMAP.pixel_shader)
 

--- a/MagTag/MagTag_Christmas_Countdown/code.py
+++ b/MagTag/MagTag_Christmas_Countdown/code.py
@@ -25,16 +25,8 @@ circle_group = displayio.Group()
 
 #  import tree bitmap
 filename = "/atree.bmp"
-
-# CircuitPython 6 & 7 compatible
-tree = displayio.OnDiskBitmap(open(filename, "rb"))
-tree_grid = displayio.TileGrid(
-    tree, pixel_shader=getattr(tree, 'pixel_shader', displayio.ColorConverter())
-)
-
-# # CircuitPython 7+ compatible
-# tree = displayio.OnDiskBitmap(filename)
-# tree_grid = displayio.TileGrid(tree, pixel_shader=tree.pixel_shader)
+tree = displayio.OnDiskBitmap(filename)
+tree_grid = displayio.TileGrid(tree, pixel_shader=tree.pixel_shader)
 
 #  add bitmap to its group
 tree_group.append(tree_grid)

--- a/MagTag/MagTag_Dishwasher_Status/wake_on_button/code.py
+++ b/MagTag/MagTag_Dishwasher_Status/wake_on_button/code.py
@@ -22,31 +22,15 @@ alarm.sleep_memory[0] = not alarm.sleep_memory[0]
 bmp_file = "/images/clean.bmp" if alarm.sleep_memory[0] else "/images/dirty.bmp"
 
 # show bitmap
-
-# CircuitPython 6 & 7 compatible
-with open(bmp_file, "rb") as fp:
-    bitmap = displayio.OnDiskBitmap(fp)
-    tile_grid = displayio.TileGrid(
-        bitmap, pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
-    )
-    group = displayio.Group()
-    group.append(tile_grid)
-    epd.root_group = group
-    time.sleep(epd.time_to_refresh + 0.01)
-    epd.refresh()
-    while epd.busy:
-        pass
-
-# # CircuitPython 7+ compatible
-# bitmap = displayio.OnDiskBitmap(bmp_file)
-# tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
-# group = displayio.Group()
-# group.append(tile_grid)
-# epd.root_group = group
-# time.sleep(epd.time_to_refresh + 0.01)
-# epd.refresh()
-# while epd.busy:
-#     pass
+bitmap = displayio.OnDiskBitmap(bmp_file)
+tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
+group = displayio.Group()
+group.append(tile_grid)
+epd.root_group = group
+time.sleep(epd.time_to_refresh + 0.01)
+epd.refresh()
+while epd.busy:
+    pass
 
 # go to sleep
 alarm.exit_and_deep_sleep_until_alarms(*pin_alarms)

--- a/MagTag/MagTag_Dishwasher_Status/wake_on_flip/code.py
+++ b/MagTag/MagTag_Dishwasher_Status/wake_on_flip/code.py
@@ -51,31 +51,15 @@ else:
 epd.rotation = rotation
 
 # show bitmap
-
-# CircuitPython 6 & 7 compatible
-with open(bmp_file, "rb") as fp:
-    bitmap = displayio.OnDiskBitmap(fp)
-    tile_grid = displayio.TileGrid(
-        bitmap, pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter())
-    )
-    group = displayio.Group()
-    group.append(tile_grid)
-    epd.root_group = group
-    time.sleep(epd.time_to_refresh + 0.01)
-    epd.refresh()
-    while epd.busy:
-        pass
-
-# # CircuitPython 7+ compatible
-# bitmap = displayio.OnDiskBitmap(bmp_file)
-# tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
-# group = displayio.Group()
-# group.append(tile_grid)
-# epd.root_group = group
-# time.sleep(epd.time_to_refresh + 0.01)
-# epd.refresh()
-# while epd.busy:
-#     pass
+bitmap = displayio.OnDiskBitmap(bmp_file)
+tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
+group = displayio.Group()
+group.append(tile_grid)
+epd.root_group = group
+time.sleep(epd.time_to_refresh + 0.01)
+epd.refresh()
+while epd.busy:
+    pass
 
 
 # config accelo irq

--- a/Magic_Nine_Ball/code.py
+++ b/Magic_Nine_Ball/code.py
@@ -33,24 +33,13 @@ while True:
     shaken = False
 
     print("Image load {}".format(images[i]))
-    # CircuitPython 6 & 7 compatible
     try:
-        f = open(images[i], "rb")
-        odb = displayio.OnDiskBitmap(f)
+        odb = displayio.OnDiskBitmap(images[i])
     except ValueError:
         print("Image unsupported {}".format(images[i]))
         del images[i]
         continue
-    face = displayio.TileGrid(odb, pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter()))
-
-    # # CircuitPython 7+ compatible
-    # try:
-    #     odb = displayio.OnDiskBitmap(images[i])
-    # except ValueError:
-    #     print("Image unsupported {}".format(images[i]))
-    #     del images[i]
-    #     continue
-    # face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+    face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
     splash.append(face)
     # Wait for the image to load.

--- a/Matrix_Portal/MatrixPortal_S3_Flight_Proximity_Tracker/code.py
+++ b/Matrix_Portal/MatrixPortal_S3_Flight_Proximity_Tracker/code.py
@@ -218,12 +218,10 @@ def create_icon_tilegrid(ident):
     icon_path = f"/airline_logos/{airline_code}.bmp"
 
     try:
-        file = open(icon_path, "rb")
-        icon_bitmap = OnDiskBitmap(file)
+        icon_bitmap = OnDiskBitmap(icon_path)
     except OSError:
         print(f"Icon for {airline_code} not found. Using placeholder.")
-        file = open(PLACEHOLDER_ICON_PATH, "rb")
-        icon_bitmap = OnDiskBitmap(file)
+        icon_bitmap = OnDiskBitmap(PLACEHOLDER_ICON_PATH)
 
     icon_tilegrid = TileGrid(icon_bitmap, pixel_shader=icon_bitmap.pixel_shader, x=0, y=0)
     return icon_tilegrid

--- a/Matrix_Portal/Matrix_Portal_Moon_Clock/code.py
+++ b/Matrix_Portal/Matrix_Portal_Moon_Clock/code.py
@@ -232,16 +232,8 @@ GROUP = displayio.Group()
 try:
     FILENAME = 'moon/splash-' + str(DISPLAY.rotation) + '.bmp'
 
-    # CircuitPython 6 & 7 compatible
-    BITMAP = displayio.OnDiskBitmap(open(FILENAME, 'rb'))
-    TILE_GRID = displayio.TileGrid(
-        BITMAP,
-        pixel_shader=getattr(BITMAP, 'pixel_shader', displayio.ColorConverter())
-    )
-
-    # # CircuitPython 7+ compatible
-    # BITMAP = displayio.OnDiskBitmap(FILENAME)
-    # TILE_GRID = displayio.TileGrid(BITMAP, pixel_shader=BITMAP.pixel_shader)
+    BITMAP = displayio.OnDiskBitmap(FILENAME)
+    TILE_GRID = displayio.TileGrid(BITMAP, pixel_shader=BITMAP.pixel_shader)
 
     GROUP.append(TILE_GRID)
 except:
@@ -413,15 +405,6 @@ while True:
     # Update moon image (GROUP[0])
     FILENAME = 'moon/moon' + '{0:0>2}'.format(FRAME) + '.bmp'
 
-    # CircuitPython 6 & 7 compatible
-    # BITMAP = displayio.OnDiskBitmap(open(FILENAME, 'rb'))
-    # TILE_GRID = displayio.TileGrid(
-    #     BITMAP,
-    #     pixel_shader=getattr(BITMAP, 'pixel_shader',
-    #                          displayio.ColorConverter())
-    # )
-
-    # CircuitPython 7+ compatible
     BITMAP = displayio.OnDiskBitmap(FILENAME)
     TILE_GRID = displayio.TileGrid(BITMAP, pixel_shader=BITMAP.pixel_shader)
 

--- a/Matrix_Portal/Matrix_Portal_Tip_Jar/code.py
+++ b/Matrix_Portal/Matrix_Portal_Tip_Jar/code.py
@@ -75,23 +75,13 @@ def load_image():
 
     filename = SPRITESHEET_FOLDER + "/" + file_list[CURRENT_IMAGE]
 
-    # CircuitPython 6 & 7 compatible
-    bitmap = displayio.OnDiskBitmap(open(filename, "rb"))
+    bitmap = displayio.OnDiskBitmap(filename)
     sprite = displayio.TileGrid(
         bitmap,
-        pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter()),
+        pixel_shader=bitmap.pixel_shader,
         tile_width=bitmap.width,
         tile_height=matrix.display.height,
     )
-
-    # # CircuitPython 7+ compatible
-    # bitmap = displayio.OnDiskBitmap(filename)
-    # sprite = displayio.TileGrid(
-    #     bitmap,
-    #     pixel_shader=bitmap.pixel_shader,
-    #     tile_width=bitmap.width,
-    #     tile_height=matrix.display.height,
-    # )
 
     sprite_group.append(sprite)
 

--- a/Matrix_Sprite_Animation_Player/code.py
+++ b/Matrix_Sprite_Animation_Player/code.py
@@ -62,24 +62,13 @@ def load_image():
         sprite_group.pop()
 
     filename = SPRITESHEET_FOLDER + "/" + file_list[current_image]
-
-    # CircuitPython 6 & 7 compatible
-    bitmap = displayio.OnDiskBitmap(open(filename, "rb"))
+    bitmap = displayio.OnDiskBitmap(filename)
     sprite = displayio.TileGrid(
         bitmap,
-        pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter()),
+        pixel_shader=bitmap.pixel_shader,
         tile_width=bitmap.width,
         tile_height=matrix.display.height,
     )
-
-    # # CircuitPython 7+ compatible
-    # bitmap = displayio.OnDiskBitmap(filename)
-    # sprite = displayio.TileGrid(
-    #     bitmap,
-    #     pixel_shader=bitmap.pixel_shader,
-    #     tile_width=bitmap.width,
-    #     tile_height=matrix.display.height,
-    # )
 
     sprite_group.append(sprite)
 

--- a/Pep_Talk_Generator/clue/code.py
+++ b/Pep_Talk_Generator/clue/code.py
@@ -106,10 +106,10 @@ arial12.load_glyphs(
 display = board.DISPLAY
 clue_group = displayio.Group()
 
-bitmap_file = open("bmps/background.bmp", "rb")
-bitmap1 = displayio.OnDiskBitmap(bitmap_file)
+
+bitmap1 = displayio.OnDiskBitmap("bmps/background.bmp")
 tile_grid = displayio.TileGrid(
-    bitmap1, pixel_shader=getattr(bitmap1, "pixel_shader", displayio.ColorConverter())
+    bitmap1, pixel_shader=bitmap1.pixel_shader
 )
 clue_group.append(tile_grid)
 

--- a/PyPortal/Pathfinder/pathfinder_auto/code.py
+++ b/PyPortal/Pathfinder/pathfinder_auto/code.py
@@ -73,25 +73,21 @@ vo_sound = [
 
 pyportal = PyPortal(status_neopixel=board.NEOPIXEL)
 
-# Open the file
-with open(emote_img[0], "rb") as bitmap_file:
-    # Setup the file as the bitmap data source
-    bitmap = displayio.OnDiskBitmap(bitmap_file)
-    # Create a TileGrid to hold the bitmap
-    tile_grid = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap,
-                                                                'pixel_shader',
-                                                                displayio.ColorConverter()))
-    # Create a Group to hold the TileGrid
-    group = displayio.Group()
-    # Add the TileGrid to the Group
-    group.append(tile_grid)
-    # Add the Group to the Display
-    display.root_group = group
-    if sound_mode != 0:
-        # play a sound file
-        pyportal.play_file(vo_sound[10])
-    else:
-        pyportal.play_file("/vo/pathfnd_silent.wav")  # hack to deal w no mute method
+# Setup the file as the bitmap data source
+bitmap = displayio.OnDiskBitmap(emote_img[0])
+# Create a TileGrid to hold the bitmap
+tile_grid = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap.pixel_shader))
+# Create a Group to hold the TileGrid
+group = displayio.Group()
+# Add the TileGrid to the Group
+group.append(tile_grid)
+# Add the Group to the Display
+display.root_group = group
+if sound_mode != 0:
+    # play a sound file
+    pyportal.play_file(vo_sound[10])
+else:
+    pyportal.play_file("/vo/pathfnd_silent.wav")  # hack to deal w no mute method
 
 
 # Loop forever so you can enjoy your image
@@ -107,7 +103,6 @@ while True:
     pixel.show()
     time.sleep(1)
 
-    # CircuitPython 7+ compatible
     bitmap = displayio.OnDiskBitmap(emote_img[i])
     tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
     group = displayio.Group()

--- a/PyPortal/Pathfinder/pathfinder_touch/code.py
+++ b/PyPortal/Pathfinder/pathfinder_touch/code.py
@@ -71,25 +71,21 @@ vo_sound = [
 
 pyportal = PyPortal(status_neopixel=board.NEOPIXEL)
 
-# Open the file
-with open(emote_img[0], "rb") as bitmap_file:
-    # Setup the file as the bitmap data source
-    bitmap = displayio.OnDiskBitmap(bitmap_file)
-    # Create a TileGrid to hold the bitmap
-    tile_grid = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap,
-                                                                'pixel_shader',
-                                                                displayio.ColorConverter()))
-    # Create a Group to hold the TileGrid
-    group = displayio.Group()
-    # Add the TileGrid to the Group
-    group.append(tile_grid)
-    # Add the Group to the Display
-    display.root_group = group
-    if sound_mode != 0:
-        # play a sound file
-        pyportal.play_file(vo_sound[10])
-    else:
-        pyportal.play_file("/vo/pathfnd_silent.wav")  # hack to deal w no mute method
+# Setup the file as the bitmap data source
+bitmap = displayio.OnDiskBitmap(emote_img[0])
+# Create a TileGrid to hold the bitmap
+tile_grid = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap.pixel_shader))
+# Create a Group to hold the TileGrid
+group = displayio.Group()
+# Add the TileGrid to the Group
+group.append(tile_grid)
+# Add the Group to the Display
+display.root_group = group
+if sound_mode != 0:
+    # play a sound file
+    pyportal.play_file(vo_sound[10])
+else:
+    pyportal.play_file("/vo/pathfnd_silent.wav")  # hack to deal w no mute method
 
 while True:
     if not pyportal.touchscreen.touch_point:
@@ -101,7 +97,6 @@ while True:
     pixel.show()
     time.sleep(1)
 
-    # CircuitPython 7+ compatible
     bitmap = displayio.OnDiskBitmap(emote_img[i])
     tile_grid = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
     group = displayio.Group()

--- a/PyPortal/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
+++ b/PyPortal/PyPortal_AWS_IOT_Planter/aws_gfx_helper.py
@@ -135,16 +135,7 @@ class AWS_GFX(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        # CircuitPython 6 & 7 compatible
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(icon,
-                                               pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-
-        # # CircuitPython 7+ compatible
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_Alarm_Clock/code.py
+++ b/PyPortal/PyPortal_Alarm_Clock/code.py
@@ -277,19 +277,8 @@ class Time_State(State):
                 filename = "/icons/"+weather_icon_name+".bmp"
 
                 if filename:
-                    # CircuitPython 6 & 7 compatible
-                    if self.icon_file:
-                        self.icon_file.close()
-                    self.icon_file = open(filename, "rb")
-                    icon = displayio.OnDiskBitmap(self.icon_file)
-
-                    icon_sprite = displayio.TileGrid(icon,
-                                                     pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()),
-                                                     x=0, y=0)
-
-                    # # CircuitPython 7+ compatible
-                    # icon = displayio.OnDiskBitmap(filename)
-                    # icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+                    icon = displayio.OnDiskBitmap(filename)
+                    icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
                     self.weather_icon.append(icon_sprite)
 
@@ -354,14 +343,9 @@ class Time_State(State):
             # CircuitPython 6 & 7 compatible
             if self.snooze_file:
                 self.snooze_file.close()
-            self.snooze_file = open('/icons/zzz.bmp', "rb")
-            icon = displayio.OnDiskBitmap(self.snooze_file)
-            icon_sprite = displayio.TileGrid(icon,
-                                             pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
 
-            # # CircuitPython 7+ compatible
-            # icon = displayio.OnDiskBitmap("/icons/zzz.bmp")
-            # icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+            icon = displayio.OnDiskBitmap("/icons/zzz.bmp")
+            icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
             self.snooze_icon.append(icon_sprite)
             pyportal.splash.append(self.snooze_icon)

--- a/PyPortal/PyPortal_Azure_Plant_Monitor/azure_gfx_helper.py
+++ b/PyPortal/PyPortal_Azure_Plant_Monitor/azure_gfx_helper.py
@@ -134,18 +134,7 @@ class Azure_GFX(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        # CircuitPython 6 & 7 compatible
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(
-            icon, pixel_shader=getattr(icon, "pixel_shader", displayio.ColorConverter())
-        )
-
-        # CircuitPython 7 compatible
-        # # Remove self._icon_file - it is no longer used
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_Electioncal_US/electioncal_graphics.py
+++ b/PyPortal/PyPortal_Electioncal_US/electioncal_graphics.py
@@ -143,18 +143,7 @@ class Electioncal_Graphics(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        # CircuitPython 6 & 7 compatible
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(
-            icon,
-            pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter())
-        )
-
-        # # CircuitPython 7+ compatible
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_GCP_IOT_Planter/gcp_gfx_helper.py
+++ b/PyPortal/PyPortal_GCP_IOT_Planter/gcp_gfx_helper.py
@@ -136,18 +136,7 @@ class Google_GFX(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        # CircuitPython 6 & 7 compatible
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(
-            icon,
-            pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter())
-        )
-
-        # # CircuitPython 7+ compatible
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_Mirror_Display/openweather_graphics.py
+++ b/PyPortal/PyPortal_Mirror_Display/openweather_graphics.py
@@ -129,11 +129,7 @@ class OpenWeather_Graphics(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-
-        icon = displayio.OnDiskBitmap(self._icon_file)
+        icon = displayio.OnDiskBitmap(filename)
         self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_OpenWeather/openweather_graphics.py
+++ b/PyPortal/PyPortal_OpenWeather/openweather_graphics.py
@@ -130,16 +130,7 @@ class OpenWeather_Graphics(displayio.Group):
         if not filename:
             return  # we're done, no icon desired
 
-        # CircuitPython 6 & 7 compatible
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(
-            icon, pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-
-        # # CircuitPython 7+ compatible
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=background.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=background.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_Smart_Thermometer/thermometer_helper.py
+++ b/PyPortal/PyPortal_Smart_Thermometer/thermometer_helper.py
@@ -135,13 +135,6 @@ class Thermometer_GFX(displayio.Group):
         if self._icon_file:
             self._icon_file.close()
 
-        # CircuitPython 6 & 7 compatible
-        # self._icon_file = open(filename, "rb")
-        # icon = displayio.OnDiskBitmap(self._icon_file)
-        # self._icon_sprite = displayio.TileGrid(icon,
-        #                                        pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-
-        # # CircuitPython 7+ compatible
         icon = displayio.OnDiskBitmap(filename)
         self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 

--- a/PyPortal/PyPortal_Titano_Weather_Station/code.py
+++ b/PyPortal/PyPortal_Titano_Weather_Station/code.py
@@ -56,20 +56,20 @@ alarm_sounds = [alarm_sound_trash, alarm_sound_bed,
 #  setting up the bitmaps for the alarms
 
 #  sleep alarm
-sleep_bitmap = displayio.OnDiskBitmap(open("/sleepBMP.bmp", "rb"))
-sleep_tilegrid = displayio.TileGrid(sleep_bitmap, pixel_shader=getattr(sleep_bitmap, 'pixel_shader', displayio.ColorConverter()))
+sleep_bitmap = displayio.OnDiskBitmap("/sleepBMP.bmp")
+sleep_tilegrid = displayio.TileGrid(sleep_bitmap, pixel_shader=sleep_bitmap.pixel_shader)
 group_bed = displayio.Group()
 group_bed.append(sleep_tilegrid)
 
 #  trash alarm
-trash_bitmap = displayio.OnDiskBitmap(open("/trashBMP.bmp", "rb"))
-trash_tilegrid = displayio.TileGrid(trash_bitmap, pixel_shader=getattr(trash_bitmap, 'pixel_shader', displayio.ColorConverter()))
+trash_bitmap = displayio.OnDiskBitmap("/trashBMP.bmp")
+trash_tilegrid = displayio.TileGrid(trash_bitmap, pixel_shader=trash_bitmap.pixel_shader)
 group_trash = displayio.Group()
 group_trash.append(trash_tilegrid)
 
 #  meal alarm
-eat_bitmap = displayio.OnDiskBitmap(open("/eatBMP.bmp", "rb"))
-eat_tilegrid = displayio.TileGrid(eat_bitmap, pixel_shader=getattr(eat_bitmap, 'pixel_shader', displayio.ColorConverter()))
+eat_bitmap = displayio.OnDiskBitmap("/eatBMP.bmp")
+eat_tilegrid = displayio.TileGrid(eat_bitmap, pixel_shader=eat_bitmap.pixel_shader)
 group_eat = displayio.Group()
 group_eat.append(eat_tilegrid)
 

--- a/PyPortal/PyPortal_Titano_Weather_Station/openweather_graphics.py
+++ b/PyPortal/PyPortal_Titano_Weather_Station/openweather_graphics.py
@@ -178,14 +178,7 @@ class OpenWeather_Graphics(displayio.Group):
         if self._icon_file:
             self._icon_file.close()
 
-        # CircuitPython 6 & 7 compatible
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
-        self._icon_sprite = displayio.TileGrid(icon,
-                                               pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-
-        # # CircuitPython 7+ compatible
-        # icon = displayio.OnDiskBitmap(filename)
-        # self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
+        icon = displayio.OnDiskBitmap(filename)
+        self._icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
         self._icon_group.append(self._icon_sprite)

--- a/PyPortal/PyPortal_User_Interface/code.py
+++ b/PyPortal/PyPortal_User_Interface/code.py
@@ -93,16 +93,8 @@ def set_image(group, filename):
     if not filename:
         return  # we're done, no icon desired
 
-    # CircuitPython 6 & 7 compatible
-    image_file = open(filename, "rb")
-    image = displayio.OnDiskBitmap(image_file)
-    image_sprite = displayio.TileGrid(
-        image, pixel_shader=getattr(image, "pixel_shader", displayio.ColorConverter())
-    )
-
-    # # CircuitPython 7+ compatible
-    # image = displayio.OnDiskBitmap(filename)
-    # image_sprite = displayio.TileGrid(image, pixel_shader=image.pixel_shader)
+    image = displayio.OnDiskBitmap(filename)
+    image_sprite = displayio.TileGrid(image, pixel_shader=image.pixel_shader)
 
     group.append(image_sprite)
 

--- a/PyPortal/PyPortal_Wheres_My_Friend/code.py
+++ b/PyPortal/PyPortal_Wheres_My_Friend/code.py
@@ -72,11 +72,10 @@ def set_image(image_group, filename):
     if image_group:
         image_group.pop()
 
-    image_file = open(filename, "rb")
-    image = displayio.OnDiskBitmap(image_file)
+
+    image = displayio.OnDiskBitmap(filename)
     image_sprite = displayio.TileGrid(image,
-                                      pixel_shader=getattr(image, 'pixel_shader',
-                                      displayio.ColorConverter()))
+                                      pixel_shader=image.pixel_shader)
     image_sprite.x = IMAGE_SPRITE_X
     image_sprite.y = IMAGE_SPRITE_Y
     image_group.append(image_sprite)

--- a/PyPortal/pyportal_weather_station/weatherstation_helper.py
+++ b/PyPortal/pyportal_weather_station/weatherstation_helper.py
@@ -132,18 +132,9 @@ class WeatherStation_GFX(displayio.Group):
 
         if not filename:
             return  # we're done, no icon desired
-        if self._icon_file:
-            self._icon_file.close()
-        self._icon_file = open(filename, "rb")
-        icon = displayio.OnDiskBitmap(self._icon_file)
 
-        # CircuitPython 6 & 7 compatible
+        icon = displayio.OnDiskBitmap(filename)
         self._icon_sprite = displayio.TileGrid(
             icon,
-            pixel_shader=getattr(icon, 'pixel_shader', displayio.ColorConverter()))
-
-        # # CircuitPython 7+ compatible
-        # self._icon_sprite = displayio.TileGrid(
-        #     icon,
-        #     pixel_shader=icon.pixel_shader)
+            pixel_shader=icon.pixel_shader)
         board.DISPLAY.refresh(target_frames_per_second=60)

--- a/TMC2209_Camera_Slider/CircuitPython/code.py
+++ b/TMC2209_Camera_Slider/CircuitPython/code.py
@@ -43,7 +43,7 @@ display = ST7789(display_bus, width=240, height=240, rowstart=80, auto_refresh=F
 splash = displayio.Group()
 display.root_group = splash
 
-bitmap = displayio.OnDiskBitmap(open("/icons.bmp", "rb"))
+bitmap = displayio.OnDiskBitmap("/icons.bmp")
 
 grid_bg = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader,
                              tile_height=100, tile_width=100,

--- a/Tilemap_Game_With_CircuitPython/code.py
+++ b/Tilemap_Game_With_CircuitPython/code.py
@@ -443,17 +443,9 @@ def show_splash(new_text, color, vertical_offset=18):
 # Make the splash context
 splash = displayio.Group()
 
-# CircuitPython 6 & 7 compatible
-
 # game message background bmp file
-game_message_background = open("tilegame_assets/game_message_background.bmp", "rb")
-odb = displayio.OnDiskBitmap(game_message_background)
-bg_grid = displayio.TileGrid(odb, pixel_shader=getattr(odb, 'pixel_shader', displayio.ColorConverter()))
-
-# # CircuitPython 7+ compatible
-# game message background bmp file
-# odb = displayio.OnDiskBitmap("tilegame_assets/game_message_background.bmp")
-# bg_grid = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
+odb = displayio.OnDiskBitmap("tilegame_assets/game_message_background.bmp")
+bg_grid = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)
 
 splash.append(bg_grid)
 

--- a/Vertical_Garden_Barometer/code.py
+++ b/Vertical_Garden_Barometer/code.py
@@ -61,26 +61,14 @@ clue.display.brightness = 0.8
 clue_display = displayio.Group()
 
 # draw the rising image
-# CircuitPython 6 & 7 compatible
-rising_file = open("rising.bmp", "rb")
-rising_bmp = displayio.OnDiskBitmap(rising_file)
-rising_sprite = displayio.TileGrid(rising_bmp, pixel_shader=getattr(rising_bmp, 'pixel_shader', displayio.ColorConverter()))
-
-# # CircuitPython 7+ compatible
-# rising_bmp = displayio.OnDiskBitmap("rising.bmp")
-# rising_sprite = displayio.TileGrid(rising_bmp, pixel_shader=rising_bmp.pixel_shader)
+rising_bmp = displayio.OnDiskBitmap("rising.bmp")
+rising_sprite = displayio.TileGrid(rising_bmp, pixel_shader=rising_bmp.pixel_shader)
 
 clue_display.append(rising_sprite)
 
 # draw the sinking image
-# CircuitPython 6 & 7 compatible
-sinking_file = open("sinking.bmp", "rb")
-sinking_bmp = displayio.OnDiskBitmap(sinking_file)
-sinking_sprite = displayio.TileGrid(sinking_bmp, pixel_shader=getattr(sinking_bmp, 'pixel_shader', displayio.ColorConverter()))
-
-# # CircuitPython 7+ compatible
-# sinking_bmp = displayio.OnDiskBitmap("sinking.bmp")
-# sinking_sprite = displayio.TileGrid(sinking_bmp, pixel_shader=sinking_bmp.pixel_shader)
+sinking_bmp = displayio.OnDiskBitmap("sinking.bmp")
+sinking_sprite = displayio.TileGrid(sinking_bmp, pixel_shader=sinking_bmp.pixel_shader)
 
 clue_display.append(sinking_sprite)
 

--- a/Voice2Json_Edge_Detection/demo.py
+++ b/Voice2Json_Edge_Detection/demo.py
@@ -58,13 +58,9 @@ def load_image(path):
     "Load an image from the path"
     if len(splash):
         splash.pop()
-    # CircuitPython 6 & 7 compatible
-    bitmap = displayio.OnDiskBitmap(open(path, "rb"))
-    sprite = displayio.TileGrid(bitmap, pixel_shader=getattr(bitmap, 'pixel_shader', displayio.ColorConverter()))
 
-    # # CircuitPython 7+ compatible
-    # bitmap = displayio.OnDiskBitmap(path)
-    # sprite = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
+    bitmap = displayio.OnDiskBitmap(path)
+    sprite = displayio.TileGrid(bitmap, pixel_shader=bitmap.pixel_shader)
 
     splash.append(sprite)
 

--- a/Walkmp3rson/code.py
+++ b/Walkmp3rson/code.py
@@ -102,7 +102,7 @@ main_display_group = displayio.Group()  # everything goes in main group
 display.root_group = main_display_group  # show main group (clears screen, too)
 
 # background bitmap w OnDiskBitmap
-tape_bitmap = displayio.OnDiskBitmap(open("mp3_tape.bmp", "rb"))
+tape_bitmap = displayio.OnDiskBitmap("mp3_tape.bmp")
 tape_tilegrid = displayio.TileGrid(tape_bitmap, pixel_shader=tape_bitmap.pixel_shader)
 main_display_group.append(tape_tilegrid)
 

--- a/Weather_Display_Matrix/openweather_graphics.py
+++ b/Weather_Display_Matrix/openweather_graphics.py
@@ -47,15 +47,8 @@ class OpenWeather_Graphics(displayio.Group):
         self.display = display
 
         splash = displayio.Group()
-        # CircuitPython 6 & 7 compatible
-        background = displayio.OnDiskBitmap(open("loading.bmp", "rb"))
-        bg_sprite = displayio.TileGrid(
-            background,
-            pixel_shader=getattr(background, 'pixel_shader', displayio.ColorConverter()),
-        )
-        # # CircuitPython 7+ compatible
-        # background = displayio.OnDiskBitmap("loading.bmp")
-        # bg_sprite = displayio.TileGrid(background, pixel_shader=background.pixel_shader)
+        background = displayio.OnDiskBitmap("loading.bmp")
+        bg_sprite = displayio.TileGrid(background, pixel_shader=background.pixel_shader)
 
         splash.append(bg_sprite)
         display.root_group = splash
@@ -73,22 +66,13 @@ class OpenWeather_Graphics(displayio.Group):
         self._current_label = None
 
         # Load the icon sprite sheet
-        # CircuitPython 6 & 7 compatible
-        icons = displayio.OnDiskBitmap(open(icon_spritesheet, "rb"))
+        icons = displayio.OnDiskBitmap(icon_spritesheet)
         self._icon_sprite = displayio.TileGrid(
             icons,
-            pixel_shader=getattr(icons, 'pixel_shader', displayio.ColorConverter()),
+            pixel_shader=icons.pixel_shader,
             tile_width=icon_width,
             tile_height=icon_height
         )
-        # # CircuitPython 7+ compatible
-        # icons = displayio.OnDiskBitmap(icon_spritesheet)
-        # self._icon_sprite = displayio.TileGrid(
-        #     icons,
-        #     pixel_shader=icons.pixel_shader,
-        #     tile_width=icon_width,
-        #     tile_height=icon_height
-        # )
 
         self.set_icon(None)
         self._scrolling_texts = []


### PR DESCRIPTION
removes many CircuitPython 6.x fallback compatibility and updates everything to use the 7.x + API which has been supported for a while now. 

With 10.x we will remove the backward compatibility in the core.