### PR TITLE
change volume parameter

### DIFF
--- a/TLV320DAC3100_Examples/TLV320_CircuitPython_WAV/code.py
+++ b/TLV320DAC3100_Examples/TLV320_CircuitPython_WAV/code.py
@@ -15,7 +15,7 @@ dac.configure_clocks(sample_rate=44100, bit_depth=16)
 
 # use headphones
 dac.headphone_output = True
-dac.headphone_volume = -15  # dB
+dac.dac_volume = -15  # dB
 # or use speaker
 # dac.speaker_output = True
 # dac.speaker_volume = -10 # dB


### PR DESCRIPTION

Small change to fix volume control in guide.

The original `dac.headphone_volume` has [no effect on volume](https://github.com/adafruit/Adafruit_CircuitPython_TLV320/pull/6).

Tested on CircuitPython 9.2.8 using a Feather RP2040 Datalogger and TLV320DAC3100.

The example code in the library has been updated and even the tone example in this guide already includes the working volume parameter.

```
dac.dac_volume = -15
```

![IMG_3577](https://github.com/user-attachments/assets/dec39260-5c6e-4986-a8ba-123aa675c3a1)

