### PR TITLE
support for newer Adafruit CLUE 2025 accelerometer

### DIFF
--- a/CLUE/CLUE_Egg_Drop/code.py
+++ b/CLUE/CLUE_Egg_Drop/code.py
@@ -8,6 +8,7 @@ import board
 from digitalio import DigitalInOut, Direction, Pull
 import pwmio
 from adafruit_lsm6ds.lsm6ds33 import LSM6DS33
+from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC
 from adafruit_lsm6ds import AccelRange, AccelHPF, Rate
 from adafruit_display_text import label
 import displayio
@@ -49,7 +50,13 @@ board.DISPLAY.root_group = splash
 # connect to the accelerometer
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-sensor = LSM6DS33(i2c)
+# connect to the accelerometer
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+try:
+    sensor = LSM6DS33(i2c)      # older CLUEs
+except RuntimeError:
+    sensor = LSM6DS3TRC(i2c)    # newer CLUEs (Jan 2025)
 # highest range for impacts!
 sensor.accelerometer_range = AccelRange.RANGE_16G
 # we'll read at about 1KHz


### PR DESCRIPTION
The [Adafruit CLUE board](https://www.adafruit.com/product/4500) was updated in January 2025 with a new accelerometer. A [forum user reported](https://forums.adafruit.com/viewtopic.php?t=220858) the egg drop code was not working last week. We were able to determine the code only looked for the older model accelerometer. This small change used in other CLUE projects will check for both versions of the accelerometer.

```
+--------------------+-----------------+-------------------------+
| CLUE Board Revision | Accelerometer   | Status / Result         |
+--------------------+-----------------+-------------------------+
| Rev C (early units) | LSM6DS33        | ✅ Detected and working  |
| Rev E (Jan 2025)    | LSM6DS3TR-C     | ✅ Detected and working  |
+--------------------+-----------------+-------------------------+
```
