### PR TITLE
update ci test for ybox3

### DIFF
--- a/Bluetooth_Lumon_Speaker/Bluetooth_Lumon_Speaker.ino
+++ b/Bluetooth_Lumon_Speaker/Bluetooth_Lumon_Speaker.ino
@@ -18,9 +18,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// ==> Example which shows how to use the built in ESP32 I2S >= 3.0.0
+// As of ESP BSP 3.3.10, need to include arduino-audio-tools by Phil Schatzman
+// https://github.com/pschatzmann/arduino-audio-tools
 
 #include "ESP_I2S.h"
+#include "AudioTools.h"
 #include "BluetoothA2DPSink.h"
 
 const uint8_t I2S_SCK = 8;       /* Audio data bit clock */

--- a/PicoW_YBox3/PicoW_YBox3.ino
+++ b/PicoW_YBox3/PicoW_YBox3.ino
@@ -5,6 +5,7 @@
 // YBox3 with Pico W and DVI PiCowbell
 // Bouncing ball screensaver written by Phil B.
 // Update user config section with your information
+// as of Philhower 5.7.0, FS needs to be defined under Flash Size
 
 #include <Arduino.h>
 #include <time.h>


### PR DESCRIPTION
new philhower release (5.7.0) adds a check that any sketch with OTA has a FS defined. changing the check to use tinyusb pico w for ybox3. tested locally