### PR TITLE
Clarify leading zero handling in time display

### DIFF
--- a/Digital_Clock_with_CircuitPython/code.py
+++ b/Digital_Clock_with_CircuitPython/code.py
@@ -59,7 +59,7 @@ def clock_conversion(h, m, set_brightness):
     if hour_12 == 0:
         hour_12 = 12
     display.print(f"{(hour_12):02}:{m:02}")  # Use for leading zero re. 09:35
-    # display.print(f"{hour_12:2}:{m:02}")   # uncomment to suppress leading zero 
+    # display.print(f"{hour_12:2}:{m:02}")   # uncomment to suppress leading zero
     #                                        #  (shows 1:00 instead of 01:00)
     display.ampm = am_pm
     if set_brightness:


### PR DESCRIPTION
Per guide feedback where a user wanted suppressed zero on times from 01:00 to 09:59. Guide will be augmented per Ladyada to allow the user to select which behavior they want just by commenting out a line and uncommenting out the desired behavior Default is the code as written that does not suppress a zero.
