### PR TITLE
new float volume setting and don't set volume to override

### DIFF
--- a/Fruit_Jam/Larsio_Paint_Music/sound_manager.py
+++ b/Fruit_Jam/Larsio_Paint_Music/sound_manager.py
@@ -83,7 +83,7 @@ class SoundManager:
                     # Initialize TLV320
                     fjPeriphs = adafruit_fruitjam.Peripherals(
                         audio_output=launcher_config["audio"].get("output", "headphone"), 
-                        safe_volume_limit=launcher_config["audio"].get("volume_override_danger",12),
+                        safe_volume_limit=launcher_config["audio"].get("volume_override_danger",.75),
                         sample_rate=11025,
                         bit_depth=16,
                         i2c=board.STEMMA_I2C()
@@ -103,7 +103,7 @@ class SoundManager:
                     # Initialize TLV320
                     fjPeriphs = adafruit_fruitjam.Peripherals(
                         audio_output=launcher_config["audio"].get("output", "headphone"), 
-                        safe_volume_limit=launcher_config["audio"].get("volume_override_danger",12),
+                        safe_volume_limit=launcher_config["audio"].get("volume_override_danger",.75),
                         sample_rate=11025,
                         bit_depth=16,
                         i2c=board.I2C()
@@ -112,10 +112,8 @@ class SoundManager:
                     self.tlv = fjPeriphs.dac
 
                 # If volume was specified use it, otherwise use the fruitjam library default
-                if "volume_override_danger" in launcher_config["audio"]:
-                    fjPeriphs.volume = launcher_config["audio"]["volume_override_danger"]
-                elif "volume" in launcher_config["audio"]:
-                    fjPeriphs.volume = launcher_config["audio"]["volume"] # FruitJam vol (1-20)
+                if "volume" in launcher_config["audio"]:
+                    fjPeriphs.volume = launcher_config["audio"]["volume"] # FruitJam vol 0.0-1.0
 
                 # Setup I2S audio output - important to do this AFTER configuring the DAC
                 # Fruitjam library actually does this before we modify the configuration

--- a/Metro/Metro_RP2350_Chips_Challenge/code.py
+++ b/Metro/Metro_RP2350_Chips_Challenge/code.py
@@ -50,7 +50,7 @@ if "audio" not in launcher_config:
 
 fjPeriphs = adafruit_fruitjam.Peripherals.Peripherals(
     audio_output=launcher_config["audio"].get("output", "headphone"),
-    safe_volume_limit=launcher_config["audio"].get("volume_override_danger",12),
+    safe_volume_limit=launcher_config["audio"].get("volume_override_danger",.75),
     sample_rate=44100,
     bit_depth=16,
     i2c=board.I2C()
@@ -61,10 +61,8 @@ if not hasattr(board, "I2S_BCLK") and \
     fjPeriphs.audio = audiobusio.I2SOut(board.D9, board.D10, board.D11)
 
 # If volume was specified use it, otherwise use the fruitjam library default
-if "volume_override_danger" in launcher_config["audio"]:
-    fjPeriphs.volume = launcher_config["audio"]["volume_override_danger"]
-elif "volume" in launcher_config["audio"]:
-    fjPeriphs.volume = launcher_config["audio"]["volume"] # FruitJam vol (1-20)
+if "volume" in launcher_config["audio"]:
+    fjPeriphs.volume = launcher_config["audio"]["volume"] # FruitJam vol 0.0-1.0
 
 if fjPeriphs.audio is not None:
     audio = Audio(fjPeriphs.audio, SOUND_EFFECTS)


### PR DESCRIPTION
@FoamyGuy 

This updates the default volume settings to the float 0.0-1.0 range and restricts the "volume_override_danger" parameter to setting only the safe_volume_limit and not directly impacting the volume setting.

I'm marking this as draft as the merge should be coordinated with other apps and library PRs including https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/pull/22