### PR TITLE
Generalizations on Metro_RP2350_Chips_Challenge  for Fruit Jam

### DIFF
--- a/Fruit_Jam/Larsio_Paint_Music/sound_manager.py
+++ b/Fruit_Jam/Larsio_Paint_Music/sound_manager.py
@@ -141,37 +141,37 @@ class SoundManager:
         try:
             # Channel 1 samples
             self.samples = {
-                59: audiocore.WaveFile("/samples/larso_B3.wav"),  # B3
-                60: audiocore.WaveFile("/samples/larso_C4.wav"),  # C4
-                62: audiocore.WaveFile("/samples/larso_D4.wav"),  # D4
-                64: audiocore.WaveFile("/samples/larso_E4.wav"),  # E4
-                65: audiocore.WaveFile("/samples/larso_F4.wav"),  # F4
-                67: audiocore.WaveFile("/samples/larso_G4.wav"),  # G4
-                69: audiocore.WaveFile("/samples/larso_A4.wav"),  # A4
-                71: audiocore.WaveFile("/samples/larso_B4.wav"),  # B4
-                72: audiocore.WaveFile("/samples/larso_C5.wav"),  # C5
-                74: audiocore.WaveFile("/samples/larso_D5.wav"),  # D5
-                76: audiocore.WaveFile("/samples/larso_E5.wav"),  # E5
-                77: audiocore.WaveFile("/samples/larso_F5.wav"),  # F5
-                79: audiocore.WaveFile("/samples/larso_G5.wav"),  # G5
+                59: audiocore.WaveFile("samples/larso_B3.wav"),  # B3
+                60: audiocore.WaveFile("samples/larso_C4.wav"),  # C4
+                62: audiocore.WaveFile("samples/larso_D4.wav"),  # D4
+                64: audiocore.WaveFile("samples/larso_E4.wav"),  # E4
+                65: audiocore.WaveFile("samples/larso_F4.wav"),  # F4
+                67: audiocore.WaveFile("samples/larso_G4.wav"),  # G4
+                69: audiocore.WaveFile("samples/larso_A4.wav"),  # A4
+                71: audiocore.WaveFile("samples/larso_B4.wav"),  # B4
+                72: audiocore.WaveFile("samples/larso_C5.wav"),  # C5
+                74: audiocore.WaveFile("samples/larso_D5.wav"),  # D5
+                76: audiocore.WaveFile("samples/larso_E5.wav"),  # E5
+                77: audiocore.WaveFile("samples/larso_F5.wav"),  # F5
+                79: audiocore.WaveFile("samples/larso_G5.wav"),  # G5
             }
             print("Loaded channel 1 WAV samples")
 
             # Load samples for channel 2
             self.heart_samples = {
-                59: audiocore.WaveFile("/samples/musicnote16_B3.wav"),  # B3
-                60: audiocore.WaveFile("/samples/musicnote16_C4.wav"),  # C4
-                62: audiocore.WaveFile("/samples/musicnote16_D4.wav"),  # D4
-                64: audiocore.WaveFile("/samples/musicnote16_E4.wav"),  # E4
-                65: audiocore.WaveFile("/samples/musicnote16_F4.wav"),  # F4
-                67: audiocore.WaveFile("/samples/musicnote16_G4.wav"),  # G4
-                69: audiocore.WaveFile("/samples/musicnote16_A4.wav"),  # A4
-                71: audiocore.WaveFile("/samples/musicnote16_B4.wav"),  # B4
-                72: audiocore.WaveFile("/samples/musicnote16_C5.wav"),  # C5
-                74: audiocore.WaveFile("/samples/musicnote16_D5.wav"),  # D5
-                76: audiocore.WaveFile("/samples/musicnote16_E5.wav"),  # E5
-                77: audiocore.WaveFile("/samples/musicnote16_F5.wav"),  # F5
-                79: audiocore.WaveFile("/samples/musicnote16_G5.wav"),  # G5
+                59: audiocore.WaveFile("samples/musicnote16_B3.wav"),  # B3
+                60: audiocore.WaveFile("samples/musicnote16_C4.wav"),  # C4
+                62: audiocore.WaveFile("samples/musicnote16_D4.wav"),  # D4
+                64: audiocore.WaveFile("samples/musicnote16_E4.wav"),  # E4
+                65: audiocore.WaveFile("samples/musicnote16_F4.wav"),  # F4
+                67: audiocore.WaveFile("samples/musicnote16_G4.wav"),  # G4
+                69: audiocore.WaveFile("samples/musicnote16_A4.wav"),  # A4
+                71: audiocore.WaveFile("samples/musicnote16_B4.wav"),  # B4
+                72: audiocore.WaveFile("samples/musicnote16_C5.wav"),  # C5
+                74: audiocore.WaveFile("samples/musicnote16_D5.wav"),  # D5
+                76: audiocore.WaveFile("samples/musicnote16_E5.wav"),  # E5
+                77: audiocore.WaveFile("samples/musicnote16_F5.wav"),  # F5
+                79: audiocore.WaveFile("samples/musicnote16_G5.wav"),  # G5
             }
             print("Loaded channel 2 WAV samples")
 
