### PR TITLE
Change deprecated splash usage to root_group

### DIFF
--- a/FunHouse_Fume_Extractor/code.py
+++ b/FunHouse_Fume_Extractor/code.py
@@ -56,7 +56,7 @@ icon2 = displayio.TileGrid(bitmap5, pixel_shader=palette5, x = 2, y = 2)
 group = displayio.Group()
 #  adding start-up bitmap to group
 group.append(tile_grid)
-funhouse.splash.append(group)
+funhouse.graphics.root_group.append(group)
 #  text for fume data
 fume_text = funhouse.add_text(
     text="    ",
@@ -74,7 +74,7 @@ fan_text = funhouse.add_text(
     text_font="fonts/Arial-Bold-24.pcf",
 )
 #  showing graphics
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 #  state machines
 run = False #  state if main code is running

--- a/FunHouse_HA_Companion/code.py
+++ b/FunHouse_HA_Companion/code.py
@@ -65,10 +65,10 @@ pres_label = funhouse.add_text(
 )
 
 # Now display the splash to draw all labels at once
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 status = Circle(229, 10, 10, fill=0xFF0000, outline=0x880000)
-funhouse.splash.append(status)
+funhouse.graphics.root_group.append(status)
 
 def connected(client, _userdata, _result, _payload):
     status.fill = 0x00FF00

--- a/FunHouse_LIFX/code.py
+++ b/FunHouse_LIFX/code.py
@@ -77,7 +77,7 @@ time_label = funhouse.add_text(
     text=trip_time, text_scale=2, text_position=(30, 25), text_color=0x606060
 )
 
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 # Turn on the light
 print("Turning on light...")

--- a/FunHouse_Mailslot/code.py
+++ b/FunHouse_Mailslot/code.py
@@ -31,7 +31,7 @@ mail_label = funhouse.add_text(
 )
 reset_label = funhouse.add_text(text="reset", text_position=(3, 70), text_color=GRAY)
 
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 
 def send_io_data(mail_value):

--- a/FunHouse_Motion_Outlet/code.py
+++ b/FunHouse_Motion_Outlet/code.py
@@ -82,10 +82,10 @@ countdown_label = funhouse.add_text(
     text_color=0xFFFF00,
     text_font="fonts/Arial-Bold-24.pcf",
 )
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 status = Circle(229, 10, 10, fill=0xFF0000, outline=0x880000)
-funhouse.splash.append(status)
+funhouse.graphics.root_group.append(status)
 
 # Initialize a new MQTT Client object
 if USE_MQTT:

--- a/FunHouse_Pet_Bowl_Sensor/code.py
+++ b/FunHouse_Pet_Bowl_Sensor/code.py
@@ -77,10 +77,10 @@ level_label = funhouse.add_text(
     text_color=0xFFFF00,
     text_font="fonts/Arial-Bold-24.pcf",
 )
-funhouse.display.root_group = funhouse.splash
+funhouse.display.root_group = funhouse.graphics.root_group
 
 status = Circle(229, 10, 10, fill=0xFF0000, outline=0x880000)
-funhouse.splash.append(status)
+funhouse.graphics.root_group.append(status)
 
 # Initialize a new MQTT Client object
 funhouse.network.init_mqtt(

--- a/MagTag/MagTag_Covid_Vaccination/code.py
+++ b/MagTag/MagTag_Covid_Vaccination/code.py
@@ -65,8 +65,8 @@ progress_bar_1 = ProgressBar(
     BAR_X, 95, BAR_WIDTH, BAR_HEIGHT, 1.0, bar_color=0x999999, outline_color=0x000000
 )
 
-magtag.graphics.splash.append(progress_bar)
-magtag.graphics.splash.append(progress_bar_1)
+magtag.graphics.root_group.append(progress_bar)
+magtag.graphics.root_group.append(progress_bar_1)
 magtag.graphics.set_background("/bmps/background.bmp")
 
 

--- a/MagTag/MagTag_Flashcards/chapters/code.py
+++ b/MagTag/MagTag_Flashcards/chapters/code.py
@@ -40,7 +40,7 @@ for i in range(list_len):
 
 # Add button labels at the bottom of the screen
 BUTTON_TEXT_IDX = list_len
-magtag.graphics.splash.append(Rect(0, magtag.graphics.display.height - 14,
+magtag.graphics.root_group.append(Rect(0, magtag.graphics.display.height - 14,
                                    magtag.graphics.display.width,
                                    magtag.graphics.display.height, fill=0x0))
 magtag.add_text(

--- a/MagTag/MagTag_Google_Calendar/authenticator.py
+++ b/MagTag/MagTag_Google_Calendar/authenticator.py
@@ -32,7 +32,7 @@ graphics = Graphics(auto_refresh=False)
 display = graphics.display
 
 background = Rect(0, 0, 296, 128, fill=0xFFFFFF)
-graphics.splash.append(background)
+graphics.root_group.append(background)
 
 label_overview_text = Label(
     font_large,
@@ -42,18 +42,18 @@ label_overview_text = Label(
     color=0x000000,
     text="Authorize this device with Google:",
 )
-graphics.splash.append(label_overview_text)
+graphics.root_group.append(label_overview_text)
 
 label_verification_url = Label(font_small, x=0, y=40, line_spacing=0.75, color=0x000000)
-graphics.splash.append(label_verification_url)
+graphics.root_group.append(label_verification_url)
 
 label_user_code = Label(font_small, x=0, y=80, color=0x000000, line_spacing=0.75)
-graphics.splash.append(label_user_code)
+graphics.root_group.append(label_user_code)
 
 label_qr_code = Label(
     font_small, x=0, y=100, color=0x000000, text="Or scan the QR code:"
 )
-graphics.splash.append(label_qr_code)
+graphics.root_group.append(label_qr_code)
 
 # Set scope(s) of access required by the API you're using
 scopes = ["https://www.googleapis.com/auth/calendar.readonly"]
@@ -85,7 +85,7 @@ label_verification_url.text = (
 label_user_code.text = "2. Enter code: %s" % google_auth.user_code
 
 graphics.qrcode(google_auth.verification_url.encode(), qr_size=2, x=240, y=70)
-graphics.display.root_group = graphics.splash
+graphics.display.root_group = graphics.root_group
 display.refresh()
 
 # Poll Google's authorization server
@@ -98,9 +98,9 @@ print("Add the following lines to your settings.toml file:")
 print(f'google_access_token="{google_auth.access_token}"')
 print(f'google_refresh_token="{google_auth.refresh_token}"')
 
-graphics.splash.pop()
-graphics.splash.pop()
-graphics.splash.pop()
+graphics.root_group.pop()
+graphics.root_group.pop()
+graphics.root_group.pop()
 
 label_overview_text.text = "Successfully Authenticated!"
 label_verification_url.text = (

--- a/MagTag/MagTag_Google_Calendar/code.py
+++ b/MagTag/MagTag_Google_Calendar/code.py
@@ -205,7 +205,7 @@ magtag.set_background(0xFFFFFF)
 
 # Add the header
 line_header = Line(0, 30, 320, 30, color=0x000000)
-magtag.splash.append(line_header)
+magtag.graphics.root_group.append(line_header)
 
 label_header = magtag.add_text(
     text_font="fonts/Arial-18.pcf",

--- a/MagTag/MagTag_Google_Sheets/naughty_nice/code.py
+++ b/MagTag/MagTag_Google_Sheets/naughty_nice/code.py
@@ -60,7 +60,7 @@ MAGTAG.add_text(
 
 # Add 14-pixel-tall black bar at bottom of display. It's a distinct layer
 # (not just background) to appear on top of name list if it runs long.
-MAGTAG.graphics.splash.append(Rect(0, MAGTAG.graphics.display.height - 14,
+MAGTAG.graphics.root_group.append(Rect(0, MAGTAG.graphics.display.height - 14,
                                    MAGTAG.graphics.display.width,
                                    MAGTAG.graphics.display.height, fill=0x0))
 

--- a/MagTag/MagTag_Google_Sheets/weekly_planner/code.py
+++ b/MagTag/MagTag_Google_Sheets/weekly_planner/code.py
@@ -69,7 +69,7 @@ MAGTAG.add_text(
 
 # Add 14-pixel-tall black bar at bottom of display. It's a distinct layer
 # (not just background) to appear on top of task list if it runs long.
-MAGTAG.graphics.splash.append(Rect(0, MAGTAG.graphics.display.height - 14,
+MAGTAG.graphics.root_group.append(Rect(0, MAGTAG.graphics.display.height - 14,
                                    MAGTAG.graphics.display.width,
                                    MAGTAG.graphics.display.height, fill=0x0))
 

--- a/MagTag/MagTag_Progress_Displays/weblate_translated_percent/code.py
+++ b/MagTag/MagTag_Progress_Displays/weblate_translated_percent/code.py
@@ -75,7 +75,7 @@ progress_bar = ProgressBar(
     BAR_X, BAR_Y, BAR_WIDTH, BAR_HEIGHT, 1.0, bar_color=0x999999, outline_color=0x000000
 )
 
-magtag.graphics.splash.append(progress_bar)
+magtag.graphics.root_group.append(progress_bar)
 
 timestamp = None
 

--- a/MagTag/MagTag_Progress_Displays/year_progress_percent/code.py
+++ b/MagTag/MagTag_Progress_Displays/year_progress_percent/code.py
@@ -53,7 +53,7 @@ progress_bar = ProgressBar(
     BAR_X, BAR_Y, BAR_WIDTH, BAR_HEIGHT, 1.0, bar_color=0x999999, outline_color=0x000000
 )
 
-magtag.graphics.splash.append(progress_bar)
+magtag.graphics.root_group.append(progress_bar)
 
 
 try:

--- a/MagTag/MagTag_Seasonal_Produce/code.py
+++ b/MagTag/MagTag_Seasonal_Produce/code.py
@@ -78,7 +78,7 @@ MAGTAG.add_text(
 
 # Add 14-pixel-tall black bar at bottom of display. It's a distinct layer
 # (not just background) to appear on top of produce list if it runs long.
-MAGTAG.graphics.splash.append(Rect(0, MAGTAG.graphics.display.height - 14,
+MAGTAG.graphics.root_group.append(Rect(0, MAGTAG.graphics.display.height - 14,
                                    MAGTAG.graphics.display.width,
                                    MAGTAG.graphics.display.height, fill=0x0))
 

--- a/MagTag/MagTag_Tides/code.py
+++ b/MagTag/MagTag_Tides/code.py
@@ -130,12 +130,12 @@ station_info.anchored_position = (158, 126)
 # ----------------------------
 # Add all the graphic layers
 # ----------------------------
-magtag.splash.append(tide_tg)
-magtag.splash.append(grid_overlay)
-magtag.splash.append(plot_y_labels)
-magtag.splash.append(tide_info)
-magtag.splash.append(date_label)
-magtag.splash.append(station_info)
+magtag.graphics.root_group.append(tide_tg)
+magtag.graphics.root_group.append(grid_overlay)
+magtag.graphics.root_group.append(plot_y_labels)
+magtag.graphics.root_group.append(tide_info)
+magtag.graphics.root_group.append(date_label)
+magtag.graphics.root_group.append(station_info)
 
 # /////////////////////////////////////////////////////////////////////////
 

--- a/MagTag/MagTag_Weather/forecast/code.py
+++ b/MagTag/MagTag_Weather/forecast/code.py
@@ -344,9 +344,9 @@ future_banners = [
     make_banner(x=210, y=81),
 ]
 
-magtag.splash.append(today_banner)
+magtag.graphics.root_group.append(today_banner)
 for future_banner in future_banners:
-    magtag.splash.append(future_banner)
+    magtag.graphics.root_group.append(future_banner)
 
 # ===========
 #  M A I N

--- a/MagTag/MagTag_Weather/onecall/code.py
+++ b/MagTag/MagTag_Weather/onecall/code.py
@@ -283,9 +283,9 @@ future_banners = [
     make_banner(x=210, y=102),
 ]
 
-magtag.splash.append(today_banner)
+magtag.graphics.root_group.append(today_banner)
 for future_banner in future_banners:
-    magtag.splash.append(future_banner)
+    magtag.graphics.root_group.append(future_banner)
 
 # ===========
 #  M A I N

--- a/MagTag/MagTag_Weather/openmeteo/code.py
+++ b/MagTag/MagTag_Weather/openmeteo/code.py
@@ -280,9 +280,9 @@ future_banners = [
     make_banner(x=210, y=102),
 ]
 
-magtag.splash.append(today_banner)
+magtag.graphics.root_group.append(today_banner)
 for future_banner in future_banners:
-    magtag.splash.append(future_banner)
+    magtag.graphics.root_group.append(future_banner)
 
 # ===========
 #  M A I N

--- a/PyPortal/PyPortal_Alarm_Clock/code.py
+++ b/PyPortal/PyPortal_Alarm_Clock/code.py
@@ -136,8 +136,8 @@ def create_text_areas(configs):
 
 
 def clear_splash():
-    for _ in range(len(pyportal.splash) - 1):
-        pyportal.splash.pop()
+    for _ in range(len(pyportal.root_group) - 1):
+        pyportal.root_group.pop()
 
 
 def touch_in_button(t, b):
@@ -337,8 +337,8 @@ class Time_State(State):
     def enter(self):
         self.adjust_backlight_based_on_light(force=True)
         for ta in self.text_areas:
-            pyportal.splash.append(ta)
-        pyportal.splash.append(self.weather_icon)
+            pyportal.root_group.append(ta)
+        pyportal.root_group.append(self.weather_icon)
         if snooze_time:
             # CircuitPython 6 & 7 compatible
             if self.snooze_file:
@@ -348,7 +348,7 @@ class Time_State(State):
             icon_sprite = displayio.TileGrid(icon, pixel_shader=icon.pixel_shader)
 
             self.snooze_icon.append(icon_sprite)
-            pyportal.splash.append(self.snooze_icon)
+            pyportal.root_group.append(self.snooze_icon)
         if alarm_enabled:
             self.text_areas[1].text = '%2d:%02d' % (alarm_hour, alarm_minute)
         else:
@@ -532,7 +532,7 @@ class Setting_State(State):
 
         pyportal.set_background(self.background)
         for ta in self.text_areas:
-            pyportal.splash.append(ta)
+            pyportal.root_group.append(ta)
         if alarm_enabled:
             self.text_areas[0].text = '%02d:%02d' % (alarm_hour, alarm_minute) # set time textarea
         else:

--- a/PyPortal/PyPortal_Astronauts/code.py
+++ b/PyPortal/PyPortal_Astronauts/code.py
@@ -54,6 +54,6 @@ while True:
             names_textarea.x = names_position[0]
             names_textarea.y = names_position[1]
             names_textarea.color = names_color
-            pyportal.splash.append(names_textarea)
+            pyportal.root_group.append(names_textarea)
             time.sleep(30)  # wait 30 seconds to read it
-            pyportal.splash.pop()
+            pyportal.root_group.pop()

--- a/PyPortal/PyPortal_CMA_Art_Frame/code.py
+++ b/PyPortal/PyPortal_CMA_Art_Frame/code.py
@@ -53,7 +53,7 @@ pyportal = PyPortal(default_bg=BACKGROUND_FILE,
                     text_color=0xFFFFFF)
 
 circle = Circle(WIDTH - 8, HEIGHT - 7, 5, fill=0)
-pyportal.splash.append(circle)
+pyportal.root_group.append(circle)
 loopcount = 0
 errorcount = 0
 while True:

--- a/PyPortal/PyPortal_CircuitPython_2020/code.py
+++ b/PyPortal/PyPortal_CircuitPython_2020/code.py
@@ -47,7 +47,7 @@ for pos in (days_position, hours_position, minutes_position):
     textarea.x = pos[0]
     textarea.y = pos[1]
     textarea.color = text_color
-    pyportal.splash.append(textarea)
+    pyportal.root_group.append(textarea)
     text_areas.append(textarea)
 refresh_time = None
 

--- a/PyPortal/PyPortal_Electioncal_US/code.py
+++ b/PyPortal/PyPortal_Electioncal_US/code.py
@@ -38,7 +38,7 @@ pyportal = PyPortal(url=DATA_SOURCE,
                     default_bg=0x000000)
 
 
-gfx = electioncal_graphics.Electioncal_Graphics(pyportal.splash, am_pm=True)
+gfx = electioncal_graphics.Electioncal_Graphics(pyportal.root_group, am_pm=True)
 display_refresh = None
 while True:
     # only query the online time once per hour (and on first run)

--- a/PyPortal/PyPortal_EventCountdown/code.py
+++ b/PyPortal/PyPortal_EventCountdown/code.py
@@ -47,7 +47,7 @@ for pos in (days_position, hours_position, minutes_position):
     textarea.x = pos[0]
     textarea.y = pos[1]
     textarea.color = text_color
-    pyportal.splash.append(textarea)
+    pyportal.root_group.append(textarea)
     text_areas.append(textarea)
 refresh_time = None
 

--- a/PyPortal/PyPortal_EventCountup/code.py
+++ b/PyPortal/PyPortal_EventCountup/code.py
@@ -47,7 +47,7 @@ for pos in (years_position, days_position, hours_position, minutes_position):
     textarea.x = pos[0]
     textarea.y = pos[1]
     textarea.color = text_color
-    pyportal.splash.append(textarea)
+    pyportal.root_group.append(textarea)
     text_areas.append(textarea)
 refresh_time = None
 

--- a/PyPortal/PyPortal_Google_Calendar/authenticator/code.py
+++ b/PyPortal/PyPortal_Google_Calendar/authenticator/code.py
@@ -26,16 +26,16 @@ font_large.load_glyphs(glyphs)
 label_overview_text = Label(
     font_large, x=0, y=45, text="To authorize this device with Google:"
 )
-graphics.splash.append(label_overview_text)
+graphics.root_group.append(label_overview_text)
 
 label_verification_url = Label(font_small, x=0, y=100, line_spacing=1)
-graphics.splash.append(label_verification_url)
+graphics.root_group.append(label_verification_url)
 
 label_user_code = Label(font_small, x=0, y=150)
-graphics.splash.append(label_user_code)
+graphics.root_group.append(label_user_code)
 
 label_qr_code = Label(font_small, x=0, y=190, text="Or scan the QR code:")
-graphics.splash.append(label_qr_code)
+graphics.root_group.append(label_qr_code)
 
 # Set scope(s) of access required by the API you're using
 scopes = ["https://www.googleapis.com/auth/calendar.readonly"]
@@ -71,7 +71,7 @@ label_user_code.text = "2. Enter code: %s" % google_auth.user_code
 
 # Create a QR code
 graphics.qrcode(google_auth.verification_url.encode(), qr_size=2, x=170, y=165)
-graphics.display.root_group = graphics.splash
+graphics.display.root_group = graphics.root_group
 
 # Poll Google's authorization server
 print("Waiting for browser authorization...")
@@ -85,9 +85,9 @@ print("Add the following lines to your settings.toml file:")
 print(f'GOOGLE_ACCESS_TOKEN = "{google_auth.access_token}"')
 print(f'GOOGLE_REFRESH_TOKEN = "{google_auth.refresh_token}"')
 # Remove QR code and code/verification labels
-graphics.splash.pop()
-graphics.splash.pop()
-graphics.splash.pop()
+graphics.root_group.pop()
+graphics.root_group.pop()
+graphics.root_group.pop()
 
 label_overview_text.text = "Successfully Authenticated!"
 label_verification_url.text = (

--- a/PyPortal/PyPortal_Google_Calendar/code.py
+++ b/PyPortal/PyPortal_Google_Calendar/code.py
@@ -202,7 +202,7 @@ font_events = "fonts/Arial-14.pcf"
 
 # Add the header
 line_header = Line(0, 50, 320, 50, color=0x000000)
-pyportal.splash.append(line_header)
+pyportal.root_group.append(line_header)
 
 label_header = pyportal.add_text(
     text_font="fonts/Arial-18.pcf",

--- a/PyPortal/PyPortal_Guitar_Tuner/code.py
+++ b/PyPortal/PyPortal_Guitar_Tuner/code.py
@@ -33,7 +33,7 @@ for peg in pegs:
                     style=Button.RECT,
                     fill_color=None, outline_color=0x5C3C15,
                     name=peg['label'])
-    pyportal.splash.append(button.group)
+    pyportal.root_group.append(button.group)
     buttons.append(button)
 
 note_select = None

--- a/PyPortal/PyPortal_Halloween_Countdown/code.py
+++ b/PyPortal/PyPortal_Halloween_Countdown/code.py
@@ -86,7 +86,7 @@ countdown_text = Label(big_font)
 countdown_text.x = 25
 countdown_text.y = 120
 countdown_text.color = 0x7942a0
-pyportal.splash.append(countdown_text)
+pyportal.root_group.append(countdown_text)
 
 refresh_time = None
 

--- a/PyPortal/PyPortal_Hurricane_Tracker/code.py
+++ b/PyPortal/PyPortal_Hurricane_Tracker/code.py
@@ -41,7 +41,7 @@ for i, c in enumerate(icons_pal):
     if c == 0xFFFF00:
         icons_pal.make_transparent(i)
 storm_icons = displayio.Group()
-pyportal.splash.append(storm_icons)
+pyportal.root_group.append(storm_icons)
 STORM_CLASS = ("TD", "TS", "HU")
 
 # setup info label
@@ -53,7 +53,7 @@ info_update = Label(
 )
 info_update.anchor_point = (0.0, 1.0)
 info_update.anchored_position = (10, board.DISPLAY.height - 10)
-pyportal.splash.append(info_update)
+pyportal.root_group.append(info_update)
 
 # these are need for lat/lon to screen x/y mapping
 VIRTUAL_WIDTH = board.DISPLAY.width * 360 / (LON_RANGE[1] - LON_RANGE[0])

--- a/PyPortal/PyPortal_ISS_Tracker/code.py
+++ b/PyPortal/PyPortal_ISS_Tracker/code.py
@@ -43,21 +43,21 @@ pyportal.get_local_time()
 # Date and time label
 date_label = Label(FONT, text="0000-00-00", color=DATE_COLOR, x=165, y=223)
 time_label = Label(FONT, text="00:00:00", color=TIME_COLOR, x=240, y=223)
-pyportal.splash.append(date_label)
-pyportal.splash.append(time_label)
+pyportal.root_group.append(date_label)
+pyportal.root_group.append(time_label)
 
 # ISS trail
 trail_bitmap = displayio.Bitmap(3, 3, 1)
 trail_palette = displayio.Palette(1)
 trail_palette[0] = TRAIL_COLOR
 trail = displayio.Group()
-pyportal.splash.append(trail)
+pyportal.root_group.append(trail)
 
 # ISS location marker
 marker = displayio.Group()
 for r in range(MARK_SIZE - MARK_THICKNESS, MARK_SIZE):
     marker.append(Circle(0, 0, r, outline=MARK_COLOR))
-pyportal.splash.append(marker)
+pyportal.root_group.append(marker)
 
 def get_location(width=WIDTH, height=HEIGHT):
     """Fetch current lat/lon, convert to (x, y) tuple scaled to width/height."""

--- a/PyPortal/PyPortal_Mirror_Display/code.py
+++ b/PyPortal/PyPortal_Mirror_Display/code.py
@@ -47,7 +47,7 @@ display = board.DISPLAY
 display.rotation = 270
 
 #  instantiate the openweather_graphics class
-gfx = openweather_graphics.OpenWeather_Graphics(pyportal.splash, am_pm=True, celsius=False)
+gfx = openweather_graphics.OpenWeather_Graphics(pyportal.root_group, am_pm=True, celsius=False)
 
 #  time keeping for refreshing screen icons and weather information
 localtile_refresh = None

--- a/PyPortal/PyPortal_MogwaiClock/code.py
+++ b/PyPortal/PyPortal_MogwaiClock/code.py
@@ -45,7 +45,7 @@ time_textarea = Label(big_font)
 time_textarea.x = 0
 time_textarea.y = 130
 time_textarea.color = 0xFF0000
-pyportal.splash.append(time_textarea)
+pyportal.root_group.append(time_textarea)
 
 # To help us know if we've changed the times, print them out!
 gremlin_hour, gremlin_min = gremlin_time[3:5]

--- a/PyPortal/PyPortal_NeoPixel_Color_Picker/code.py
+++ b/PyPortal/PyPortal_NeoPixel_Color_Picker/code.py
@@ -63,7 +63,7 @@ for spot in spots:
                     style=Button.SHADOWROUNDRECT,
                     fill_color=spot['color'], outline_color=0x222222,
                     name=spot['label'])
-    pyportal.splash.append(button)
+    pyportal.root_group.append(button)
     buttons.append(button)
 
 mode = 0

--- a/PyPortal/PyPortal_OpenWeather/code.py
+++ b/PyPortal/PyPortal_OpenWeather/code.py
@@ -47,7 +47,7 @@ pyportal = PyPortal(url=DATA_SOURCE,
                     status_neopixel=board.NEOPIXEL,
                     default_bg=0x000000)
 
-gfx = openweather_graphics.OpenWeather_Graphics(pyportal.splash, am_pm=True, celsius=False)
+gfx = openweather_graphics.OpenWeather_Graphics(pyportal.root_group, am_pm=True, celsius=False)
 
 localtile_refresh = None
 weather_refresh = None

--- a/PyPortal/PyPortal_Quarantine_Clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/code.py
@@ -68,13 +68,13 @@ font_small.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123
 label_day = label.Label(font_large, color=LABEL_DAY_COLOR)
 label_day.x = board.DISPLAY.width // 7
 label_day.y = 80
-pyportal.splash.append(label_day)
+pyportal.root_group.append(label_day)
 
 # Set up label for the time
 label_time = label.Label(font_small, color=LABEL_TIME_COLOR)
 label_time.x = board.DISPLAY.width // 4
 label_time.y = 150
-pyportal.splash.append(label_time)
+pyportal.root_group.append(label_time)
 
 refresh_time = None
 while True:

--- a/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
+++ b/PyPortal/PyPortal_Quarantine_Clock/month_clock/code.py
@@ -109,13 +109,13 @@ font_small.load_glyphs(b'abcdefghjiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123
 label_month = label.Label(font_large, color=LABEL_DAY_COLOR)
 label_month.x = board.DISPLAY.width // 10
 label_month.y = 80
-pyportal.splash.append(label_month)
+pyportal.root_group.append(label_month)
 
 # Set up label for the time
 label_time = label.Label(font_small, color=LABEL_TIME_COLOR)
 label_time.x = board.DISPLAY.width // 3
 label_time.y = 150
-pyportal.splash.append(label_time)
+pyportal.root_group.append(label_time)
 
 refresh_time = None
 while True:

--- a/PyPortal/PyPortal_Smart_Switch/code.py
+++ b/PyPortal/PyPortal_Smart_Switch/code.py
@@ -104,11 +104,11 @@ class Switch(object):
         self.switch.direction = digitalio.Direction.OUTPUT
         rect = RoundRect(SWITCHX, SWITCHY, 31, 60, 16, outline=SWITCH_COLOR,
                          fill=SWITCH_FILL_COLOR, stroke=3)
-        my_pyportal.splash.append(rect)
+        my_pyportal.root_group.append(rect)
         self.circle_on = Circle(SWITCHX + 15, SWITCHY + 16, 10, fill=SWITCH_FILL_COLOR)
-        my_pyportal.splash.append(self.circle_on)
+        my_pyportal.root_group.append(self.circle_on)
         self.circle_off = Circle(SWITCHX + 15, SWITCHY + 42, 10, fill=DISPLAY_COLOR)
-        my_pyportal.splash.append(self.circle_off)
+        my_pyportal.root_group.append(self.circle_off)
 
     # turn switch on or off
     def enable(self, enable):
@@ -149,7 +149,7 @@ class Clock(object):
         self.text_areas = create_text_areas(text_area_configs)
         self.text_areas[2].text = "starting..."
         for ta in self.text_areas:
-            self.pyportal.splash.append(ta)
+            self.pyportal.root_group.append(ta)
 
     def adjust_backlight(self, force=False):
         """Check light level. Adjust the backlight and background image if it's dark."""

--- a/PyPortal/PyPortal_Tides/admiralty_tides/code.py
+++ b/PyPortal/PyPortal_Tides/admiralty_tides/code.py
@@ -61,7 +61,7 @@ DATE_LABEL = Label(date_font, text="0000-00-00 00:00:00", color=DATE_COLOR, x=75
 
 # Add all the labels to the display
 for label in HI_LABELS + LO_LABELS + [DATE_LABEL]:
-    pyportal.splash.append(label)
+    pyportal.root_group.append(label)
 
 def get_tide_info():
     """Fetch JSON tide time info and return it."""

--- a/PyPortal/PyPortal_Tides/admiralty_tides_graphical/code.py
+++ b/PyPortal/PyPortal_Tides/admiralty_tides_graphical/code.py
@@ -67,7 +67,7 @@ palette.make_transparent(0)
 
 # Setup tide plot bitmap
 tide_plot = displayio.Bitmap(WIDTH, HEIGHT, 3)
-pyportal.splash.append(displayio.TileGrid(tide_plot, pixel_shader=palette))
+pyportal.root_group.append(displayio.TileGrid(tide_plot, pixel_shader=palette))
 
 # Setup font used for date and time
 date_font = bitmap_font.load_font(cwd+"/fonts/mono-bold-8.bdf")
@@ -75,7 +75,7 @@ date_font.load_glyphs(b'1234567890-')
 
 # Setup date label
 date_label = Label(date_font, text="0000-00-00", color=DATE_COLOR, x=7, y=14)
-pyportal.splash.append(date_label)
+pyportal.root_group.append(date_label)
 
 if board.board_id == "pyportal_titano":
     x_pos = 394
@@ -84,14 +84,14 @@ else:
 
 # Setup time label
 time_label = Label(date_font, text="00:00:00", color=TIME_COLOR, x=x_pos, y=14)
-pyportal.splash.append(time_label)
+pyportal.root_group.append(time_label)
 
 # Setup current time marker
 time_marker_bitmap = displayio.Bitmap(MARK_SIZE, MARK_SIZE, 3)
 for pixel in range(MARK_SIZE * MARK_SIZE):
     time_marker_bitmap[pixel] = 2
 time_marker = displayio.TileGrid(time_marker_bitmap, pixel_shader=palette, x=-MARK_SIZE, y=-MARK_SIZE)
-pyportal.splash.append(time_marker)
+pyportal.root_group.append(time_marker)
 
 def get_tide_data():
     """Fetch JSON tide data and return parsed results in a list."""

--- a/PyPortal/PyPortal_Tides/pp_tides/code.py
+++ b/PyPortal/PyPortal_Tides/pp_tides/code.py
@@ -51,7 +51,7 @@ DATE_LABEL = Label(date_font, text="0000-00-00 00:00:00", color=DATE_COLOR, x=75
 
 # Add all the labels to the display
 for label in HI_LABELS + LO_LABELS + [DATE_LABEL]:
-    pyportal.graphics.splash.append(label)
+    pyportal.graphics.root_group.append(label)
 
 
 def get_tide_info():

--- a/PyPortal/PyPortal_Tides/pp_tides_graphical/code.py
+++ b/PyPortal/PyPortal_Tides/pp_tides_graphical/code.py
@@ -47,7 +47,7 @@ palette.make_transparent(0)
 
 # Setup tide plot bitmap
 tide_plot = displayio.Bitmap(WIDTH, HEIGHT, 3)
-pyportal.graphics.splash.append(displayio.TileGrid(tide_plot, pixel_shader=palette))
+pyportal.graphics.root_group.append(displayio.TileGrid(tide_plot, pixel_shader=palette))
 
 # Setup font used for date and time
 date_font = bitmap_font.load_font("/fonts/mono-bold-8.bdf")
@@ -55,11 +55,11 @@ date_font.load_glyphs(b"1234567890-")
 
 # Setup date label
 date_label = Label(date_font, text="0000-00-00", color=DATE_COLOR, x=7, y=14)
-pyportal.graphics.splash.append(date_label)
+pyportal.graphics.root_group.append(date_label)
 
 # Setup time label
 time_label = Label(date_font, text="00:00:00", color=TIME_COLOR, x=234, y=14)
-pyportal.graphics.splash.append(time_label)
+pyportal.graphics.root_group.append(time_label)
 
 # Setup current time marker
 time_marker_bitmap = displayio.Bitmap(MARK_SIZE, MARK_SIZE, 3)
@@ -67,7 +67,7 @@ time_marker_bitmap.fill(2)
 time_marker = displayio.TileGrid(
     time_marker_bitmap, pixel_shader=palette, x=-MARK_SIZE, y=-MARK_SIZE
 )
-pyportal.graphics.splash.append(time_marker)
+pyportal.graphics.root_group.append(time_marker)
 
 
 def get_tide_data():

--- a/PyPortal/PyPortal_Titano_Weather_Station/code.py
+++ b/PyPortal/PyPortal_Titano_Weather_Station/code.py
@@ -133,7 +133,7 @@ alarm_checks = [None, alarms['bed'],alarms['breakfast'],alarms['lunch'],alarms['
 alarm_gfx = [group_trash, group_bed, group_eat, group_eat, group_eat]
 
 #  allows for the openweather_graphics to show
-gfx = openweather_graphics.OpenWeather_Graphics(pyportal.splash, am_pm=True, celsius=False)
+gfx = openweather_graphics.OpenWeather_Graphics(pyportal.root_group, am_pm=True, celsius=False)
 
 #  state machines
 localtile_refresh = None
@@ -250,13 +250,13 @@ while True:
         print("pressed dismiss button")
         dismissed = True
         alarm = False
-        display.root_group = pyportal.splash
+        display.root_group = pyportal.root_group
         touched = time.monotonic()
         mode = mode
     if not switch_snooze.value and not phys_snooze:
         phys_snooze = True
         print("pressed snooze button")
-        display.root_group = pyportal.splash
+        display.root_group = pyportal.root_group
         snoozed = True
         alarm = False
         touched = time.monotonic()
@@ -271,7 +271,7 @@ while True:
     if touch:
         if snooze_buttons[button_mode].contains(touch) and not touch_button_snooze:
             print("Touched snooze")
-            display.root_group = pyportal.splash
+            display.root_group = pyportal.root_group
             touch_button_snooze = True
             snoozed = True
             alarm = False
@@ -281,7 +281,7 @@ while True:
             print("Touched dismiss")
             dismissed = True
             alarm = False
-            display.root_group = pyportal.splash
+            display.root_group = pyportal.root_group
             touch_button_dismiss = True
             touched = time.monotonic()
             mode = mode

--- a/PyPortal/PyPortal_Trivia_Time/code.py
+++ b/PyPortal/PyPortal_Trivia_Time/code.py
@@ -121,12 +121,12 @@ pyportal = PyPortal(url=DATA_SOURCE,
 
 pyportal.preload_font() # speed things up by preloading font
 
-pyportal.splash.append(loading_text_area) #loading...
-pyportal.splash.append(q_text_area)
-pyportal.splash.append(reveal_text_area)
-pyportal.splash.append(timer_text_area)
+pyportal.root_group.append(loading_text_area) #loading...
+pyportal.root_group.append(q_text_area)
+pyportal.root_group.append(reveal_text_area)
+pyportal.root_group.append(timer_text_area)
 for textarea in ans_text_areas:
-    pyportal.splash.append(textarea)
+    pyportal.root_group.append(textarea)
 
 while True:
     # Load new question when screen is touched

--- a/PyPortal/PyPortal_UV_Index/code.py
+++ b/PyPortal/PyPortal_UV_Index/code.py
@@ -80,7 +80,7 @@ pyportal = PyPortal(url=url,
                     caption_font=CAPTION_FONT_FILE)
 
 canvas = displayio.Group()
-pyportal.splash.append(canvas)
+pyportal.root_group.append(canvas)
 bar_font = bitmap_font.load_font(BAR_FONT_FILE)
 
 while True:

--- a/PyPortal/PyPortal_Wakeup_Light/code.py
+++ b/PyPortal/PyPortal_Wakeup_Light/code.py
@@ -84,9 +84,9 @@ light_on_time_position = (15,220)
 light_on_time_textarea = Label(info_font, color=light_on_time_color,
                                x=light_on_time_position[0], y=light_on_time_position[1])
 
-pyportal.splash.append(time_textarea)
-pyportal.splash.append(wakeup_time_textarea)
-pyportal.splash.append(light_on_time_textarea)
+pyportal.root_group.append(time_textarea)
+pyportal.root_group.append(wakeup_time_textarea)
+pyportal.root_group.append(light_on_time_textarea)
 
 while True:
     try:

--- a/PyPortal/PyPortal_WeeklyCountdown/code.py
+++ b/PyPortal/PyPortal_WeeklyCountdown/code.py
@@ -48,7 +48,7 @@ for pos in (days_position, hours_position, minutes_position):
     textarea.x = pos[0]
     textarea.y = pos[1]
     textarea.color = text_color
-    pyportal.splash.append(textarea)
+    pyportal.root_group.append(textarea)
     text_areas.append(textarea)
 refresh_time = None
 


### PR DESCRIPTION
This updates all portalbase derived projects to used `root_group` instead of `splash`, which is deprecated in the portalbase library and prints a warning message when used.

I tested a few of the Magtag ones successfully on original magtag hardware. I also tested one pyportal and one funhouse project with these changes. 

Once this is merged I will go through guide pages and check for references to the changed code in non-embedded blocks that will need updating. 