### PR TITLE
Fix i2s rp2350 example

### DIFF
--- a/Feather_RP2350_Examples/CircuitPython_I2S_Tone/code.py
+++ b/Feather_RP2350_Examples/CircuitPython_I2S_Tone/code.py
@@ -12,7 +12,7 @@ import audiocore
 import board
 import audiobusio
 
-audio = audiobusio.I2SOut(board.D6, board.D5, board.D9)
+audio = audiobusio.I2SOut(board.D5, board.D6, board.D9)
 
 tone_volume = 0.1  # Increase this to increase the volume of the tone.
 frequency = 440  # Set this to the Hz of the tone you want to generate.

--- a/Feather_RP2350_Examples/CircuitPython_I2S_Wav/code.py
+++ b/Feather_RP2350_Examples/CircuitPython_I2S_Wav/code.py
@@ -8,7 +8,7 @@ import audiocore
 import board
 import audiobusio
 
-audio = audiobusio.I2SOut(board.D6, board.D5, board.D9)
+audio = audiobusio.I2SOut(board.D5, board.D6, board.D9)
 
 with open("StreetChicken.wav", "rb") as wave_file:
     wav = audiocore.WaveFile(wave_file)


### PR DESCRIPTION
This took me so long to figure out. The documented I2S Examples have swapped the pins for bit clock(BCLK) and Word Select (LRC).

Per the documentation at https://docs.circuitpython.org/en/latest/shared-bindings/audiobusio/

it goes:  I2SOut(bclk, word_select, data)

However the guide specifies:

BCLK = D5
LRC   = D6
DIN    = D9

And the wiring doc is correct according to this mapping, but then the code calls:

```
audio = audiobusio.I2SOut(board.D6, board.D5, board.D9)
```

Which clearly has BCLK and LRC swapped. Now that I reviewed the API this is clear.

PR fixes the ordering, tested the example as working now.
