### PR TITLE
Minesweeper: add mouse "chording" feature

### DIFF
--- a/Metro/Metro_RP2350_Minesweeper/code.py
+++ b/Metro/Metro_RP2350_Minesweeper/code.py
@@ -266,9 +266,9 @@ while True:
 
         if left_button and right_button and not chord_selected:
             chord_coords = ((mouse_tg.x - ms_board.x) // 16, (mouse_tg.y - ms_board.y) // 16)
-            chord_selected = True
-            game_logic.square_chord_highlight(chord_coords)
-            waiting_for_release = True
+            chord_selected = game_logic.square_chord_highlight(chord_coords)
+            if chord_selected:
+                waiting_for_release = True
 
         if (ms_board.x <= mouse_tg.x <= ms_board.x + game_logic.grid_width * 16 and
             ms_board.y <= mouse_tg.y <= ms_board.y + game_logic.grid_height * 16 and


### PR DESCRIPTION
@makermelissa This adds the mouse "chording" (both keys pressed) feature we discussed briefly on an earlier PR. 

I believe in the Microsoft version the highlighted tiles used the OPEN [ 0] sprite but I'm using the MINE_QUESTION_OPEN [15] sprite because it's not being used anywhere else and therefore I don't need to set up a separate tracking array for the highlighted cells. I could update the sprite sheet to replace the question mark with a blank open cell but I think the question mark works fine.