### PR TITLE
TLV320_Tone_Arduino: add headphone support and Pico 2W hardware reset

### DIFF
--- a/TLV320DAC3100_Examples/TLV320_Tone_Arduino/TLV320_Tone_Arduino.ino
+++ b/TLV320DAC3100_Examples/TLV320_Tone_Arduino/TLV320_Tone_Arduino.ino
@@ -10,9 +10,10 @@
 
 Adafruit_TLV320DAC3100 codec;  // Create codec object
 
-#define pBCLK D9   // BITCLOCK - I2S clock
-#define pWS   D10  // LRCLOCK - Word select
-#define pDOUT D11  // DATA - I2S data
+#define pBCLK  D9   // BITCLOCK - I2S clock
+#define pWS    D10  // LRCLOCK - Word select
+#define pDOUT  D11  // DATA - I2S data
+#define pRESET 7    // RST - hardware reset (required for Pico 2W / RP2350)
 
 // Create I2S port
 I2S i2s(OUTPUT);
@@ -31,6 +32,14 @@ void setup() {
   
   while (!Serial) delay(10);
   Serial.println("\n\nTLV320DAC3100 Sine Tone Test");
+
+  // Hardware reset - required for Pico 2W (RP2350), harmless on Pico (RP2040)
+  pinMode(pRESET, OUTPUT);
+  digitalWrite(pRESET, LOW);
+  delay(100);
+  digitalWrite(pRESET, HIGH);
+  delay(100);
+
   // Start I2C communication with codec
   Serial.println("Initializing codec...");
   if (!codec.begin()) {
@@ -105,6 +114,13 @@ void setup() {
       !codec.setSPKVolume(true, 0)) { // Enable and set volume to 0dB
     Serial.println("Failed to configure speaker output!");
   }
+
+  // Uncomment to use headphone output instead of (or in addition to) speaker
+  // codec.configureHeadphoneDriver(true, true, TLV320_HP_COMMON_1_35V, false);
+  // codec.setHPLVolume(true, 0);
+  // codec.setHPRVolume(true, 0);
+  // codec.configureHPL_PGA(9, true);
+  // codec.configureHPR_PGA(9, true);
 
   // Initialize I2S peripheral
   Serial.println("Initializing I2S...");

--- a/TLV320DAC3100_Examples/TLV320_Tone_Arduino/TLV320_Tone_Arduino.ino
+++ b/TLV320DAC3100_Examples/TLV320_Tone_Arduino/TLV320_Tone_Arduino.ino
@@ -101,7 +101,7 @@ void setup() {
       !codec.setChannelVolume(true, 18)) {         // Right DAC +0dB
     Serial.println("Failed to configure DAC volume control!");
   }
-  
+
 
   if (!codec.setChannelVolume(false, 12.0) ||
       !codec.setChannelVolume(true, 12.0)) {
@@ -115,12 +115,12 @@ void setup() {
     Serial.println("Failed to configure speaker output!");
   }
 
-  // Uncomment to use headphone output instead of (or in addition to) speaker
-  // codec.configureHeadphoneDriver(true, true, TLV320_HP_COMMON_1_35V, false);
-  // codec.setHPLVolume(true, 0);
-  // codec.setHPRVolume(true, 0);
-  // codec.configureHPL_PGA(9, true);
-  // codec.configureHPR_PGA(9, true);
+  // Headphone output
+  codec.configureHeadphoneDriver(true, true, TLV320_HP_COMMON_1_35V, false);
+  codec.setHPLVolume(true, 0);
+  codec.setHPRVolume(true, 0);
+  codec.configureHPL_PGA(9, true);
+  codec.configureHPR_PGA(9, true);
 
   // Initialize I2S peripheral
   Serial.println("Initializing I2S...");


### PR DESCRIPTION
Adds headphone output support and Pico 2W (RP2350) compatibility to the TLV320 sine tone example.

## Changes

- **Hardware reset on pin 7 (RST):** Required for codec I2C init on RP2350. Without it, every codec call fails. Harmless on RP2040.
- **Headphone block:** Five lines to route audio to headphones in addition to the speaker.

## Tested on

- Raspberry Pi Pico (RP2040) ✅
- Raspberry Pi Pico 2W (RP2350) ✅
- Adafruit Metro (RP2350) ✅

[forum user](https://forums.adafruit.com/viewtopic.php?t=223762) confirmed working.