### PR TITLE
adding 4.58" 320x960 rectangle bar display

### DIFF
--- a/Factory_Tests/Qualia_ESP32S3_RGB666_FactoryTest/Qualia_ESP32S3_RGB666_FactoryTest.ino
+++ b/Factory_Tests/Qualia_ESP32S3_RGB666_FactoryTest/Qualia_ESP32S3_RGB666_FactoryTest.ino
@@ -56,6 +56,13 @@ Arduino_RGB_Display *gfx = new Arduino_RGB_Display(
 //    1 /* hync_polarity */, 46 /* hsync_front_porch */, 2 /* hsync_pulse_width */, 44 /* hsync_back_porch */,
 //    1 /* vsync_polarity */, 50 /* vsync_front_porch */, 16 /* vsync_pulse_width */, 16 /* vsync_back_porch */
 
+// 4.58" 320x960 rectangle bar display
+//    320 /* width */, 960 /* height */, rgbpanel, 0 /* rotation */, true /* auto_flush */,
+//    expander, GFX_NOT_DEFINED /* RST */, HD458002C40_init_operations, sizeof(HD458002C40_init_operations), 80 /* col_offset1 */);
+// needs also the rgbpanel to have these pulse/sync values:
+//    1 /* hsync_polarity */, 30 /* hsync_front_porch */, 10 /* hsync_pulse_width */, 50 /* hsync_back_porch */,
+//    1 /* vsync_polarity */, 15 /* vsync_front_porch */,  2 /* vsync_pulse_width */, 17 /* vsync_back_porch */
+
 uint16_t *colorWheel;
 
 // The Capacitive touchscreen overlays uses hardware I2C (SCL/SDA)


### PR DESCRIPTION
current qualia factory demo code is missing 4.58" 320x960 ADA# [5805](https://www.adafruit.com/product/5805) init / pulse / sync.

[forum issue](https://forums.adafruit.com/viewtopic.php?t=222978)

Tested and works. Change is commented out by default so no risk.

| Item                     | Ver                 |
|--------------------------|---------------------|
| Arduino IDE              | 2.3.8               |
| ESP32 BSP                | 3.3.7               |
| GFX Library for Arduino  | 1.6.5               |
| Adafruit BusIO           | 1.17.4              |
| Adafruit FT6206 Library  | 1.1.1               |
| Adafruit CST8XX Library  | 1.1.1               |
| Target board             | Qualia S3 RGB666    |
| Display                  | HD458002C40 320x960 |


![IMG_0032](https://github.com/user-attachments/assets/141530b4-e154-46f6-8375-87ab0d995a92)

