### PR TITLE
Metro_RP2350_Minesweeper: Refactor for USB mouse library and new core USB errors

### DIFF
--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -108,15 +108,12 @@ def update_ui():
     elapsed_time_label.text = f"Time: {game_logic.elapsed_time}"
 
 
-# Mouse resolution/sensitivity
-sensitivity = 4
-
 # variable for the mouse USB device instance
 mouse = find_and_init_boot_mouse(cursor_image="bitmaps/mouse_cursor.bmp")
 if mouse is None:
     raise RuntimeError("No mouse found. Please connect a USB mouse.")
 
-mouse.sensitivity = sensitivity
+mouse.sensitivity = 4  # Slow the mouse down a bit
 mouse_tg = mouse.tilegrid
 mouse_tg.x = display.width // 2
 mouse_tg.y = display.height // 2


### PR DESCRIPTION
After a little more experience with the Adafruit_usb_host_mouse library it turned out not to be too hard to update this to the higher level mouse approach.

This became more pressing when the core started raising errors when a device.manufacturer couldn't be retrieved as the loop we were using to wait for the mouse to become ready wasn't catching any errors but instead, simply checking for a non-None response. We could have just started testing for the error but using the higher level library seemed like a better route.

I still hope to update minesweeper with the right mouse button feature but that's behind a couple other projects I'm working on at the moment.
