### PR TITLE
Add check to skip over keyboard

### DIFF
--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -138,6 +138,22 @@ for device in usb.core.find(find_all=True):
     # set the mouse configuration so it can be used
     mouse.set_configuration()
 
+    # Verify mouse works by reading from it
+    buf = array.array("b", [0] * 4)
+    try:
+        # Try to read some data with a short timeout
+        data = mouse.read(0x81, buf, timeout=100)
+        print(f"Mouse test read successful: {data} bytes")
+        break
+    except usb.core.USBTimeoutError:
+        # Timeout is normal if mouse isn't moving
+        print("Mouse connected but not sending data (normal)")
+        break
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"Mouse test read failed: {e}")
+        # Continue to try next device or retry
+        mouse = None
+
 buf = array.array("b", [0] * 4)
 waiting_for_release = False
 left_button = right_button = False

--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -123,7 +123,8 @@ mouse = None
 time.sleep(1)
 
 good_devices = False
-while not good_devices:
+wait_time = time.monotonic() + 10 # wait up to 20 seconds for a good device to be found
+while not good_devices and time.monotonic() < wait_time:
     for device in usb.core.find(find_all=True):
         if device.manufacturer is not None:
             good_devices = True

--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -10,7 +10,7 @@ the player successfully reveals all squares without mines or clicks on a mine.
 """
 import array
 import time
-from displayio import Group, OnDiskBitmap, TileGrid, Bitmap, Palette
+from displayio import Group, OnDiskBitmap, TileGrid, Bitmap, Palette, CIRCUITPYTHON_TERMINAL
 from adafruit_display_text.bitmap_label import Label
 from adafruit_display_text.text_box import TextBox
 import adafruit_usb_host_descriptors
@@ -171,7 +171,7 @@ for device in usb.core.find(find_all=True):
         mouse = None
 
 if mouse is None:
-    display.root_group = displayio.CIRCUITPYTHON_TERMINAL
+    display.root_group = CIRCUITPYTHON_TERMINAL
     raise RuntimeError("No mouse found. Please connect a USB mouse.")
 
 buf = array.array("b", [0] * 4)

--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -297,7 +297,7 @@ while True:
                 # if we get a timeout error, it means there is no data available
                 pass
             except usb.core.USBError as exc:
-                # if we get a USBError, it may mean the mouse is not ready yet
+                # if we get a USBError, We may be getting no endpoint msgs which can be waited out
                 pass
 
         left_button = buf[0] & 0x01

--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -10,7 +10,7 @@ the player successfully reveals all squares without mines or clicks on a mine.
 """
 import array
 import time
-from displayio import Group, OnDiskBitmap, TileGrid, Bitmap, Palette, CIRCUITPYTHON_TERMINAL
+from displayio import Group, OnDiskBitmap, TileGrid, Bitmap, Palette
 from adafruit_display_text.bitmap_label import Label
 from adafruit_display_text.text_box import TextBox
 import adafruit_usb_host_descriptors
@@ -167,7 +167,6 @@ for device in usb.core.find(find_all=True):
         mouse = None
 
 if mouse is None:
-    display.root_group = CIRCUITPYTHON_TERMINAL
     raise RuntimeError("No mouse found. Please connect a USB mouse.")
 
 buf = array.array("b", [0] * 4)

--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -291,7 +291,7 @@ while True:
                 # read data from the mouse endpoint
                 data_len = mouse.read(mouse_endpt, buf, timeout=10)
                 if data_len > 0:
-                    break                    
+                    break
             except usb.core.USBTimeoutError:
                 # if we get a timeout error, it means there is no data available
                 pass


### PR DESCRIPTION
When both a USB keyboard and a USB mouse are connected to a Fruit Jam, "most" times, the mouse did not work. If you removed the USB keyboard then the mouse always worked, however in order to start the game in this mode you need to have a serial connection to a host computer running the terminal.

I believe the issue was that the loop that searched for the mouse hardware stopped on the first device it found (EDIT: actually it always assigns the last device found as a mouse... either way, this should fix it). I've taken the test from Larsio_Paint_Music and used it in that loop to allow the program to skip over devices that don't appear to be mice.

This change allows the Minesweeper game to be run on the Fruit Jam when it's not connected to a host computer.
