### PR TITLE
Add audio output option file to Larsio and Chip's Challenge

### DIFF
--- a/Metro/Metro_RP2350_Chips_Challenge/code.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/code.py
@@ -7,7 +7,6 @@ import board
 import picodvi
 import framebufferio
 import displayio
-import adafruit_tlv320
 import audiobusio
 from audio import Audio
 from game import Game
@@ -39,16 +38,12 @@ SOUND_EFFECTS = {
 
 displayio.release_displays()
 
-i2c = board.I2C()
-dac = adafruit_tlv320.TLV320DAC3100(i2c)
-dac.configure_clocks(sample_rate=44100, bit_depth=16)
-dac.headphone_output = True
-dac.headphone_volume = -15  # dB
-
 if hasattr(board, "I2S_BCLK"):
     audio_bus = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
-else:
+elif hasattr(board, "D9") and hasattr(board, "D10") and hasattr(board, "D11"):
     audio_bus = audiobusio.I2SOut(board.D9, board.D10, board.D11)
+else:
+    audio_bus = None
 audio = Audio(audio_bus, SOUND_EFFECTS)
 
 fb = picodvi.Framebuffer(320, 240, clk_dp=board.CKP, clk_dn=board.CKN,


### PR DESCRIPTION
This Updates both the Larsio_Paint_Music and Chip's Challenge learning guides.

This PR adds the logic necessary to read a json configuration file (launcher.conf.json, if it exists in either the current or root folders) which has an option to direct the DAC audio output to the Speaker connection rather than the default headphones. This replicates the parameter added to the Fruit Jam OS boot_animation via https://github.com/adafruit/Fruit-Jam-OS/pull/49.

The Json syntax for the parameter is as follows:
```
{
    "sound": "speaker"
}
```
If the launcher.conf.json file is not found, the parameter is not found in the file or it is not set to "speaker" the programs will fall back to the default headphones output option. The Chip's Challenge program has an additional option of "mute" which will disable the audio output potentially avoiding a crash is no audio hardware is available.