@@ -179,19 +179,19 @@ class SoundManager:
             self.drum_samples = {}
             try:
                 self.drum_samples = {
-                    59: audiocore.WaveFile("/samples/kick_01.wav"),
-                    60: audiocore.WaveFile("/samples/kick_01.wav"),
-                    62: audiocore.WaveFile("/samples/kick_01.wav"),
-                    64: audiocore.WaveFile("/samples/snare_01.wav"),
-                    65: audiocore.WaveFile("/samples/snare_01.wav"),
-                    67: audiocore.WaveFile("/samples/snare_01.wav"),
-                    69: audiocore.WaveFile("/samples/chat_01.wav"),
-                    71: audiocore.WaveFile("/samples/chat_01.wav"),
-                    72: audiocore.WaveFile("/samples/chat_01.wav"),
-                    74: audiocore.WaveFile("/samples/ohat_01.wav"),
-                    76: audiocore.WaveFile("/samples/ohat_01.wav"),
-                    77: audiocore.WaveFile("/samples/crash_01.wav"),
-                    79: audiocore.WaveFile("/samples/crash_01.wav"),
+                    59: audiocore.WaveFile("samples/kick_01.wav"),
+                    60: audiocore.WaveFile("samples/kick_01.wav"),
+                    62: audiocore.WaveFile("samples/kick_01.wav"),
+                    64: audiocore.WaveFile("samples/snare_01.wav"),
+                    65: audiocore.WaveFile("samples/snare_01.wav"),
+                    67: audiocore.WaveFile("samples/snare_01.wav"),
+                    69: audiocore.WaveFile("samples/chat_01.wav"),
+                    71: audiocore.WaveFile("samples/chat_01.wav"),
+                    72: audiocore.WaveFile("samples/chat_01.wav"),
+                    74: audiocore.WaveFile("samples/ohat_01.wav"),
+                    76: audiocore.WaveFile("samples/ohat_01.wav"),
+                    77: audiocore.WaveFile("samples/crash_01.wav"),
+                    79: audiocore.WaveFile("samples/crash_01.wav"),
                 }
                 print("Loaded channel 3 WAV samples (drums)")
             except Exception as e:
@@ -204,7 +204,7 @@ class SoundManager:
             print(f"Error loading WAV samples: {e}")
             # Fallback to basic samples if there's an error
             self.samples = {
-                65: audiocore.WaveFile("/samples/musicnote01.wav"),  # Default sample
+                65: audiocore.WaveFile("samples/musicnote01.wav"),  # Default sample
             }
             self.heart_samples = self.samples  # Use same samples as fallback
             self.drum_samples = self.samples   # Use same samples as fallback

--- a/Fruit_Jam/Larsio_Paint_Music/sprite_manager.py
+++ b/Fruit_Jam/Larsio_Paint_Music/sprite_manager.py
@@ -80,21 +80,21 @@ class SpriteManager:
         try:
             # Load the Lars note bitmap for channel 1 notes
             self.mario_head, self.mario_palette = adafruit_imageload.load(
-                "/sprites/lars_note.bmp"
+                "sprites/lars_note.bmp"
             )
             # Make the background color transparent (not just the same color)
             self.mario_palette.make_transparent(0)
 
             # Load the Heart note bitmap for channel 2 notes
             self.heart_note, self.heart_palette = adafruit_imageload.load(
-                "/sprites/heart_note.bmp"
+                "sprites/heart_note.bmp"
             )
             # Make the background color transparent
             self.heart_palette.make_transparent(0)
 
             # Load the Drum note bitmap for channel 3 notes
             self.drum_note, self.drum_palette = adafruit_imageload.load(
-                "/sprites/drum_note.bmp"
+                "sprites/drum_note.bmp"
             )
             # Make the background color transparent
             self.drum_palette.make_transparent(0)
