### PR TITLE
Replace worldtimeapi with time.now

### DIFF
--- a/CircuitPython_WeatherCloud/settings.toml
+++ b/CircuitPython_WeatherCloud/settings.toml
@@ -8,5 +8,5 @@
 
 CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones
 openweather_token="putYourOpenWeatherTokenHere"

--- a/CircuitStonks/settings.toml
+++ b/CircuitStonks/settings.toml
@@ -7,5 +7,5 @@
 
 CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones
 alphavantage_key="GRABAFREEKEYONLINE"

--- a/ESP32_S2_Reverse_TFT_Digital_Clock/code.py
+++ b/ESP32_S2_Reverse_TFT_Digital_Clock/code.py
@@ -27,7 +27,7 @@ pool = socketpool.SocketPool(wifi.radio)
 requests = adafruit_requests.Session(pool, ssl.create_default_context())
 
 # Set up the URL for fetching time data
-DATA_SOURCE = "http://worldtimeapi.org/api/timezone/" + os.getenv("TIMEZONE")
+DATA_SOURCE = "https://time.now/developer/api/timezone/" + os.getenv("TIMEZONE")
 
 # Set up display a default image
 display = board.DISPLAY

--- a/IoT_Environment_Sensor/aio.py
+++ b/IoT_Environment_Sensor/aio.py
@@ -149,7 +149,7 @@ class AIO:
             week_day = int(times[3])
             is_dst = None  # no way to know yet
         except KeyError as exc:
-            raise KeyError("Was unable to lookup the time, try setting timezone in your settings.toml according to http://worldtimeapi.org/timezones") from exc  # pylint: disable=line-too-long
+            raise KeyError("Was unable to lookup the time, try setting timezone in your settings.toml according to https://time.now/developer/timezones") from exc  # pylint: disable=line-too-long
         year, month, mday = [int(x) for x in the_date.split('-')]
         the_time = the_time.split('.')[0]
         hours, minutes, seconds = [int(x) for x in the_time.split(':')]

--- a/IoT_Environment_Sensor/settings.toml
+++ b/IoT_Environment_Sensor/settings.toml
@@ -9,4 +9,4 @@ CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
 ADAFRUIT_AIO_USERNAME="my_username"
 ADAFRUIT_AIO_KEY="my_key"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones

--- a/IoT_Party_Parrot/settings.toml
+++ b/IoT_Party_Parrot/settings.toml
@@ -7,7 +7,7 @@
 
 CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones
 twitter_api_key="insert your twitter api key here"
 twitter_secret_key="insert your twitter secret key here"
 bearer_token="insert your bearer token here"

--- a/MagTag/MagTag_CountdownCelebration/code.py
+++ b/MagTag/MagTag_CountdownCelebration/code.py
@@ -27,10 +27,10 @@ event_time = time.struct_time(
 )  # we dont know day of week/year or DST
 
 # Set up where we'll be fetching data from
-# Check http://worldtimeapi.org/timezones for valid values
+# Check https://time.now/developer/timezones for valid values
 # pylint: disable=line-too-long
-DATA_SOURCE = "http://worldtimeapi.org/api/timezone/America/New_York"
-#DATA_SOURCE = "http://worldtimeapi.org/api/timezone/Europe/Stockholm"
+DATA_SOURCE = "https://time.now/developer/api/timezone/America/New_York"
+#DATA_SOURCE = "https://time.now/developer/api/timezone/Europe/Stockholm"
 
 magtag = MagTag()
 magtag.network.connect()

--- a/MagTag/MagTag_NextBus/code.py
+++ b/MagTag/MagTag_NextBus/code.py
@@ -67,7 +67,7 @@ MINIMUM_TIME = 5 * 60
 # 6 hour default.
 CLOCK_SYNC_INTERVAL = 6 * 60 * 60
 # Load time zone string from settings.toml, else IP geolocation is used
-# (http://worldtimeapi.org/api/timezone for list). Again, this is only
+# (https://time.now/developer/api/timezone for list). Again, this is only
 # used for the 'Last checked' display, not predictions, so it's not
 # especially disruptive if missing.
 # pylint: disable=bare-except
@@ -117,7 +117,7 @@ def parse_time(timestring, is_dst=-1):
 def update_time(timezone=None):
     """ Update system date/time from WorldTimeAPI public server;
         no account required. Pass in time zone string
-        (http://worldtimeapi.org/api/timezone for list)
+        (https://time.now/developer/api/timezone for list)
         or None to use IP geolocation. Returns current local time as a
         time.struct_time and UTC offset as string. This may throw an
         exception on fetch_data() - it is NOT CAUGHT HERE, should be
@@ -125,9 +125,9 @@ def update_time(timezone=None):
         needed in different situations (e.g. reschedule for later).
     """
     if timezone: # Use timezone api
-        time_url = 'http://worldtimeapi.org/api/timezone/' + timezone
+        time_url = 'https://time.now/developer/api/timezone/' + timezone
     else: # Use IP geolocation
