### PR TITLE
Feather sense has LSM6DS3TRC; import it properly

### DIFF
--- a/Adafruit_Feather_Sense/code.py
+++ b/Adafruit_Feather_Sense/code.py
@@ -21,7 +21,7 @@ try:
     from adafruit_lsm6ds.lsm6ds33 import LSM6DS33 as LSM6DS
     lsm6ds = LSM6DS(i2c)
 except RuntimeError:
-    from adafruit_lsm6ds.lsm6ds3 import LSM6DS3 as LSM6DS
+    from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC as LSM6DS
     lsm6ds = LSM6DS(i2c)
 
 apds9960 = APDS9960(i2c)

--- a/LED_Bullwhip/code.py
+++ b/LED_Bullwhip/code.py
@@ -28,7 +28,7 @@ try:
     from adafruit_lsm6ds.lsm6ds33 import LSM6DS33 as LSM6DS
     sensor = LSM6DS(i2c)
 except RuntimeError:
-    from adafruit_lsm6ds.lsm6ds3 import LSM6DS3 as LSM6DS
+    from adafruit_lsm6ds.lsm6ds3trc import LSM6DS3TRC as LSM6DS
     sensor = LSM6DS(i2c)
 
 # CUSTOMISE COLORS HERE:


### PR DESCRIPTION
Thanks `@florigon` in Discord:

Some Feather Sense examples were import `LSM6DS3` instead of `LSM6DS3TRC`. It only really matters for the pedometer, apparently, but copying the code and then adding the pedometer code would not have worked.