@@ -102,18 +102,18 @@ class SpriteManager:
             # Load the new sprites for channels 4, 5, and 6
             # Meatball for channel 4
             self.meatball_note, self.meatball_palette = adafruit_imageload.load(
-                "/sprites/meatball.bmp"
+                "sprites/meatball.bmp"
             )
             self.meatball_palette.make_transparent(0)
 
             # Star for channel 5
             self.star_note, self.star_palette = adafruit_imageload.load(
-                "/sprites/star.bmp"
+                "sprites/star.bmp"
             )
             self.star_palette.make_transparent(0)
 
             # Bot for channel 6
-            self.bot_note, self.bot_palette = adafruit_imageload.load("/sprites/bot.bmp")
+            self.bot_note, self.bot_palette = adafruit_imageload.load("sprites/bot.bmp")
             self.bot_palette.make_transparent(0)
 
         except Exception as e:
@@ -171,45 +171,45 @@ class SpriteManager:
         try:
             # Load play button images
             self.play_up, self.play_up_palette = adafruit_imageload.load(
-                "/sprites/play_up.bmp"
+                "sprites/play_up.bmp"
             )
             self.play_up_palette.make_transparent(0)
 
             self.play_down, self.play_down_palette = adafruit_imageload.load(
-                "/sprites/play_down.bmp"
+                "sprites/play_down.bmp"
             )
             self.play_down_palette.make_transparent(0)
 
             # Load stop button images
             self.stop_up, self.stop_up_palette = adafruit_imageload.load(
-                "/sprites/stop_up.bmp"
+                "sprites/stop_up.bmp"
             )
             self.stop_up_palette.make_transparent(0)
 
             self.stop_down, self.stop_down_palette = adafruit_imageload.load(
-                "/sprites/stop_down.bmp"
+                "sprites/stop_down.bmp"
             )
             self.stop_down_palette.make_transparent(0)
 
             # Load loop button images
             self.loop_up, self.loop_up_palette = adafruit_imageload.load(
-                "/sprites/loop_up.bmp"
+                "sprites/loop_up.bmp"
             )
             self.loop_up_palette.make_transparent(0)
 
             self.loop_down, self.loop_down_palette = adafruit_imageload.load(
-                "/sprites/loop_down.bmp"
+                "sprites/loop_down.bmp"
             )
             self.loop_down_palette.make_transparent(0)
 
             # Load clear button images
             self.clear_up, self.clear_up_palette = adafruit_imageload.load(
-                "/sprites/clear_up.bmp"
+                "sprites/clear_up.bmp"
             )
             self.clear_up_palette.make_transparent(0)
 
             self.clear_down, self.clear_down_palette = adafruit_imageload.load(
-                "/sprites/clear_down.bmp"
+                "sprites/clear_down.bmp"
             )
             self.clear_down_palette.make_transparent(0)
 

--- a/Metro/Metro_RP2350_Chips_Challenge/code.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/code.py
@@ -45,9 +45,9 @@ dac.configure_clocks(sample_rate=44100, bit_depth=16)
 dac.headphone_output = True
 dac.headphone_volume = -15  # dB
 
-try:
+if hasattr(board, "I2S_BCLK"):
     audio_bus = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
-except:
+else:
     audio_bus = audiobusio.I2SOut(board.D9, board.D10, board.D11)
 audio = Audio(audio_bus, SOUND_EFFECTS)
 