-        time_url = 'http://worldtimeapi.org/api/ip'
+        time_url = 'https://time.now/developer/api/ip'
 
     time_data = NETWORK.fetch_data(time_url,
                                    json_path=[['datetime'], ['dst'],

--- a/MagTag/MagTag_Project_Selector/settings.toml
+++ b/MagTag/MagTag_Project_Selector/settings.toml
@@ -9,6 +9,6 @@ CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
 ADAFRUIT_AIO_USERNAME="my_username"
 ADAFRUIT_AIO_KEY="my_key"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones
 openweather_token="my_openweather_token"
 openweather_location="New York City, US"

--- a/Matrix_Portal/Matrix_Portal_Moon_Clock/code.py
+++ b/Matrix_Portal/Matrix_Portal_Moon_Clock/code.py
@@ -69,7 +69,7 @@ HEADERS = { "User-Agent" : "AdafruitMoonClock/1.1 support@adafruit.com" }
 
 def update_system_time():
     """ Update system clock date/time from Adafruit IO. Credentials and time
-        zone are in settings.toml. See http://worldtimeapi.org/api/timezone for
+        zone are in settings.toml. See https://time.now/developer/api/timezone for
         list of time zones. If missing, will attempt using IP geolocation.
         Returns present local (not UTC) time as a struct_time and UTC offset
         as string "sHH:MM". This may throw an exception on get_local_time(),

--- a/PicoW_YBox3/PicoW_YBox3.ino
+++ b/PicoW_YBox3/PicoW_YBox3.ino
@@ -50,7 +50,7 @@ char dateBuffer[20];
 char timeBuffer[10];
 
 String weatherEndpoint = "http://api.openweathermap.org/data/2.5/weather?q=" + owm_location + "&appid=" + owm_key;
-String clockEndpoint = "http://worldtimeapi.org/api/timezone/Etc/UTC";
+String clockEndpoint = "https://time.now/developer/api/timezone/Etc/UTC";
 String apiEndpoint = clockEndpoint;
 String channelNow = "clock";
 

--- a/PyPortal/PyPortal_Halloween_Countdown/settings.toml
+++ b/PyPortal/PyPortal_Halloween_Countdown/settings.toml
@@ -9,4 +9,4 @@ CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
 ADAFRUIT_AIO_USERNAME="my_username"
 ADAFRUIT_AIO_KEY="my_key"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones

--- a/PyPortal/PyPortal_Smart_Switch/code.py
+++ b/PyPortal/PyPortal_Smart_Switch/code.py
@@ -79,7 +79,7 @@ def get_local_timestamp(location=None):
             tzseconds += tzminutes * 60
         print(seconds + tzseconds, tzoffset, tzhours, tzminutes)
     except KeyError:
-        raise KeyError("Was unable to lookup the time, try setting timezone in your settings.toml according to http://worldtimeapi.org/timezones")  # pylint: disable=line-too-long
+        raise KeyError("Was unable to lookup the time, try setting timezone in your settings.toml according to https://time.now/developer/timezones")  # pylint: disable=line-too-long
 
     # now clean up
     response.close()

--- a/PyPortal/PyPortal_Smart_Switch/settings.toml
+++ b/PyPortal/PyPortal_Smart_Switch/settings.toml
@@ -9,4 +9,4 @@ CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
 ADAFRUIT_AIO_USERNAME="my_username"
 ADAFRUIT_AIO_KEY="my_key"
-timezone=""  # leave blank or use timezone from # http://worldtimeapi.org/timezones
+timezone=""  # leave blank or use timezone from # https://time.now/developer/timezones

--- a/PyPortal/PyPortal_Titano_Weather_Station/settings.toml
+++ b/PyPortal/PyPortal_Titano_Weather_Station/settings.toml
@@ -9,6 +9,6 @@ CIRCUITPY_WIFI_SSID="your-wifi-ssid"
 CIRCUITPY_WIFI_PASSWORD="your-wifi-password"
 ADAFRUIT_AIO_USERNAME="my_username"
 ADAFRUIT_AIO_KEY="my_key"
-timezone="America/New_York"  # http://worldtimeapi.org/timezones
+timezone="America/New_York"  # https://time.now/developer/timezones
 openweather_token="my_openweather_token"
 location="New York, US"

--- a/PyPortal/PyPortal_WeeklyCountdown/code.py
+++ b/PyPortal/PyPortal_WeeklyCountdown/code.py
@@ -21,7 +21,7 @@ EVENT_DURATION = 3600   # in seconds!
 # Instead of messing around with timezones, just put in
 # the *location* of the event, and we'll automatically set the PyPortal's
 # time to that location. Then compute the math from there
-# for a list of valid locations, see http://worldtimeapi.org/api/timezone
+# for a list of valid locations, see https://time.now/developer/api/timezone
 EVENT_LOCATION = "America/New_York"  # set to None if its for your local time
 
 # the current working directory (where this file is)


### PR DESCRIPTION
Single line change updating worldtimeapi -> time.now.

I did an earlier test [PR to confirm this worked](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/228) for a one-off piece of code outside the Learn system. 

Since worldtimeapi is no longer these examples are not currently pulling correct time. 

 | Guide | Filename |
  |-------|----------|
  | PicoW_YBox3 | PicoW_YBox3.ino |
  | ESP32_S2_Reverse_TFT_Digital_Clock | code.py |
  | MagTag/MagTag_NextBus | code.py |
  | MagTag/MagTag_CountdownCelebration | code.py |
  | MagTag/MagTag_Project_Selector | settings.toml |
  | Matrix_Portal/Matrix_Portal_Moon_Clock | code.py |
  | PyPortal/PyPortal_WeeklyCountdown | code.py |
  | PyPortal/PyPortal_Smart_Switch | code.py |
  | PyPortal/PyPortal_Smart_Switch | settings.toml |
  | PyPortal/PyPortal_Halloween_Countdown | settings.toml |
  | PyPortal/PyPortal_Titano_Weather_Station | settings.toml |
  | IoT_Environment_Sensor | aio.py |
  | IoT_Environment_Sensor | settings.toml |
  | IoT_Party_Parrot | settings.toml |
  | CircuitStonks | settings.toml |
  | CircuitPython_WeatherCloud | settings.toml |