### PR TITLE
Fix Weather Display Matrix wind speed formatting

### DIFF
--- a/Weather_Display_Matrix/openweather_graphics.py
+++ b/Weather_Display_Matrix/openweather_graphics.py
@@ -135,9 +135,9 @@ class OpenWeather_Graphics(displayio.Group):
         wind = weather["wind"]["speed"]
         print(wind)
         if self.meters_speed:
-            self.wind_text.text = "%d m/s" % wind
+            self.wind_text.text = "%.1f m/s" % wind
         else:
-            self.wind_text.text = "%d mph" % wind
+            self.wind_text.text = "%.1f mph" % wind
 
         self.display.root_group = self.root_group
 


### PR DESCRIPTION
## Summary\n- Preserve one decimal place when displaying OpenWeather wind speed values\n- Avoid showing sub-1 m/s or mph speeds as 0 due to integer formatting\n\n## Testing\n- Ran `python3 -m py_compile Weather_Display_Matrix/openweather_graphics.py`