### PR TITLE
remove unknown command

### DIFF
--- a/CircuitPython_ESP32_Camera/esp32-s3-eye-lcdview/code.py
+++ b/CircuitPython_ESP32_Camera/esp32-s3-eye-lcdview/code.py
@@ -41,7 +41,6 @@ cam.vflip = True
 board.DISPLAY.auto_refresh = False
 display_bus = board.DISPLAY.bus
 
-display_bus.send(36, struct.pack(">hh", 0, 239))
 display_bus.send(42, struct.pack(">hh", 0, 239))
 display_bus.send(43, struct.pack(">hh", 0, 80+239))
 t0 = adafruit_ticks.ticks_ms()


### PR DESCRIPTION
forum post: https://forums.adafruit.com/viewtopic.php?t=224668 pointed out that 36 (0x24) is not a known command for ST7789 and as a result doesn't do anything. removing that line from the example
