### PR TITLE
Disable discovery options in feather_bme280.yaml

### DIFF
--- a/home-assistant-io/feather_bme280.yaml
+++ b/home-assistant-io/feather_bme280.yaml
@@ -38,6 +38,8 @@ mqtt:
     topic: ${io_username}/feeds/status
     payload: Offline
   log_topic:
+  discovery: false
+  discover_ip: false
 
 # Enable Home Assistant API
 api:


### PR DESCRIPTION
Tagging @brentru for review, this guide possibly needs updating further, but it's probably good as is.
I found when adding the LilyGo T-Display S3 with the SEN66, and following this config YAML to add MQTT publishing to IO, I needed to stop the discovery and ping topics still, so added these two lines.

My full config:
```
esphome:
  name: lilygotdisplays3tpu
  friendly_name: T-DisplayS3 TPU

esp32:
  variant: esp32s3
  framework:
    type: esp-idf
  flash_size: 16MB

# use SEN6x PR
external_components:
  - source: github://pr#12553
    components: [sen6x]
    refresh: 1h


# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: "beef here="

ota:
  - platform: esphome
    password: "something"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Lilygotdisplays3"
    password: "password"

captive_portal:

# Adafruit IO MQTT Setup
mqtt:
  broker: 'io.adafruit.com'
  username: tyeth
  password: SECRETS
  topic_prefix: 'tyeth/feeds'
  birth_message:
    topic: tyeth/feeds/tdisplays3tpu-status
    payload: Online
  will_message:
    topic: tyeth/feeds/tdisplays3tpu-status
    payload: Offline
  log_topic:
  discovery: false
  discover_ip: false

binary_sensor:
  - platform: gpio
    pin:
      number: GPIO0
      inverted: true
    discovery: False
    name: "Button 1"
  - platform: gpio
    pin:
      number: GPIO14
      inverted: true
    name: "Button 2"
    discovery: False

output:
  - platform: ledc
    frequency: 2000
    pin: GPIO38
    id: backlight_output
    discovery: False

light:
  - platform: monochromatic
    output: backlight_output
    name: LCD Backlight
    id: led
    restore_mode: ALWAYS_ON
    default_transition_length: 0s
    discovery: False

sensor:
  - platform: sen6x
    type: SEN66
    i2c_id: i2c_bus
    temperature:
      name: Temperature
      accuracy_decimals: 2
      state_topic: tyeth/feeds/tpu-temp
      discovery: False
      filters: []
    humidity:
      name: Humidity
      accuracy_decimals: 1
      state_topic: tyeth/feeds/tpu-humidity
      discovery: False
      filters: []
    pm_1_0:
      name: PM <1µm Weight concentration
      accuracy_decimals: 2
      state_topic: tyeth/feeds/tpu-pm1-0
      discovery: False
      filters: []
    pm_2_5:
      name: PM <2.5µm Weight concentration
      accuracy_decimals: 2
      state_topic: tyeth/feeds/tpu-pm2-5
      discovery: False
      filters: []
    pm_4_0:
      name: PM <4µm Weight concentration
      accuracy_decimals: 2
      state_topic: tyeth/feeds/tpu-pm4-0
      discovery: False
      filters: []
    pm_10_0:
      name: PM <10µm Weight concentration
      accuracy_decimals: 2
      state_topic: tyeth/feeds/tpu-pm10-0
      discovery: False
      filters: []
    nox:
      name: NOx
      state_topic: tyeth/feeds/tpu-nox
      discovery: False
      filters: []
    voc:
      name: VOC
      state_topic: tyeth/feeds/tpu-voc
      discovery: False
      filters: []
      # algorithm_tuning:
      #   index_offset: 100
      #   learning_time_offset_hours: 12
      #   learning_time_gain_hours: 12
      #   gating_max_duration_minutes: 180
      #   std_initial: 50
      #   gain_factor: 230
    co2:
      name: Carbon Dioxide
      state_topic: tyeth/feeds/tpu-co2
      discovery: False
      filters: []
    #   ambient_pressure_compensation:
    #     pressure: 1013
    # formaldehyde:
    #   name: Formaldehyde
    # temperature_compensation:
    #   offset: 0
    #   normalized_offset_slope: 0
    #   time_constant: 0
    #   slot: 0
    update_interval: 60s

i2c:
  - scl: 17
    sda: 18
    scan: true
    id: i2c_onboard
    frequency: 400kHz
  - scl: 44
    sda: 43
    id: i2c_bus
    frequency: 400kHz

spi:
  type: octal
  clk_pin: 8
  data_pins:
    - 39
    - 40
    - 41
    - 42
    - ignore_strapping_warning: true
      number: 45
    - ignore_strapping_warning: true
      number: 46
    - 47
    - 48

psram:
  speed: 80MHz
  mode: octal

display:
  - platform: mipi_spi
    model: t-display-s3
    rotation: 270
    show_test_card: true # display basic hello-world
```