### PR TITLE
CircuitPython Text Editor 2.4" FeatherWing

### DIFF
--- a/CircuitPython_Text_Editor/adafruit_editor/dang.py
+++ b/CircuitPython_Text_Editor/adafruit_editor/dang.py
@@ -33,8 +33,12 @@ except ImportError:
         pass
 
 
+# 3.5" display (480x320): LINES = 24, COLS = 80
 LINES = 24
 COLS = 80
+# 2.4" display (320x240): LINES = 19, COLS = 53
+# LINES = 19
+# COLS = 53
 
 special_keys = {
     "\x1b": ...,  # all prefixes of special keys must be entered as Ellipsis

--- a/CircuitPython_Text_Editor/code.py
+++ b/CircuitPython_Text_Editor/code.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MIT
 import traceback
 from adafruit_editor import editor, picker
+# 3.5" FeatherWing (original)
 from adafruit_featherwing import tft_featherwing_35
+# 2.4" FeatherWing V2
+# from adafruit_featherwing import tft_featherwing_24
 import terminalio
 import displayio
 from adafruit_display_text.bitmap_label import Label
@@ -14,7 +17,10 @@ def print(message):
     usb_cdc.data.write(f"{message}\r\n".encode("utf-8"))
 
 
+# 3.5" FeatherWing (original)
 tft_featherwing = tft_featherwing_35.TFTFeatherWing35V2()
+# 2.4" FeatherWing V2
+# tft_featherwing = tft_featherwing_24.TFTFeatherWing24V2()
 display = tft_featherwing.display
 display.rotation = 180
 


### PR DESCRIPTION
A [forum user](https://forums.adafruit.com/viewtopic.php?t=221779) was trying to use the [2.4" FeatherWing ](https://www.adafruit.com/product/3315) instead of the guide default of the 3.5" FeatherWing. 

This PR adds support for the 2.4", but leaves the module and modified screen dimensions commented out.

I've confirmed the 3.5" default guide code still runs as expected as well as the 2.4" when the code comments are reversed. 