### PR TITLE
Spell_Jam: Add word sounds

### DIFF
--- a/Fruit_Jam/Fruit_Jam_Spell_Jam/code.py
+++ b/Fruit_Jam/Fruit_Jam_Spell_Jam/code.py
@@ -64,24 +64,7 @@ fj.neopixels.brightness = 0.1
 
 word_fetcher = WordFetcherTTS(fj, launcher_config)
 
-def say_and_spell_lastword():
-    """
-    Say the last word, then spell it out one letter at a time, finally say it once more.
-    """
-    if sayword:
-        if word_fetcher.output_path[-4:] == ".mp3":
-            fj.play_mp3_file(word_fetcher.output_path)
-        elif word_fetcher.output_path[-4:] == ".wav":
-            fj.play_file(word_fetcher.output_path)
-        time.sleep(0.2)
-    for letter in lastword:
-        fj.play_mp3_file(f"spell_jam_assets/letter_mp3s/{letter.upper()}.mp3")
-    time.sleep(0.2)
-    if sayword:
-        if word_fetcher.output_path[-4:] == ".mp3":
-            fj.play_mp3_file(word_fetcher.output_path)
-        elif word_fetcher.output_path[-4:] == ".wav":
-            fj.play_file(word_fetcher.output_path)
+def play_sound():
     soundPath = None
     if 'words' in os.listdir('spell_jam_assets'):
         soundPath = 'spell_jam_assets/words/'
@@ -102,6 +85,26 @@ def say_and_spell_lastword():
                 elif sound[-4:] == ".wav":
                     fj.play_file(f'{soundPath}{sound}')
                 break
+
+def say_and_spell_lastword():
+    """
+    Say the last word, then spell it out one letter at a time, finally say it once more.
+    """
+    if sayword:
+        if word_fetcher.output_path[-4:] == ".mp3":
+            fj.play_mp3_file(word_fetcher.output_path)
+        elif word_fetcher.output_path[-4:] == ".wav":
+            fj.play_file(word_fetcher.output_path)
+        time.sleep(0.2)
+    for letter in lastword:
+        fj.play_mp3_file(f"spell_jam_assets/letter_mp3s/{letter.upper()}.mp3")
+    time.sleep(0.2)
+    if sayword:
+        if word_fetcher.output_path[-4:] == ".mp3":
+            fj.play_mp3_file(word_fetcher.output_path)
+        elif word_fetcher.output_path[-4:] == ".wav":
+            fj.play_file(word_fetcher.output_path)
+    play_sound()
 
     fj.neopixels.fill(0x000000)
 


### PR DESCRIPTION
This is a fun little enhancement to the Fruit_Jam_Spell_Jam application. If you place either .wav or .mp3 audio files in the either the /apps/Fruit_Jam_Spell_Jam/spell_jam_assets/words (checked first) or /sd/spell_jam_assets/words the application will play the matching audio file after spelling the entered word.

I'm using it to add animal sounds so that when the word "cow" is entered the app says it, spells it and then moos like a cow. I found a couple web sites with free downloadable animal sounds but I plan to keep an eye out for AI models that might be used as well.

This could also be used if an AI model wasn't available, a parent could record a bunch of words and then the app would say the typed in word based on the file match rather than generating the audio of the word.

If you don't really want to continue to  update the learn guide for this type of enhancement. I'm happy to update my playground instead. It obviously wouldn't automatically be bundled into Fruit Jam OS then though.....