### PR TITLE
Do not ignore RuntimeError when doing pin finding

### DIFF
--- a/CircuitPython_Essentials/I2C_Test_Script/code.py
+++ b/CircuitPython_Essentials/I2C_Test_Script/code.py
@@ -15,8 +15,6 @@ def is_hardware_I2C(scl, sda):
         return True
     except ValueError:
         return False
-    except RuntimeError:
-        return True
 
 
 def get_unique_pins():

--- a/CircuitPython_Templates/i2c_find_pins/code.py
+++ b/CircuitPython_Templates/i2c_find_pins/code.py
@@ -13,8 +13,6 @@ def is_hardware_i2c(scl, sda):
         return True
     except ValueError:
         return False
-    except RuntimeError:
-        return True
 
 
 def get_unique_pins():

--- a/Fruit_Jam/Fruit_Jam_Examples/CircuitPython_I2C_Find_Pins/code.py
+++ b/Fruit_Jam/Fruit_Jam_Examples/CircuitPython_I2C_Find_Pins/code.py
@@ -15,8 +15,6 @@ def is_hardware_i2c(scl, sda):
         return True
     except ValueError:
         return False
-    except RuntimeError:
-        return True
 
 
 def get_unique_pins():

--- a/PDM_Microphone/Wheres_my_PDMIn/code.py
+++ b/PDM_Microphone/Wheres_my_PDMIn/code.py
@@ -14,8 +14,6 @@ def is_hardware_PDM(clock, data):
         return True
     except ValueError:
         return False
-    except RuntimeError:
-        return True
 
 
 def get_unique_pins():


### PR DESCRIPTION
Various pin-finder scripts were catching `RuntimeError` and saying the found pin pair was OK. I don't know why this was the case; I think it may have just been an error.

`NotImplementedError` is a `RuntimeError`, so for boards on which, say, `PDMIn` was not implemented, the pin-finder script would mistakenly say all pin pairs worked.

Thanks @CrackXT for pointing this out: https://github.com/adafruit/circuitpython/issues/11055#issuecomment-4744207883