### PR TITLE
update actions to Node.24; remove unneeded `if:` from arduino_cli.yml

### DIFF
--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       answer: ${{ steps.is-needed.outputs.answer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - name: Check if run by adabot
@@ -66,15 +66,15 @@ jobs:
     if: needs.check-if-needed.outputs.answer == 'true'
     needs: check-if-needed
     steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
     # Checkout the learn repo itself
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Checkout the CI scripts
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -105,7 +105,7 @@ jobs:
 
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ github.event.repository.name }}.${{ github.sha }}
         path: |
@@ -127,7 +127,7 @@ jobs:
 
     - name: Create release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         files: build/${{ matrix.arduino-platform }}.zip
         fail_on_unmatched_files: false

--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -29,7 +29,6 @@ jobs:
           echo "status=$isdispatch" >> "$GITHUB_OUTPUT"
       - name: Check for Arduino file updates
         id: check-updated
-        if: steps.check-cron.outputs.status == false && steps.check-dispatch.outputs.status == false
         run: |
           changedfiles=$(git diff --name-only -r HEAD^1 HEAD)
           ischanged=false

--- a/.github/workflows/arduino_cron.yml
+++ b/.github/workflows/arduino_cron.yml
@@ -29,7 +29,7 @@ jobs:
           echo "status=$isdispatch" >> "$GITHUB_OUTPUT"
       - name: Check for Arduino file updates
         id: check-updated
-        if: ${{ steps.check-cron.outputs.status }} == false && ${{ steps.check-dispatch.outputs.status }} == false
+        if: steps.check-cron.outputs.status == false && steps.check-dispatch.outputs.status == false
         run: |
           changedfiles=$(git diff --name-only -r HEAD^1 HEAD)
           ischanged=false

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -6,11 +6,11 @@ jobs:
   spdx:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Checkout Current Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: check SPDX licensing
       run: python ./SPDX.py
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Versions
@@ -29,7 +29,7 @@ jobs:
       run: |
         pip install --force-reinstall pylint==2.7.1
     - name: Checkout Current Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: lint
       run: ./pylint_check.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -21,10 +21,10 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 


### PR DESCRIPTION
- Fixes #3235.

Update CI actions to their latest versions, mainly to use Node.24

- Fixes #3234.

This `if:` was always true:
```
        if: ${{ steps.check-cron.outputs.status }} == false && ${{ steps.check-dispatch.outputs.status }} == false
```
I first removed the curly brace expansions, but that caused it to be false sometimes, which caused the `is-needed` step to fail, because because `steps.check-updated.outputs.status` was not set. But `is-needed` was already checking the values in the `if:`. So the `if:` wasn't really needed (it could save a little time, but not a big deal).