### PR TITLE
Update code.py JSON_URL to reflect change in github folder structure

### DIFF
--- a/MagTag/MagTag_Seasonal_Produce/code.py
+++ b/MagTag/MagTag_Seasonal_Produce/code.py
@@ -35,7 +35,7 @@ if None in [ssid, password]:
 TWELVE_HOUR = True # If set, show 12-hour vs 24-hour (e.g. 3:00 vs 15:00)
 DD_MM = False      # If set, show DD/MM instead of MM/DD dates
 # Location of produce data (file:// or http:// or https://):
-JSON_URL = 'https://raw.githubusercontent.com/adafruit/Adafruit_Learning_System_Guides/master/MagTag_Seasonal_Produce/produce.json'
+JSON_URL = 'https://raw.githubusercontent.com/adafruit/Adafruit_Learning_System_Guides/master/MagTag/MagTag_Seasonal_Produce/produce.json'
 
 # Location is configured in settings.toml. If location is not contained there,
 # default value below will be used.


### PR DESCRIPTION
This project is currently broken and throws an error "NameError: local variable referenced before assignment" referencing File "produce.py", line 45, in fetch. 

There was a change to the folder structure on GitHub at some point and the MagTag projects were moved inside a MagTag folder and the URL for the produce.json file was broken. 

I corrected the JSON_URL variable to reflect the new URL and tested on my MagTag device. This resolved the error and the project loads correctly for me now.

I also submitted a "Feedback? Corrections?" request on https://learn.adafruit.com/seasonal-produce-for-adafruit-magtag/install-code-and-graphics. 