--- a/Metro/Metro_RP2350_Chips_Challenge/code.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/code.py
@@ -21,20 +21,20 @@ from definitions import SECOND_LENGTH, TICKS_PER_SECOND
 DATA_FILE = "CHIPS.DAT"
 
 SOUND_EFFECTS = {
-    "BUTTON_PUSHED": "/sounds/pop2.wav",
-    "DOOR_OPENED": "/sounds/door.wav",
-    "ITEM_COLLECTED": "/sounds/blip2.wav",
-    "BOOTS_STOLEN": "/sounds/strike.wav",
-    "WATER_SPLASH": "/sounds/water2.wav",
-    "TELEPORT": "/sounds/teleport.wav",
-    "CANT_MOVE": "/sounds/oof3.wav",
-    "CHIP_LOSES": "/sounds/bummer.wav",
-    "LEVEL_COMPLETE": "/sounds/ditty1.wav",
-    "IC_COLLECTED": "/sounds/click3.wav",
-    "BOMB_EXPLOSION": "/sounds/hit3.wav",
-    "SOCKET_SOUND": "/sounds/chimes.wav",
-    "TIME_LOW_TICK": "/sounds/click1.wav",
-    "TIME_UP": "/sounds/bell.wav"
+    "BUTTON_PUSHED": "sounds/pop2.wav",
+    "DOOR_OPENED": "sounds/door.wav",
+    "ITEM_COLLECTED": "sounds/blip2.wav",
+    "BOOTS_STOLEN": "sounds/strike.wav",
+    "WATER_SPLASH": "sounds/water2.wav",
+    "TELEPORT": "sounds/teleport.wav",
+    "CANT_MOVE": "sounds/oof3.wav",
+    "CHIP_LOSES": "sounds/bummer.wav",
+    "LEVEL_COMPLETE": "sounds/ditty1.wav",
+    "IC_COLLECTED": "sounds/click3.wav",
+    "BOMB_EXPLOSION": "sounds/hit3.wav",
+    "SOCKET_SOUND": "sounds/chimes.wav",
+    "TIME_LOW_TICK": "sounds/click1.wav",
+    "TIME_UP": "sounds/bell.wav"
 }
 
 displayio.release_displays()
@@ -45,7 +45,10 @@ dac.configure_clocks(sample_rate=44100, bit_depth=16)
 dac.headphone_output = True
 dac.headphone_volume = -15  # dB
 
-audio_bus = audiobusio.I2SOut(board.D9, board.D10, board.D11)
+try:
+    audio_bus = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
+except:
+    audio_bus = audiobusio.I2SOut(board.D9, board.D10, board.D11)
 audio = Audio(audio_bus, SOUND_EFFECTS)
 
 fb = picodvi.Framebuffer(320, 240, clk_dp=board.CKP, clk_dn=board.CKN,

--- a/Metro/Metro_RP2350_Chips_Challenge/game.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/game.py
@@ -26,8 +26,8 @@ from savestate import SaveState
 from microcontroller import nvm
 
 # Colors must be colors in palette
-LARGE_FONT = bitmap_font.load_font("/fonts/Arial-Bold-10.pcf")
-SMALL_FONT = bitmap_font.load_font("/fonts/Arial-8.pcf")
+LARGE_FONT = bitmap_font.load_font("fonts/Arial-Bold-10.pcf")
+SMALL_FONT = bitmap_font.load_font("fonts/Arial-8.pcf")
 
 colors = {
     "key_color": 0xAAFF00, # Light Green

--- a/Metro/Metro_RP2350_Chips_Challenge/savestate.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/savestate.py
@@ -24,6 +24,14 @@ class SaveState:
         self._sdcard = None
 
     def _mount_sd_card(self):
+
+        # Check if the SD card is already mounted
+        try:
+            storage.remount('/sd',readonly=False)
+            return True
+        except:
+            pass
+
         self._card_detect = DigitalInOut(board.SD_CARD_DETECT)
         self._card_detect.switch_to_input(pull=Pull.UP)
         if self._card_detect.value:

--- a/Metro/Metro_RP2350_Chips_Challenge/savestate.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/savestate.py
@@ -27,9 +27,9 @@ class SaveState:
 
         # Check if the SD card is already mounted
         try:
-            storage.remount('/sd',readonly=False)
+            storage.getmount("/sd")
             return True
-        except:
+        except OSError:
             pass
 
         self._card_detect = DigitalInOut(board.SD_CARD_DETECT)


### PR DESCRIPTION
This pull request addresses the issues identified in https://github.com/adafruit/Fruit-Jam-OS/issues/32.

1) The "Fonts" and "Sounds" files were accessed using an absolute path from the root directory, this PR modifies that so the files are accessed from a relative path from the directory the code.py file is executed from. This should not have any impact on running the standalone code file as described in the learn guide but will also allow the code to be run from a sub folder as is done in Fruit Jam OS.

2) The original code used specific pins wired to the TLV320DAC3100 I2S audio breakout. This PR first attempts to initialize the DAC using typical pin names for boards that have built in I2S boards and only if that fails, falls back to the original pins defined in the learn guide.

3) The original code attempted to mount an SD card to save "save states" on. The core will now auto mount SD cards for boards with installed SD slots. This was causing the original code to crash when it attempted to mount the SD card that was already mounted. This PR changes the games mount function to first attempt to perform a storage.remount and if successful simply return indicating the mount was successful. If the remount isn't successful the original function to attempt and SD card mount is performed.  