### PR TITLE
Fruitjam Match3: Improve mouse compatibility

### DIFF
--- a/Metro/Metro_RP2350_Match3/match3_game/code.py
+++ b/Metro/Metro_RP2350_Match3/match3_game/code.py
@@ -26,12 +26,22 @@ from adafruit_debouncer import Debouncer
 import adafruit_sdcard
 import msgpack
 import storage
-from match3_game_helpers import (
-    Match3Game,
-    STATE_GAMEOVER,
-    STATE_PLAYING_SETCALLED,
-    GameOverException,
-)
+try:
+    from match3_game_helpers import (
+        Match3Game,
+        STATE_GAMEOVER,
+        STATE_PLAYING_SETCALLED,
+        GameOverException,
+    )
+except ImportError:
+    # Needed for Fruit Jam OS if "Play again" is selected at end of game
+    os.chdir('/apps/Metro_RP2350_Match3')
+    from match3_game_helpers import (
+        Match3Game,
+        STATE_GAMEOVER,
+        STATE_PLAYING_SETCALLED,
+        GameOverException,
+    )
 
 original_autoreload_val = supervisor.runtime.autoreload
 supervisor.runtime.autoreload = False


### PR DESCRIPTION
When some mice, including the inexpensive mouse from the Adafruit shop, were used with the Match3 game, mouse movement was restricted to the X axis only and that motion was controlled by moving the mouse in the Y direction.

For some reason these mice were reading data buffers of length 8 but apparently have the data format of a 4 byte buffer read.

This PR adds logic to check 8 byte buffer reads and see if the first 50 reads from the mouse show exactly 0 movement in the Y direction. If it does, the mouse is assume to be supplying the buffer data in the 4 byte format.

The read timeout was also increased from 10 to 20 milliseconds since the 10 mSec was apparently too fast for the Adafruit mouse I was testing with.

I tested with the Adafruit Mouse as well as a cheap Logitech gaming mouse and they both worked well with these changes.

For the mice that need the data format change, the 50 reads takes a couple seconds so the mouse initially is stuck just moving left and right but once the format switches it has normal motion control.