### PR TITLE
fruit jam logic gates import file feature

### DIFF
--- a/Fruit_Jam/Fruit_Jam_Logic_Gates/workspace.py
+++ b/Fruit_Jam/Fruit_Jam_Logic_Gates/workspace.py
@@ -427,7 +427,7 @@ class Workspace:
                 # update the message to the user with the value they typed
                 self.message_lbl.text += key_str
                 if "logic_gates_import.json" in os.listdir("/"):
-                    with open("logic_gates_import.json", "r") as f:
+                    with open("/logic_gates_import.json", "r") as f:
                         import_data = f.read()
                         # write JSON data to the save file with slot number in filename
                         with open(f"/saves/logic_gates_{key_str}.json", "w") as f:


### PR DESCRIPTION
Allows the user to import a `logic_gates_import.json` file from CIRCUITPY into a specified save slot. This makes it possible to share save files thru the internet or any text exchange medium and get them loaded into the simulator. I used it initially on the examples provided in #3147 

I will up the relevant guide page at same time as this is merged.