### PR TITLE
MagTag Daily Weather: Add battery state display

### DIFF
--- a/MagTag/MagTag_Weather/openmeteo/code.py
+++ b/MagTag/MagTag_Weather/openmeteo/code.py
@@ -9,7 +9,6 @@ import displayio
 import adafruit_imageload
 from adafruit_display_text import label
 from adafruit_magtag.magtag import MagTag
-import analogio
 
 # --| USER CONFIG |--------------------------
 LAT = 47.6  # latitude


### PR DESCRIPTION
What:
My MagTag seemed to be draining fast on battery, but maybe I just misremembered when and how much I charged it last. Figured daily updates on battery state could be good.

Changes:
Added a label to the DisplayIO group, using similar code to the other labels.
Positioned it in an open space, based on the positioning of other labels.
Updated the label where the other daily data is updated.
Used a basic normalizing formula based on 3.5-4.2 volts as 0-100% to approximate the percentage.
Also print battery state on the console during start-up.

Issues:
With a really long CITY name, the labels could overlap.
