### PR TITLE
Changed order of NeoPixel lighting

### DIFF
--- a/Espresso_Water_Meter/code.py
+++ b/Espresso_Water_Meter/code.py
@@ -125,8 +125,8 @@ if avg_distance is not None:
         # pylint: disable=invalid-name
         avg_distance = 22
     print(f"Average distance: {avg_distance:.1f} cm")
-    # Set color based on average distance
-    set_pixel_color(avg_distance)
+    # Set color based on average distance - Moved down after connection test
+    # set_pixel_color(avg_distance)
 
     # Check battery status
     battery_voltage = battery_monitor.cell_voltage
@@ -150,6 +150,9 @@ if avg_distance is not None:
         pixel.fill(OFF)
         time.sleep(10)
         microcontroller.reset()
+
+    # Set color based on average distance
+    set_pixel_color(avg_distance)
 
     # Create a socket pool
     pool = socketpool.SocketPool(wifi.radio)


### PR DESCRIPTION
NeoPixel currently holds on to cyan or pink color after the connection test, instead of indicating water level in the test. I moved the NeoPixel color display down, so that the water level status color would be the one that holds (after the connection test color, of course)

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change-- Just moved the line down past the Wifi connection test.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it. - N/A

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process. -- Tested against my own espresso water meter setup :) 

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
